### PR TITLE
Replace pylint-mccabe with pylint built-in complexity checker

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -20,7 +20,7 @@ persistent=yes
 
 # List of plugins (as comma separated values of python modules names) to load,
 # usually to register additional checkers.
-load-plugins=pylint_mccabe,pylint_quotes
+load-plugins=pylint.extensions.mccabe,pylint_quotes
 
 # Use multiple processes to speed up Pylint.
 jobs=1
@@ -65,7 +65,7 @@ confidence=
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
-disable=locally-disabled,duplicate-code,too-many-arguments,too-many-instance-attributes,invalid-name,too-few-public-methods,no-name-in-module,import-error,missing-docstring,map-builtin-not-iterating,buffer-builtin,long-suffix,import-star-module-level,xrange-builtin,apply-builtin,input-builtin,raising-string,reload-builtin,hex-method,delslice-method,execfile-builtin,unpacking-in-except,round-builtin,backtick,print-statement,using-cmp-argument,oct-method,raw_input-builtin,long-builtin,unichr-builtin,filter-builtin-not-iterating,metaclass-assignment,old-raise-syntax,cmp-builtin,old-octal-literal,next-method-called,standarderror-builtin,setslice-method,basestring-builtin,suppressed-message,range-builtin-not-iterating,indexing-exception,dict-view-method,getslice-method,cmp-method,coerce-builtin,old-division,coerce-method,old-ne-operator,file-builtin,intern-builtin,parameter-unpacking,reduce-builtin,dict-iter-method,zip-builtin-not-iterating,useless-suppression,unicode-builtin,nonzero-method,no-absolute-import
+disable=inconsistent-return-statements,locally-disabled,duplicate-code,too-many-arguments,too-many-instance-attributes,invalid-name,too-few-public-methods,no-name-in-module,import-error,missing-docstring,map-builtin-not-iterating,buffer-builtin,long-suffix,import-star-module-level,xrange-builtin,apply-builtin,input-builtin,raising-string,reload-builtin,hex-method,delslice-method,execfile-builtin,unpacking-in-except,round-builtin,backtick,print-statement,using-cmp-argument,oct-method,raw_input-builtin,long-builtin,unichr-builtin,filter-builtin-not-iterating,metaclass-assignment,old-raise-syntax,cmp-builtin,old-octal-literal,next-method-called,standarderror-builtin,setslice-method,basestring-builtin,suppressed-message,range-builtin-not-iterating,indexing-exception,dict-view-method,getslice-method,cmp-method,coerce-builtin,old-division,coerce-method,old-ne-operator,file-builtin,intern-builtin,parameter-unpacking,reduce-builtin,dict-iter-method,zip-builtin-not-iterating,useless-suppression,unicode-builtin,nonzero-method,no-absolute-import
 
 
 [REPORTS]

--- a/Pipfile
+++ b/Pipfile
@@ -16,9 +16,7 @@ structlog = "*"
 
 pytest = "==2.8.2"
 "flake8" = "==3.4.1"
-pylint = "==1.7.4"
-astroid = "==1.5.3"
-pylint-mccabe = "==0.1.3"
+pylint = "==1.8.2"
 pylint-quotes = "==0.1.6"
 
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,19 +1,19 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "d00b5fee9c5c28f9ef5deac7d1469c346c4dad9b19dc3184cd4250f3196ca812"
+            "sha256": "8223e1c97e3adefc4a5053214d4a0eecf93e4957932d34ae4756559ff0863f66"
         },
         "host-environment-markers": {
             "implementation_name": "cpython",
-            "implementation_version": "3.6.3",
+            "implementation_version": "3.4.2",
             "os_name": "posix",
             "platform_machine": "x86_64",
             "platform_python_implementation": "CPython",
-            "platform_release": "16.7.0",
+            "platform_release": "17.4.0",
             "platform_system": "Darwin",
-            "platform_version": "Darwin Kernel Version 16.7.0: Thu Jan 11 22:59:40 PST 2018; root:xnu-3789.73.8~1/RELEASE_X86_64",
-            "python_full_version": "3.6.3",
-            "python_version": "3.6",
+            "platform_version": "Darwin Kernel Version 17.4.0: Sun Dec 17 09:19:54 PST 2017; root:xnu-4570.41.2~1/RELEASE_X86_64",
+            "python_full_version": "3.4.2",
+            "python_version": "3.4",
             "sys_platform": "darwin"
         },
         "pipfile-spec": 6,
@@ -94,10 +94,10 @@
     "develop": {
         "astroid": {
             "hashes": [
-                "sha256:39a21dd2b5d81a6731dc0ac2884fa419532dffd465cdd43ea6c168d36b76efb3",
-                "sha256:492c2a2044adbf6a84a671b7522e9295ad2f6a7c781b899014308db25312dd35"
+                "sha256:db5cfc9af6e0b60cd07c19478fb54021fc20d2d189882fbcbc94fc69a8aecc58",
+                "sha256:f0a0e386dbca9f93ea9f3ea6f32b37a24720502b7baa9cb17c3976a680d43a06"
             ],
-            "version": "==1.5.3"
+            "version": "==1.6.1"
         },
         "flake8": {
             "hashes": [
@@ -155,13 +155,6 @@
             ],
             "version": "==0.6.1"
         },
-        "pep8": {
-            "hashes": [
-                "sha256:b22cfae5db09833bb9bd7c8463b53e1a9c9b39f12e304a8d0bba729c501827ee",
-                "sha256:fe249b52e20498e59e0b5c5256aa52ee99fc295b26ec9eaa85776ffdb9fe6374"
-            ],
-            "version": "==1.7.1"
-        },
         "py": {
             "hashes": [
                 "sha256:8cca5c229d225f8c1e3085be4fcf306090b00850fefad892f9d96c7b6e2f310f",
@@ -185,16 +178,10 @@
         },
         "pylint": {
             "hashes": [
-                "sha256:948679535a28afc54afb9210dabc6973305409042ece8e5768ca1409910c1ed8",
-                "sha256:1f65b3815c3bf7524b845711d54c4242e4057dd93826586620239ecdfe591fb1"
+                "sha256:156839bedaa798febee72893beef00c650c2e7abafb5586fc7a6a56be7f80412",
+                "sha256:4fe3b99da7e789545327b75548cee6b511e4faa98afe268130fea1af4b5ec022"
             ],
-            "version": "==1.7.4"
-        },
-        "pylint-mccabe": {
-            "hashes": [
-                "sha256:f3628affbc6064c08477243915f6752f3ef59fb82803b00be92f30d0ef7bbf29"
-            ],
-            "version": "==0.1.3"
+            "version": "==1.8.2"
         },
         "pylint-quotes": {
             "hashes": [


### PR DESCRIPTION
### What is the context of this PR?
We use pylint-mccabe to do complexity checking on our Python code. Recently this has become incompatible with the latest version of astroid (used by pylint) - infoxchange/pylint-mccabe#3. It also hasn't been updated in over 5 years.

We should replace it with the pylint built in complexity checker - https://pylint.readthedocs.io/en/latest/technical_reference/extensions.html#design-checker (as mentioned in PyCQA/astroid#471)

### How to review
Does the linting work?