### PR TITLE
Added support for month year date range

### DIFF
--- a/schemas/questions/date_range.json
+++ b/schemas/questions/date_range.json
@@ -35,7 +35,14 @@
         "minItems": 2,
         "maxItems": 2,
         "items": {
-          "$ref": "../answers/date.json#/answer"
+          "oneOf": [
+            {
+              "$ref": "../answers/date.json#/answer"
+            },
+            {
+              "$ref": "../answers/month_year_date.json#/answer"
+            }
+          ]
         }
       }
     },


### PR DESCRIPTION
Added `MonthYearDate` as one of the answer types for `DateRange` question type.
Needed to support changes in runner to support `MonthYearDate` ranges.
[Branch](https://github.com/ONSdigital/eq-survey-runner/tree/eq-1931-pipe-difference-between-two-dates)