### PR TITLE
Allow integers for when comparisons

### DIFF
--- a/schemas/common_definitions.json
+++ b/schemas/common_definitions.json
@@ -107,7 +107,8 @@
         "value": {
           "type": [
             "string",
-            "boolean"
+            "boolean",
+            "integer"
           ]
         }
       },


### PR DESCRIPTION
Routing based on numbers requires this.