### PR TITLE
Add default for numeric answers

### DIFF
--- a/app/validation/validator.py
+++ b/app/validation/validator.py
@@ -171,7 +171,17 @@ class Validator:
             # Validate referred numeric answer decimals
             errors.extend(self._validate_referred_numeric_answer_decimals(answer, answer_ranges))
 
+            # Validate default is only used with non mandatory answers
+            errors.extend(self._validate_numeric_default(answer))
+
         return errors
+
+    def _validate_numeric_default(self, answer):
+        error = []
+        if answer.get('mandatory') and answer.get('default') is not None:
+            error.append(self._error_message('Default is being used with a mandatory answer: {}'.format(answer['id'])))
+
+        return error
 
     def _get_numeric_range_values(self, answer, answer_ranges):
 

--- a/schemas/answers/currency.json
+++ b/schemas/answers/currency.json
@@ -34,6 +34,10 @@
         "type": "integer",
         "description": "Number of decimal places allowed"
       },
+      "default": {
+        "type": "integer",
+        "description": "Default value on POST if none given"
+      },
       "alias": {
         "$ref": "definitions.json#/alias"
       },

--- a/schemas/answers/number.json
+++ b/schemas/answers/number.json
@@ -34,6 +34,10 @@
         "type": "integer",
         "description": "Number of decimal places allowed"
       },
+      "default": {
+        "type": "integer",
+        "description": "Default value on POST if none given"
+      },
       "alias": {
         "$ref": "definitions.json#/alias"
       },

--- a/schemas/answers/percentage.json
+++ b/schemas/answers/percentage.json
@@ -32,6 +32,10 @@
         "type": "integer",
         "description": "Number of decimal places allowed"
       },
+      "default": {
+        "type": "integer",
+        "description": "Default value on POST if none given"
+      },
       "alias": {
         "$ref": "definitions.json#/alias"
       },

--- a/schemas/answers/unit.json
+++ b/schemas/answers/unit.json
@@ -32,6 +32,10 @@
         "type": "integer",
         "description": "Number of decimal places allowed"
       },
+      "default": {
+        "type": "integer",
+        "description": "Default value on POST if none given"
+      },
       "alias": {
         "$ref": "definitions.json#/alias"
       },

--- a/tests/schemas/test_invalid_numeric_answers.json
+++ b/tests/schemas/test_invalid_numeric_answers.json
@@ -127,6 +127,23 @@
                     }]
                 },
                 {
+                    "type": "Questionnaire",
+                    "id": "block-7",
+                    "questions": [{
+                        "type": "General",
+                        "id": "question-7",
+                        "title": "Enter a value 7",
+                        "answers": [{
+                                "id": "answer-7",
+                                "label": "Default with Mandatory",
+                                "type": "Number",
+                                "mandatory": true,
+                                "default": 0
+                            }
+                        ]
+                    }]
+                },
+                {
                     "type": "Summary",
                     "id": "summary"
                 }

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -57,7 +57,7 @@ class TestSchemaValidation(unittest.TestCase):
         json_to_validate = self.open_and_load_schema_file(file)
 
         errors = self.validator.validate_numeric_answer_types(json_to_validate)
-        self.assertEqual(len(errors), 8)
+        self.assertEqual(len(errors), 9)
         self.assertEqual(
             errors[0]['message'],
             'Schema Integrity Error. Invalid range of min = 0 and max = -1.0 is possible for answer "answer-2".')
@@ -89,6 +89,10 @@ class TestSchemaValidation(unittest.TestCase):
             errors[7]['message'],
             'Schema Integrity Error. The referenced answer "answer-1" has a greater number of decimal places than '
             'answer "answer-6"')
+
+        self.assertEqual(
+            errors[8]['message'],
+            'Schema Integrity Error. Default is being used with a mandatory answer: answer-7')
 
     def test_invalid_id_in_answers_to_calculate(self):
 


### PR DESCRIPTION
The "default" value will be stored in the answer store on POST when no value is given for the answer.