### PR TITLE
timeout renamed duration

### DIFF
--- a/schemas/questionnaire_v1.json
+++ b/schemas/questionnaire_v1.json
@@ -73,7 +73,7 @@
       },
       "required": [
         "enabled",
-        "timeout"
+        "duration"
       ],
       "additionalProperties": false
     },


### PR DESCRIPTION
Within **view_submitted_response** object the required fields should read **duration** rather than **timeout**.  Part of #15