### PR TITLE
Don't return 200 status_code on error

### DIFF
--- a/app/views/validate.py
+++ b/app/views/validate.py
@@ -4,8 +4,11 @@ import json
 from json import JSONDecodeError
 
 from flask import Blueprint, request, jsonify, Response
+from structlog import get_logger
 
 from app.validation.validator import Validator
+
+logger = get_logger()
 
 validate_blueprint = Blueprint('validate', __name__)
 
@@ -14,6 +17,7 @@ validator = Validator()
 
 @validate_blueprint.route('/validate', methods=['POST'])
 def validate_schema_request_body():
+    logger.info('Validating schema')
     return validate_schema(request.data.decode())
 
 
@@ -21,6 +25,7 @@ def validate_schema_request_body():
 def validate_schema_from_url():
     values = request.args
     if 'url' in values:
+        logger.info('Validating schema from URL', url=values['url'])
         try:
             with urllib.request.urlopen(values['url']) as url:
                 return validate_schema(url.read().decode())
@@ -32,6 +37,7 @@ def validate_schema(data):
     try:
         json_to_validate = json.loads(data)
     except JSONDecodeError:
+        logger.info('Could not parse JSON', status=400)
         return Response(status=400, response='Could not parse JSON')
 
     response = {}
@@ -40,5 +46,8 @@ def validate_schema(data):
 
     if errors:
         response['errors'] = errors
+        logger.info('Schema validator returned errors', status=400)
+        return jsonify(response), 400
 
+    logger.info('Schema validation passed', status=200)
     return jsonify(response), 200


### PR DESCRIPTION
Returning a `400` error makes it easier to detect if a schema is invalid