### PR TITLE
Pin pip and pipenv to working versions in concourse

### DIFF
--- a/ci/concourse.yml
+++ b/ci/concourse.yml
@@ -57,12 +57,7 @@ jobs:
         - -exc
         - |
           cd eq-schema-validator
-          pyenv install
-          pip install -U pip pipenv
-          pipenv install --dev --deploy
-          pipenv check
-          pipenv run ./scripts/run_lint.sh
-          pipenv run py.test
+          ./ci/install.sh
 
   - put: eq-schema-validator-image
     params:
@@ -98,12 +93,7 @@ jobs:
         - -exc
         - |
           cd eq-schema-validator-pull-request
-          pyenv install
-          pip install -U pip pipenv
-          pipenv install --dev --deploy
-          pipenv check
-          pipenv run ./scripts/run_lint.sh
-          pipenv run py.test
+          ./ci/install.sh
 
   - put: eq-schema-validator-image
     params:

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+pyenv install
+pip install pip==9.0.3 pipenv==11.10.0
+pipenv install --dev --deploy
+pipenv check
+pipenv run ./scripts/run_lint.sh
+pipenv run py.test


### PR DESCRIPTION
Concourse is failing since latest update to pip.

I have pinned the version of `pip` and `pipenv` until this issue is resolved.
Note: Concourse is still throwing the same error as before but is able to carry on.

[Issue](https://github.com/wemake-services/wemake-django-template/issues/287)

I have also separated the scripts that are run in `concourse.yml` to `install.sh` so that it could be modified without resetting the `concourse.yml` each time.