### PR TITLE
Moved dateutil from dev dependency to project dependecies

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -10,6 +10,7 @@ name = "pypi"
 Flask = "*"
 jsonschema = "*"
 structlog = "*"
+python-dateutil = "*"
 
 
 [dev-packages]
@@ -18,7 +19,6 @@ pytest = "==2.8.2"
 "flake8" = "==3.4.1"
 pylint = "==1.8.2"
 pylint-quotes = "==0.1.6"
-python-dateutil = "*"
 
 
 [requires]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "a92a7ac25dd867a6bbb41658eb17bc0b80c3701dba2feae4092f83fae286a769"
+            "sha256": "f07540f54524e62d538a38a8323a3f4c034988b3dc873f32b83ecde67542a715"
         },
         "host-environment-markers": {
             "implementation_name": "cpython",
@@ -68,6 +68,13 @@
                 "sha256:a6be69091dac236ea9c6bc7d012beab42010fa914c459791d627dad4910eb665"
             ],
             "version": "==1.0"
+        },
+        "python-dateutil": {
+            "hashes": [
+                "sha256:3220490fb9741e2342e1cf29a503394fdac874bc39568288717ee67047ff29df",
+                "sha256:9d8074be4c993fbe4947878ce593052f71dac82932a677d49194d8ce9778002e"
+            ],
+            "version": "==2.7.2"
         },
         "six": {
             "hashes": [
@@ -164,7 +171,9 @@
         },
         "pycodestyle": {
             "hashes": [
+                "sha256:5ff2fbcbab997895ba9ead77e1b38b3ebc2e5c3b8a6194ef918666e4c790a00e",
                 "sha256:6c4245ade1edfad79c3446fadfc96b0de2759662dc29d07d80a6f27ad1ca6ba9",
+                "sha256:1ec08a51c901dfe44921576ed6e4c1f5b7ecbad403f871397feedb5eb8e4fa14",
                 "sha256:682256a5b318149ca0d2a9185d365d8864a768a28db66a84a2ea946bcc426766"
             ],
             "version": "==2.3.1"
@@ -196,13 +205,6 @@
                 "sha256:da2fc57320dd11f621d166634c52b989aa2291af1296c32a27a11777aa4128b9"
             ],
             "version": "==2.8.2"
-        },
-        "python-dateutil": {
-            "hashes": [
-                "sha256:3220490fb9741e2342e1cf29a503394fdac874bc39568288717ee67047ff29df",
-                "sha256:9d8074be4c993fbe4947878ce593052f71dac82932a677d49194d8ce9778002e"
-            ],
-            "version": "==2.7.2"
         },
         "six": {
             "hashes": [


### PR DESCRIPTION
Previous under dev dependencies, eq-compose wasn't picking it up and resulted in smoke test failures.

To Test:
Point schema-validator module in compose to this branch and run compose followed by smoke test. All should pass