### PR TITLE
Fixes validation for minimum number of checkbox/radio options.

### DIFF
--- a/schemas/answers/checkbox.json
+++ b/schemas/answers/checkbox.json
@@ -25,7 +25,10 @@
         ]
       },
       "options": {
-        "$ref": "definitions.json#/options"
+        "allOf": [
+          { "$ref": "definitions.json#/options"},
+          { "minItems": 1 }
+        ]
       },
       "mandatory": {
         "type": "boolean"

--- a/schemas/answers/definitions.json
+++ b/schemas/answers/definitions.json
@@ -11,7 +11,6 @@
   "options": {
     "type": "array",
     "uniqueItems": true,
-    "minItems": 2,
     "items": {
       "type": "object",
       "properties": {

--- a/schemas/answers/dropdown.json
+++ b/schemas/answers/dropdown.json
@@ -28,7 +28,10 @@
         "type": "string"
       },
       "options": {
-        "$ref": "definitions.json#/options"
+        "allOf": [
+          { "$ref": "definitions.json#/options"},
+          { "minItems": 2 }
+        ]
       },
       "alias": {
         "$ref": "definitions.json#/alias"

--- a/schemas/answers/radio.json
+++ b/schemas/answers/radio.json
@@ -25,7 +25,10 @@
         ]
       },
       "options": {
-        "$ref": "definitions.json#/options"
+        "allOf": [
+          { "$ref": "definitions.json#/options"},
+          { "minItems": 2 }
+        ]
       },
       "mandatory": {
         "type": "boolean"


### PR DESCRIPTION
### Description
A recent change to the schema validator broke some Questionnaires (including LFS) that are being authored in Pre-prod.

The schema validator previously enforced that any multiple choice answers (i.e. Checkbox/Radio answers, must have a minimum of 2 options.

This PR changes the schema definitions of checkbox and radio to ensure that Radio answers must have a minimum of 2 options, but allow Checkbox answers to have a minimum of 1 Option (for single option checkbox answers).

### How to review
This change should allow single option checkboxes and enforce a minimum of 2 options for radio answers. All other validations (e.g. failure if missing any options) should still apply.