### PR TITLE
Eq 1947 date range validation

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -18,6 +18,7 @@ pytest = "==2.8.2"
 "flake8" = "==3.4.1"
 pylint = "==1.8.2"
 pylint-quotes = "==0.1.6"
+python-dateutil = "*"
 
 
 [requires]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,19 +1,19 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "8223e1c97e3adefc4a5053214d4a0eecf93e4957932d34ae4756559ff0863f66"
+            "sha256": "a92a7ac25dd867a6bbb41658eb17bc0b80c3701dba2feae4092f83fae286a769"
         },
         "host-environment-markers": {
             "implementation_name": "cpython",
-            "implementation_version": "3.4.2",
+            "implementation_version": "3.6.3",
             "os_name": "posix",
             "platform_machine": "x86_64",
             "platform_python_implementation": "CPython",
             "platform_release": "17.4.0",
             "platform_system": "Darwin",
             "platform_version": "Darwin Kernel Version 17.4.0: Sun Dec 17 09:19:54 PST 2017; root:xnu-4570.41.2~1/RELEASE_X86_64",
-            "python_full_version": "3.4.2",
-            "python_version": "3.4",
+            "python_full_version": "3.6.3",
+            "python_version": "3.6",
             "sys_platform": "darwin"
         },
         "pipfile-spec": 6,
@@ -94,10 +94,10 @@
     "develop": {
         "astroid": {
             "hashes": [
-                "sha256:db5cfc9af6e0b60cd07c19478fb54021fc20d2d189882fbcbc94fc69a8aecc58",
-                "sha256:f0a0e386dbca9f93ea9f3ea6f32b37a24720502b7baa9cb17c3976a680d43a06"
+                "sha256:38186e481b65877fd8b1f9acc33e922109e983eb7b6e487bd4c71002134ad331",
+                "sha256:35cfae47aac19c7b407b7095410e895e836f2285ccf1220336afba744cc4c5f2"
             ],
-            "version": "==1.6.1"
+            "version": "==1.6.3"
         },
         "flake8": {
             "hashes": [
@@ -157,10 +157,10 @@
         },
         "py": {
             "hashes": [
-                "sha256:8cca5c229d225f8c1e3085be4fcf306090b00850fefad892f9d96c7b6e2f310f",
-                "sha256:ca18943e28235417756316bfada6cd96b23ce60dd532642690dcfdaba988a76d"
+                "sha256:983f77f3331356039fdd792e9220b7b8ee1aa6bd2b25f567a963ff1de5a64f6a",
+                "sha256:29c9fab495d7528e80ba1e343b958684f4ace687327e6f789a94bf3d1915f881"
             ],
-            "version": "==1.5.2"
+            "version": "==1.5.3"
         },
         "pycodestyle": {
             "hashes": [
@@ -196,6 +196,13 @@
                 "sha256:da2fc57320dd11f621d166634c52b989aa2291af1296c32a27a11777aa4128b9"
             ],
             "version": "==2.8.2"
+        },
+        "python-dateutil": {
+            "hashes": [
+                "sha256:3220490fb9741e2342e1cf29a503394fdac874bc39568288717ee67047ff29df",
+                "sha256:9d8074be4c993fbe4947878ce593052f71dac82932a677d49194d8ce9778002e"
+            ],
+            "version": "==2.7.2"
         },
         "six": {
             "hashes": [

--- a/schemas/answers/date.json
+++ b/schemas/answers/date.json
@@ -42,6 +42,84 @@
             }
           }
         }
+      },
+      "minimum": {
+        "type": "object",
+        "description": "minimum offset date for user entered date to be larger than.",
+        "properties": {
+          "value": {
+            "type": "string",
+            "description": "date string or 'now'."
+          },
+          "answer_id": {
+            "type": "string",
+            "description": "The id of an answer from which to obtain the date"
+          },
+          "meta": {
+            "type": "string",
+            "description": "Metadata provided by the calling service. This will vary between surveys."
+          },
+          "offset_by": {
+            "$ref": "../common_definitions.json#/offset_by"
+          }
+        },
+        "additionalProperties": false,
+        "oneOf": [
+          {
+            "required": [
+              "value"
+            ]
+          },
+          {
+            "required": [
+              "answer_id"
+            ]
+          },
+          {
+            "required": [
+              "meta"
+            ]
+          }
+        ]
+      },
+      "maximum": {
+        "type": "object",
+        "description": "maximum offset date for user entered date to be lower than.",
+        "properties": {
+          "value": {
+            "type": "string",
+            "description": "date string or 'now'."
+          },
+          "answer_id": {
+            "type": "string",
+            "description": "The id of an answer from which to obtain the date"
+          },
+          "meta": {
+            "type": "string",
+            "description": "Metadata provided by the calling service. This will vary between surveys."
+          },
+          "offset_by": {
+            "$ref": "../common_definitions.json#/offset_by"
+          }
+        },
+        "additionalProperties": false,
+        "oneOf": [
+          {
+            "required": [
+              "value"
+            ]
+          },
+          {
+            "required": [
+              "answer_id"
+            ]
+          },
+          {
+            "required": [
+              "meta"
+            ]
+          }
+        ]
       }
     },
     "additionalProperties": false,

--- a/schemas/common_definitions.json
+++ b/schemas/common_definitions.json
@@ -127,30 +127,7 @@
               "pattern": "^(now|\\d{4}\\-(0?[1-9]|1[012])(|\\-(0?[1-9]|[12][0-9]|3[01])))$"
             },
             "offset_by": {
-              "type": "object",
-              "properties": {
-                "days": {
-                  "type": "integer"
-                },
-                "months": {
-                  "type": "integer"
-                },
-                "years": {
-                  "type": "integer"
-                }
-              },
-              "additionalProperties": false,
-              "anyOf": [
-                  {
-                    "required": [ "days" ]
-                  },
-                  {
-                    "required": [ "months" ]
-                  },
-                  {
-                    "required": [ "years" ]
-                  }
-                ]
+              "$ref": "common_definitions.json#/offset_by"
             }
           },
           "additionalProperties": false,
@@ -242,6 +219,32 @@
       }
     },
     "additionalProperties": false
+  },
+  "offset_by": {
+    "type": "object",
+    "properties": {
+      "days": {
+        "type": "integer"
+      },
+      "months": {
+        "type": "integer"
+      },
+      "years": {
+        "type": "integer"
+      }
+    },
+    "additionalProperties": false,
+    "anyOf": [
+        {
+          "required": [ "days" ]
+        },
+        {
+          "required": [ "months" ]
+        },
+        {
+          "required": [ "years" ]
+        }
+      ]
   },
   "routing_rules": {
     "type": "array",

--- a/schemas/questions/date_range.json
+++ b/schemas/questions/date_range.json
@@ -33,6 +33,75 @@
         "type": "string",
         "enum": ["DateRange"]
       },
+      "period_limits": {
+        "type": "object",
+        "description": "minimum and/or maximum time limit for the period to be in days/months/years.",
+        "properties": {
+          "minimum": {
+            "type": "object",
+            "description": "minimum limit for the period to be greater than.",
+            "properties": {
+              "days": {
+                "type": "integer"
+              },
+              "months": {
+                "type": "integer"
+              },
+              "years": {
+                "type": "integer"
+              }
+            },
+            "additionalProperties": false,
+            "anyOf": [
+              {
+                "required": [ "days" ]
+              },
+              {
+                "required": [ "months" ]
+              },
+              {
+                "required": [ "years" ]
+              }
+            ]
+          },
+          "maximum": {
+            "type": "object",
+            "description": "minimum limit for the period to be greater than.",
+            "properties": {
+              "days": {
+                "type": "integer"
+              },
+              "months": {
+                "type": "integer"
+              },
+              "years": {
+                "type": "integer"
+              }
+            },
+            "additionalProperties": false,
+            "anyOf": [
+              {
+                "required": [ "days" ]
+              },
+              {
+                "required": [ "months" ]
+              },
+              {
+                "required": [ "years" ]
+              }
+            ]
+          }
+        },
+        "additionalProperties": false,
+          "anyOf": [
+            {
+              "required": [ "minimum" ]
+            },
+            {
+              "required": [ "maximum" ]
+            }
+          ]
+      },
       "answers": {
         "type": "array",
         "minItems": 2,

--- a/tests/schemas/test_invalid_date_range_period.json
+++ b/tests/schemas/test_invalid_date_range_period.json
@@ -1,0 +1,58 @@
+{
+    "mime_type": "application/json/ons/eq",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.2",
+    "survey_id": "023",
+    "title": "Date formats",
+    "description": "A test schema for different date formats",
+    "theme": "default",
+    "legal_basis": "StatisticsOfTradeAct",
+    "variables": {
+        "period": "{{ format_conditional_date (answers.period_from, exercise.start_date)}} to {{ format_conditional_date (answers.period_to, exercise.end_date)}}"
+    },
+    "sections": [{
+        "id": "default-section",
+        "groups": [{
+            "id": "dates",
+            "title": "Date Range Validation",
+            "blocks": [{
+                    "type": "Question",
+                    "id": "date-range-block",
+                    "title": "Date Range",
+                    "questions": [{
+                        "id": "date-range-question",
+                        "title": "Enter Date Range",
+                        "type": "DateRange",
+                        "period_limits": {
+                            "minimum": {
+                                "years": 1,
+                                "days": 23
+                            },
+                            "maximum": {
+                                "months": 1,
+                                "days": 20
+                            }
+                        },
+                        "answers": [{
+                                "id": "date-range-from",
+                                "label": "Period from",
+                                "mandatory": true,
+                                "type": "Date"
+                            },
+                            {
+                                "id": "date-range-to",
+                                "label": "Period to",
+                                "mandatory": true,
+                                "type": "Date"
+                            }
+                        ]
+                    }]
+                },
+                {
+                    "type": "Summary",
+                    "id": "summary"
+                }
+            ]
+        }]
+    }]
+}

--- a/tests/schemas/test_invalid_single_date_min_max_period.json
+++ b/tests/schemas/test_invalid_single_date_min_max_period.json
@@ -1,0 +1,60 @@
+{
+    "mime_type": "application/json/ons/eq",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.2",
+    "survey_id": "023",
+    "title": "Date formats",
+    "description": "A test schema for different date formats",
+    "theme": "default",
+    "legal_basis": "StatisticsOfTradeAct",
+    "variables": {
+        "period": "{{ format_conditional_date (answers.period_from, exercise.start_date)}} to {{ format_conditional_date (answers.period_to, exercise.end_date)}}"
+    },
+    "sections": [{
+        "id": "default-section",
+        "groups": [{
+            "id": "dates",
+            "title": "Date Range Validation",
+            "blocks": [{
+                    "type": "Question",
+                    "id": "date-range-block",
+                    "title": "Date Range",
+                    "questions": [{
+                        "id": "date-range-question",
+                        "title": "Enter Date Range",
+                        "type": "DateRange",
+                        "answers": [{
+                                "id": "date-range-from",
+                                "label": "Period from",
+                                "mandatory": true,
+                                "type": "Date",
+                                "minimum": {
+                                    "value": "now",
+                                    "offset_by": {
+                                      "days": -19
+                                    }
+                                },
+                                "maximum": {
+                                  "value": "2017-06-11",
+                                  "offset_by": {
+                                      "days": 2
+                                    }
+                                }
+                            },
+                            {
+                                "id": "date-range-to",
+                                "label": "Period to",
+                                "mandatory": true,
+                                "type": "Date"
+                            }
+                        ]
+                    }]
+                },
+                {
+                    "type": "Summary",
+                    "id": "summary"
+                }
+            ]
+        }]
+    }]
+}

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -123,6 +123,28 @@ class TestSchemaValidation(unittest.TestCase):
         self.assertEqual(errors[1]['message'], 'Schema Integrity Error. Answer id - breakdown-4 does not exist within '
                                                'this question - breakdown-question')
 
+    def test_invalid_date_range_period(self):
+
+        file = 'schemas/test_invalid_date_range_period.json'
+        json_to_validate = self.open_and_load_schema_file(file)
+
+        errors = self.validator.validate_schema(json_to_validate)
+
+        self.assertEqual(len(errors), 1)
+        self.assertEqual(errors[0]['message'], 'Schema Integrity Error. The minimum period is greater than the maximum '
+                                               'period for date-range-question')
+
+    def test_invalid_single_date_period(self):
+
+        file = 'schemas/test_invalid_single_date_min_max_period.json'
+        json_to_validate = self.open_and_load_schema_file(file)
+
+        errors = self.validator.validate_schema(json_to_validate)
+
+        self.assertEqual(len(errors), 1)
+        self.assertEqual(errors[0]['message'], 'Schema Integrity Error. The minimum offset date is greater than the '
+                                               'maximum offset date')
+
     @staticmethod
     def open_and_load_schema_file(file):
         json_file = open(os.path.join(os.path.dirname(os.path.realpath(__file__)), file), encoding='utf8')


### PR DESCRIPTION
Added object types `minimum/maximum` to: 

- `DateRange` question for period validation
- `Date` answer type. 

Also added further validation in answer types where there is a minimum and a maximum so that, schema shouldn't fail. Only validates where there is a minimum and a maximum and both have `value` offset dates.