### PR TITLE
Improve validation of answer options

### DIFF
--- a/app/validation/validator.py
+++ b/app/validation/validator.py
@@ -36,6 +36,8 @@ class Validator:
         errors.extend(self.validate_duplicates(json_to_validate, ignored_keys, 'id'))
         errors.extend(self.validate_duplicates(json_to_validate, ignored_keys, 'alias'))
 
+        errors.extend(self.validate_duplicate_options(json_to_validate))
+
         errors.extend(self.validate_contains_confirmation_or_summary(json_to_validate))
 
         errors.extend(self.validate_child_answers_define_parent(json_to_validate))
@@ -192,6 +194,29 @@ class Validator:
                 unique_items.append(value)
 
         return duplicate_errors
+
+    def validate_duplicate_options(self, json_to_validate):
+        errors = []
+
+        for block in self._get_blocks(json_to_validate):
+            answers_for_block = self._get_answers_for_block(block)
+
+            for answers in answers_for_block:
+                labels = set()
+                values = set()
+
+                for option in answers.get('options', []):
+
+                    if option['label'] in labels:
+                        errors.append(self._error_message('Duplicate label found - {}'.format(option['label'])))
+
+                    if option['value'] in values:
+                        errors.append(self._error_message('Duplicate value found - {}'.format(option['value'])))
+
+                    labels.add(option['label'])
+                    values.add(option['value'])
+
+        return errors
 
     def validate_contains_confirmation_or_summary(self, json_to_validate):
         blocks = self._get_blocks(json_to_validate)

--- a/schemas/answers/definitions.json
+++ b/schemas/answers/definitions.json
@@ -11,6 +11,7 @@
   "options": {
     "type": "array",
     "uniqueItems": true,
+    "minItems": 2,
     "items": {
       "type": "object",
       "properties": {


### PR DESCRIPTION
### What is the context of this PR?
Enforces that any answer type that uses options, ie Radios, Checkboxes, Dropdowns etc must contain at least 2 options. Also checks for duplicate option label and value between the options.

### How to review 
1. Ensure schema validation fails when an answer type that uses options doesn't have at least 2 options and vice versa.
2. Ensure that validation fails when options contain duplicates and vice versa.