### PR TITLE
Specify required metadata in schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,6 +84,9 @@ celerybeat-schedule
 venv/
 ENV/
 
+# intellij
+.idea/
+
 # Spyder project settings
 .spyderproject
 .spyproject

--- a/schemas/questionnaire_v1.json
+++ b/schemas/questionnaire_v1.json
@@ -59,6 +59,29 @@
         "StatisticsOfTradeAct"
       ]
     },
+    "metadata": {
+      "type": "object",
+      "required": [
+        "user_id",
+        "period_id"
+      ],
+      "patternProperties": {
+        "^.*$": {
+          "type": "object",
+          "properties": {
+            "validator": {
+              "type": "string",
+              "enum": [
+                "date",
+                "string",
+                "object"
+              ]
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
     "view_submitted_response": {
       "type": "object",
       "properties": {

--- a/tests/schemas/test_invalid_date_range_period.json
+++ b/tests/schemas/test_invalid_date_range_period.json
@@ -7,8 +7,13 @@
     "description": "A test schema for different date formats",
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
-    "variables": {
-        "period": "{{ format_conditional_date (answers.period_from, exercise.start_date)}} to {{ format_conditional_date (answers.period_to, exercise.end_date)}}"
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
     },
     "sections": [{
         "id": "default-section",

--- a/tests/schemas/test_invalid_id_in_grouped_answers_to_calculate.json
+++ b/tests/schemas/test_invalid_id_in_grouped_answers_to_calculate.json
@@ -7,6 +7,14 @@
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
     "description": "A survey that tests grouped and calculated answers against a total",
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
+    },
     "sections": [{
         "id": "default-section",
         "groups": [{

--- a/tests/schemas/test_invalid_metadata.json
+++ b/tests/schemas/test_invalid_metadata.json
@@ -1,0 +1,116 @@
+{
+    "data_version": "0.0.1",
+    "description": "Test Schema Context",
+    "mime_type": "application/json/ons/eq",
+    "schema_version": "0.0.1",
+    "survey_id": "144",
+    "theme": "default",
+    "legal_basis": "Voluntary",
+    "title": "Test Schema Context",
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        },
+        "ru_name": {
+            "validator": "string"
+        },
+        "trad_as": {
+            "validator": "string"
+        },
+        "period_str": {
+            "validator": "string"
+        },
+        "trad_as_or_ru_name": {
+            "validator": "string"
+        },
+        "ref_p_start_date": {
+            "validator": "date"
+        },
+        "ref_p_end_date": {
+            "validator": "date"
+        },
+        "employment_date": {
+            "validator": "date"
+        },
+        "return_by": {
+            "validator": "date"
+        },
+        "region_code": {
+            "validator": "string"
+        },
+        "variant_flags": {
+            "validator": "object"
+        },
+        "invalid_metadata": {
+            "validator": "string"
+        }
+    },
+    "sections": [{
+        "id": "default-section",
+        "groups": [{
+                "blocks": [{
+                    "id": "introduction",
+                    "type": "Introduction",
+                    "primary_content": [{
+                        "type": "Preview",
+                        "id": "preview",
+                        "title": "",
+                        "content": [{
+                            "title": "period_str: {{ metadata['period_str'] }}"
+                        }, {
+                            "title": "ru_name: {{ metadata['ru_name'] }}"
+                        }, {
+                            "title": "trad_as: {{ metadata['trad_as'] }}"
+                        }, {
+                            "title": "trad_as_or_ru_name: {{ metadata['trad_as_or_ru_name'] }}"
+                        }, {
+                            "title": "ref_p_start_date: {{ metadata['ref_p_start_date'] }}"
+                        }, {
+                            "title": "ref_p_end_date: {{ metadata['ref_p_end_date'] }}"
+                        }, {
+                            "title": "employment_date: {{ metadata['employment_date'] }}"
+                        }, {
+                            "title": "return_by: {{ metadata['return_by'] }}"
+                        }, {
+                            "title": "region_code: {{ metadata['region_code'] }}"
+                        }, {
+                            "title": "variant_flags: {{ metadata['variant_flags'] }}"
+                        }, {
+
+                            "title": "Invalid: {{ metadata['invalid'] }}"
+                        }]
+                    }]
+                }],
+                "id": "general-business-information",
+                "title": "General Business Information"
+            },
+            {
+                "blocks": [{
+                    "id": "confirmation",
+                    "description": "",
+                    "questions": [{
+                        "answers": [],
+                        "id": "ready-to-submit-completed-question",
+                        "title": "Submission",
+                        "type": "General",
+                        "guidance": {
+                            "content": [{
+                                "list": [
+                                    "You will not be able to access or change your answers on submitting the questionnaire",
+                                    "If you wish to review your answers please select the relevant completed sections"
+                                ]
+                            }]
+                        }
+                    }],
+                    "title": "You are now ready to submit this survey",
+                    "type": "Confirmation"
+                }],
+                "id": "ready-to-submit",
+                "title": "Submit answers"
+            }
+        ]
+    }]
+}

--- a/tests/schemas/test_invalid_mm_yyyy_date_range_period.json
+++ b/tests/schemas/test_invalid_mm_yyyy_date_range_period.json
@@ -7,8 +7,19 @@
     "description": "A test schema for different date formats",
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
-    "variables": {
-        "period": "{{ format_conditional_date (answers.period_from, exercise.start_date)}} to {{ format_conditional_date (answers.period_to, exercise.end_date)}}"
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        },
+        "ref_p_start_date": {
+            "validator": "date"
+        },
+        "ref_p_end_date": {
+            "validator": "date"
+        }
     },
     "sections": [{
         "id": "default-section",

--- a/tests/schemas/test_invalid_numeric_answers.json
+++ b/tests/schemas/test_invalid_numeric_answers.json
@@ -7,6 +7,14 @@
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
     "description": "A questionnaire to test currency input type",
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
+    },
     "sections": [{
         "id": "section-1",
         "groups": [{

--- a/tests/schemas/test_invalid_routing_block.json
+++ b/tests/schemas/test_invalid_routing_block.json
@@ -7,6 +7,14 @@
     "description": "",
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
+    },
     "sections": [{
         "id": "section1",
         "groups": [{

--- a/tests/schemas/test_invalid_routing_group.json
+++ b/tests/schemas/test_invalid_routing_group.json
@@ -7,6 +7,14 @@
     "description": "",
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
+    },
     "sections": [
         {
             "id": "section1",

--- a/tests/schemas/test_invalid_single_date_min_max_period.json
+++ b/tests/schemas/test_invalid_single_date_min_max_period.json
@@ -7,8 +7,13 @@
     "description": "A test schema for different date formats",
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
-    "variables": {
-        "period": "{{ format_conditional_date (answers.period_from, exercise.start_date)}} to {{ format_conditional_date (answers.period_to, exercise.end_date)}}"
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
     },
     "sections": [{
         "id": "default-section",

--- a/tests/schemas/test_numeric_default_with_routing.json
+++ b/tests/schemas/test_numeric_default_with_routing.json
@@ -7,6 +7,14 @@
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
     "description": "A questionnaire to test currency input type",
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
+    },
     "sections": [{
         "id": "section-1",
         "groups": [{

--- a/tests/schemas/test_schema_id_regex.json
+++ b/tests/schemas/test_schema_id_regex.json
@@ -7,6 +7,14 @@
     "theme": "default",
     "legal_basis": "StatisticsOfTradeAct",
     "description": "A questionnaire to test schema id regex",
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
+    },
     "sections": [{
         "id": "section1",
         "groups": [{

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -156,6 +156,17 @@ class TestSchemaValidation(unittest.TestCase):
         self.assertEqual(errors[0]['message'], 'Schema Integrity Error. The minimum offset date is greater than the '
                                                'maximum offset date')
 
+    def test_invalid_metadata(self):
+        self.skipTest('Will enable once runner PR is merged.')
+        file = 'schemas/test_invalid_metadata.json'
+        json_to_validate = self.open_and_load_schema_file(file)
+
+        errors = self.validator.validate_schema(json_to_validate)
+
+        self.assertEqual(len(errors), 2)
+        self.assertEqual(errors[0]['message'], 'Schema Integrity Error. Metadata - invalid not specified in metadata field')
+        self.assertEqual(errors[1]['message'], 'Schema Integrity Error. Unused metadata defined in metadata field - invalid_metadata')
+
     @staticmethod
     def open_and_load_schema_file(file):
         json_file = open(os.path.join(os.path.dirname(os.path.realpath(__file__)), file), encoding='utf8')


### PR DESCRIPTION
### What is the context of this PR?
Runner [PR](https://github.com/ONSdigital/eq-survey-runner/pull/1571) must be merged first. Refer to runner PR for more context.
This PR enforces that:
1. `metadata` is present in the schema.
2. the mandatory metadata is present in all schemas: `user_id`, `period_id`
2. metadata used within the schema for piping are defined in the `metadata` field.

### How to review
1. Ensure all schemas pass against the runner branch.
2. Edit a schema to ensure that if you do not define the piped metadata as required then it fails.

Ways of piping metadata:

1. `metadata.ru_name`
2. `metadata['ru_name']`
3. `"meta": "ru_name"`


> Update: Made metadata optional so that this can be merged without affecting (master) runner. The publisher [PR](https://github.com/ONSdigital/eq-publisher/pull/64) can also go in. A new validator PR need be raised to be make metadata mandatory once the runner PR is ready to be merged.