### PR TITLE
New validator for dropdown input type

### DIFF
--- a/schemas/answers/dropdown.json
+++ b/schemas/answers/dropdown.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema",
+  "answer": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "$ref": "../common_definitions.json#/id"
+      },
+      "q_code": {
+        "$ref": "../common_definitions.json#/q_code"
+      },
+      "guidance": {
+        "$ref": "../common_definitions.json#/guidance"
+      },
+      "type": {
+        "type": "string",
+        "enum": [
+          "Dropdown"
+        ]
+      },
+      "mandatory": {
+        "type": "boolean"
+      },
+      "label": {
+        "type": "string"
+      },
+      "description": {
+        "type": "string"
+      },
+      "options": {
+        "$ref": "definitions.json#/options"
+      },
+      "alias": {
+        "$ref": "definitions.json#/alias"
+      },
+      "validation": {
+        "type": "object",
+        "properties": {
+          "messages": {
+            "MANDATORY_DROPDOWN": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "id",
+      "type",
+      "mandatory",
+      "label",
+      "options"
+    ]
+  }
+}

--- a/schemas/common_definitions.json
+++ b/schemas/common_definitions.json
@@ -134,6 +134,9 @@
     "type": "object",
     "description": "These messages override the standard error messages.",
     "properties": {
+      "MANDATORY_DROPDOWN": {
+        "type": "string"
+      },
       "MANDATORY_TEXTFIELD": {
         "type": "string"
       },

--- a/schemas/questions/general.json
+++ b/schemas/questions/general.json
@@ -66,6 +66,9 @@
             },
             {
               "$ref": "../answers/unit.json#/answer"
+            },
+            {
+              "$ref": "../answers/dropdown.json#/answer"
             }
           ]
         }


### PR DESCRIPTION
### What is the context of this PR?
The drop-down input type requires a new schema validator to ensure that the schemas are accurate.

Card: https://trello.com/c/lZqYhhjw/1328-add-dropdown-input-type-m

### How to review

1. In eq-survey-runner, checkout to branch: `eq-1328-add-dropdown-input-type`
2. Run the following:
`./scripts/test_schemas.sh data/en/`


Check that all the schemas pass