### PR TITLE
Add view_submitted_responses to Questionnaire

### DIFF
--- a/schemas/questionnaire_v1.json
+++ b/schemas/questionnaire_v1.json
@@ -59,6 +59,24 @@
         "StatisticsOfTradeAct"
       ]
     },
+    "view_submitted_responses": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Whether or not answers are available after submission.",
+          "type": "boolean"
+        },
+        "timeout": {
+          "description": "The amount of time in seconds submitted answers are available for.",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "enabled",
+        "timeout"
+      ],
+      "additionalProperties": false
+    },
     "variables": {
       "type": "object",
       "properties": {


### PR DESCRIPTION
Adds view_submitted_responses attribute to main questionnaire.
**enabled** is a boolean to allow viewing of submitted responses for a questionnaire.
**timeout** is an integer of the number of seconds the link for submitted answers is available after submission.