### PR TITLE
Specify required metadata in schema

### DIFF
--- a/api.py
+++ b/api.py
@@ -8,4 +8,4 @@ application.register_blueprint(validate_blueprint)
 application.register_blueprint(status_blueprint)
 
 if __name__ == '__main__':
-    application.run(port=5001)
+    application.run()

--- a/api.py
+++ b/api.py
@@ -8,4 +8,4 @@ application.register_blueprint(validate_blueprint)
 application.register_blueprint(status_blueprint)
 
 if __name__ == '__main__':
-    application.run()
+    application.run(port=5001)

--- a/app/validation/validator.py
+++ b/app/validation/validator.py
@@ -78,22 +78,15 @@ class Validator:
             return '{}'.format(e)
 
     def _validate_schema_contain_required_metadata(self, schema):
-        # Ensure that metadata used within the schema are implicitly defined in required_metadata field
+        # Ensure that metadata used within the schema are explicitly defined.
 
         errors = []
-        default_metadata = ['user_id', 'period_id']
 
-        required_metadata = schema['required_metadata']
+        default_metadata = ['user_id', 'period_id']  # Metadata that must be present in all schemas
+        required_metadata = schema['required_metadata']  # Metadata required within the schema.
 
-        # This regex will find all words that precede with "metadata" then a "[" or "." following by an optional "'"
+        # Find all words that precede with "metadata['"
         parsed_metadata = re.findall(r"(?<=metadata\[\')\w+", str(schema))
-
-        parsed_metadata1 = re.findall(r"(?<=metadata\.)\w+", str(schema))
-        if parsed_metadata1:
-            int('t')
-        # (?<=[\|\{\,\ \(]metadata)\.(\w+)(?=[\ \|\}\)\,])
-
-        print('\033[93m', set(parsed_metadata), '\x1b[0m')
 
         for metadata in set(parsed_metadata):
             if metadata not in required_metadata:
@@ -102,6 +95,7 @@ class Validator:
         for metadata in required_metadata:
             if metadata not in set(parsed_metadata) and metadata not in default_metadata:
                 errors.append(self._error_message('Unused metadata defined in required_metadata - {}'.format(metadata)))
+
         return errors
 
     def validate_calculated_ids_in_answers_to_calculate_exists(self, question):

--- a/app/validation/validator.py
+++ b/app/validation/validator.py
@@ -1,3 +1,4 @@
+import re
 from json import load
 import os
 import pathlib
@@ -22,6 +23,8 @@ class Validator:
             return schema_errors
 
         errors = []
+
+        errors.extend(self._validate_schema_contain_required_metadata(json_to_validate))
 
         numeric_answer_ranges = {}
 
@@ -73,6 +76,33 @@ class Validator:
             }
         except SchemaError as e:
             return '{}'.format(e)
+
+    def _validate_schema_contain_required_metadata(self, schema):
+        # Ensure that metadata used within the schema are implicitly defined in required_metadata field
+
+        errors = []
+        default_metadata = ['user_id', 'period_id']
+
+        required_metadata = schema['required_metadata']
+
+        # This regex will find all words that precede with "metadata" then a "[" or "." following by an optional "'"
+        parsed_metadata = re.findall(r"(?<=metadata\[\')\w+", str(schema))
+
+        parsed_metadata1 = re.findall(r"(?<=metadata\.)\w+", str(schema))
+        if parsed_metadata1:
+            int('t')
+        # (?<=[\|\{\,\ \(]metadata)\.(\w+)(?=[\ \|\}\)\,])
+
+        print('\033[93m', set(parsed_metadata), '\x1b[0m')
+
+        for metadata in set(parsed_metadata):
+            if metadata not in required_metadata:
+                errors.append(self._error_message('Metadata - {} not specified in required_metadata field'.format(metadata)))
+
+        for metadata in required_metadata:
+            if metadata not in set(parsed_metadata) and metadata not in default_metadata:
+                errors.append(self._error_message('Unused metadata defined in required_metadata - {}'.format(metadata)))
+        return errors
 
     def validate_calculated_ids_in_answers_to_calculate_exists(self, question):
         # Validates that any answer ids within the 'answer_to_group'

--- a/app/validation/validator.py
+++ b/app/validation/validator.py
@@ -24,7 +24,7 @@ class Validator:
 
         errors = []
 
-        errors.extend(self._validate_schema_contain_required_metadata(json_to_validate))
+        errors.extend(self._validate_schema_contain_metadata(json_to_validate))
 
         numeric_answer_ranges = {}
 
@@ -77,24 +77,24 @@ class Validator:
         except SchemaError as e:
             return '{}'.format(e)
 
-    def _validate_schema_contain_required_metadata(self, schema):
+    def _validate_schema_contain_metadata(self, schema):
         # Ensure that metadata used within the schema are explicitly defined.
 
         errors = []
 
         default_metadata = ['user_id', 'period_id']  # Metadata that must be present in all schemas
-        required_metadata = schema['required_metadata']  # Metadata required within the schema.
+        schema_metadata = schema['metadata']  # Metadata required within the schema.
 
         # Find all words that precede with "metadata['"
         parsed_metadata = re.findall(r"(?<=metadata\[\')\w+", str(schema))
 
         for metadata in set(parsed_metadata):
-            if metadata not in required_metadata:
-                errors.append(self._error_message('Metadata - {} not specified in required_metadata field'.format(metadata)))
+            if metadata not in schema_metadata:
+                errors.append(self._error_message('Metadata - {} not specified in metadata field'.format(metadata)))
 
-        for metadata in required_metadata:
+        for metadata in schema_metadata:
             if metadata not in set(parsed_metadata) and metadata not in default_metadata:
-                errors.append(self._error_message('Unused metadata defined in required_metadata - {}'.format(metadata)))
+                errors.append(self._error_message('Unused metadata defined in metadata field - {}'.format(metadata)))
 
         return errors
 

--- a/schemas/questionnaire_v1.json
+++ b/schemas/questionnaire_v1.json
@@ -10,7 +10,7 @@
     "sections",
     "theme",
     "legal_basis",
-    "required_metadata"
+    "metadata"
   ],
   "properties": {
     "eq_id": {
@@ -60,7 +60,7 @@
         "StatisticsOfTradeAct"
       ]
     },
-    "required_metadata": {
+    "metadata": {
       "type": "object",
       "required": ["period_id", "user_id"]
     },

--- a/schemas/questionnaire_v1.json
+++ b/schemas/questionnaire_v1.json
@@ -61,7 +61,8 @@
       ]
     },
     "required_metadata": {
-      "type": "object"
+      "type": "object",
+      "required": ["period_id", "user_id"]
     },
     "view_submitted_response": {
       "type": "object",

--- a/schemas/questionnaire_v1.json
+++ b/schemas/questionnaire_v1.json
@@ -9,7 +9,8 @@
     "title",
     "sections",
     "theme",
-    "legal_basis"
+    "legal_basis",
+    "required_metadata"
   ],
   "properties": {
     "eq_id": {
@@ -58,6 +59,9 @@
         "Voluntary",
         "StatisticsOfTradeAct"
       ]
+    },
+    "required_metadata": {
+      "type": "object"
     },
     "view_submitted_response": {
       "type": "object",

--- a/tests/schemas/test_invalid_id_in_grouped_answers_to_calculate.json
+++ b/tests/schemas/test_invalid_id_in_grouped_answers_to_calculate.json
@@ -7,6 +7,10 @@
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
     "description": "A survey that tests grouped and calculated answers against a total",
+    "required_metadata": {
+        "user_id": "string",
+        "period_id": "string"
+    },
     "sections": [{
         "id": "default-section",
         "groups": [{

--- a/tests/schemas/test_invalid_id_in_grouped_answers_to_calculate.json
+++ b/tests/schemas/test_invalid_id_in_grouped_answers_to_calculate.json
@@ -7,7 +7,7 @@
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
     "description": "A survey that tests grouped and calculated answers against a total",
-    "required_metadata": {
+    "metadata": {
         "user_id": "string",
         "period_id": "string"
     },

--- a/tests/schemas/test_invalid_numeric_answers.json
+++ b/tests/schemas/test_invalid_numeric_answers.json
@@ -7,7 +7,7 @@
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
     "description": "A questionnaire to test currency input type",
-    "required_metadata": {
+    "metadata": {
         "user_id": "string",
         "period_id": "string"
     },

--- a/tests/schemas/test_invalid_numeric_answers.json
+++ b/tests/schemas/test_invalid_numeric_answers.json
@@ -7,6 +7,10 @@
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
     "description": "A questionnaire to test currency input type",
+    "required_metadata": {
+        "user_id": "string",
+        "period_id": "string"
+    },
     "sections": [{
         "id": "section-1",
         "groups": [{

--- a/tests/schemas/test_invalid_routing_block.json
+++ b/tests/schemas/test_invalid_routing_block.json
@@ -7,7 +7,7 @@
     "description": "",
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
-    "required_metadata": {
+    "metadata": {
         "user_id": "string",
         "period_id": "string"
     },

--- a/tests/schemas/test_invalid_routing_block.json
+++ b/tests/schemas/test_invalid_routing_block.json
@@ -7,6 +7,10 @@
     "description": "",
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
+    "required_metadata": {
+        "user_id": "string",
+        "period_id": "string"
+    },
     "sections": [{
         "id": "section1",
         "groups": [{

--- a/tests/schemas/test_invalid_routing_group.json
+++ b/tests/schemas/test_invalid_routing_group.json
@@ -7,6 +7,10 @@
     "description": "",
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
+    "required_metadata": {
+        "user_id": "string",
+        "period_id": "string"
+    },
     "sections": [
         {
             "id": "section1",

--- a/tests/schemas/test_invalid_routing_group.json
+++ b/tests/schemas/test_invalid_routing_group.json
@@ -7,7 +7,7 @@
     "description": "",
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
-    "required_metadata": {
+    "metadata": {
         "user_id": "string",
         "period_id": "string"
     },

--- a/tests/schemas/test_numeric_default_with_routing.json
+++ b/tests/schemas/test_numeric_default_with_routing.json
@@ -7,7 +7,7 @@
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
     "description": "A questionnaire to test currency input type",
-    "required_metadata": {
+    "metadata": {
         "user_id": "string",
         "period_id": "string"
     },

--- a/tests/schemas/test_numeric_default_with_routing.json
+++ b/tests/schemas/test_numeric_default_with_routing.json
@@ -7,6 +7,10 @@
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
     "description": "A questionnaire to test currency input type",
+    "required_metadata": {
+        "user_id": "string",
+        "period_id": "string"
+    },
     "sections": [{
         "id": "section-1",
         "groups": [{

--- a/tests/schemas/test_schema_id_regex.json
+++ b/tests/schemas/test_schema_id_regex.json
@@ -7,6 +7,10 @@
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
     "description": "A questionnaire to test schema id regex",
+    "required_metadata": {
+        "user_id": "string",
+        "period_id": "string"
+    },
     "sections": [{
         "id": "section1",
         "groups": [{

--- a/tests/schemas/test_schema_id_regex.json
+++ b/tests/schemas/test_schema_id_regex.json
@@ -7,7 +7,7 @@
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
     "description": "A questionnaire to test schema id regex",
-    "required_metadata": {
+    "metadata": {
         "user_id": "string",
         "period_id": "string"
     },


### PR DESCRIPTION
### What is the context of this PR?
Runner [PR](https://github.com/ONSdigital/eq-survey-runner/pull/1545) must be merged first. Refer to runner PR for more context.
This PR enforces that:
1. `metadata` is present in the schema.
2. the mandatory metadata is present in all schemas: `user_id`, `period_id`
2. metadata used within the schema for piping are defined in the `metadata` field.

### How to review
1. Ensure all schemas pass against the runner branch.
2. Edit a schema to ensure that if you do not define the piped metadata as required then it fails.