### PR TITLE
Add date validation to MM-YYYY

### DIFF
--- a/schemas/answers/date.json
+++ b/schemas/answers/date.json
@@ -60,7 +60,7 @@
             "description": "Metadata provided by the calling service. This will vary between surveys."
           },
           "offset_by": {
-            "$ref": "../common_definitions.json#/offset_by"
+            "$ref": "../common_definitions.json#/offset_by_yyyy_mm_dd"
           }
         },
         "additionalProperties": false,
@@ -99,7 +99,7 @@
             "description": "Metadata provided by the calling service. This will vary between surveys."
           },
           "offset_by": {
-            "$ref": "../common_definitions.json#/offset_by"
+            "$ref": "../common_definitions.json#/offset_by_yyyy_mm_dd"
           }
         },
         "additionalProperties": false,

--- a/schemas/answers/month_year_date.json
+++ b/schemas/answers/month_year_date.json
@@ -40,6 +40,84 @@
             }
           }
         }
+      },
+      "minimum": {
+        "type": "object",
+        "description": "minimum offset date for user entered date to be larger than.",
+        "properties": {
+          "value": {
+            "type": "string",
+            "description": "date string or 'now'."
+          },
+          "answer_id": {
+            "type": "string",
+            "description": "The id of an answer from which to obtain the date"
+          },
+          "meta": {
+            "type": "string",
+            "description": "Metadata provided by the calling service. This will vary between surveys."
+          },
+          "offset_by": {
+            "$ref": "../common_definitions.json#/offset_by_yyyy_mm"
+          }
+        },
+        "additionalProperties": false,
+        "oneOf": [
+          {
+            "required": [
+              "value"
+            ]
+          },
+          {
+            "required": [
+              "answer_id"
+            ]
+          },
+          {
+            "required": [
+              "meta"
+            ]
+          }
+        ]
+      },
+      "maximum": {
+        "type": "object",
+        "description": "maximum offset date for user entered date to be lower than.",
+        "properties": {
+          "value": {
+            "type": "string",
+            "description": "date string or 'now'."
+          },
+          "answer_id": {
+            "type": "string",
+            "description": "The id of an answer from which to obtain the date"
+          },
+          "meta": {
+            "type": "string",
+            "description": "Metadata provided by the calling service. This will vary between surveys."
+          },
+          "offset_by": {
+            "$ref": "../common_definitions.json#/offset_by_yyyy_mm"
+          }
+        },
+        "additionalProperties": false,
+        "oneOf": [
+          {
+            "required": [
+              "value"
+            ]
+          },
+          {
+            "required": [
+              "answer_id"
+            ]
+          },
+          {
+            "required": [
+              "meta"
+            ]
+          }
+        ]
       }
     },
     "additionalProperties": false,

--- a/schemas/common_definitions.json
+++ b/schemas/common_definitions.json
@@ -127,7 +127,7 @@
               "pattern": "^(now|\\d{4}\\-(0?[1-9]|1[012])(|\\-(0?[1-9]|[12][0-9]|3[01])))$"
             },
             "offset_by": {
-              "$ref": "common_definitions.json#/offset_by"
+              "$ref": "common_definitions.json#/offset_by_yyyy_mm_dd"
             }
           },
           "additionalProperties": false,
@@ -220,7 +220,7 @@
     },
     "additionalProperties": false
   },
-  "offset_by": {
+  "offset_by_yyyy_mm_dd": {
     "type": "object",
     "properties": {
       "days": {
@@ -238,6 +238,26 @@
         {
           "required": [ "days" ]
         },
+        {
+          "required": [ "months" ]
+        },
+        {
+          "required": [ "years" ]
+        }
+      ]
+  },
+  "offset_by_yyyy_mm": {
+    "type": "object",
+    "properties": {
+      "months": {
+        "type": "integer"
+      },
+      "years": {
+        "type": "integer"
+      }
+    },
+    "additionalProperties": false,
+    "anyOf": [
         {
           "required": [ "months" ]
         },

--- a/tests/schemas/test_invalid_mm_yyyy_date_range_period.json
+++ b/tests/schemas/test_invalid_mm_yyyy_date_range_period.json
@@ -1,0 +1,71 @@
+{
+    "mime_type": "application/json/ons/eq",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.2",
+    "survey_id": "023",
+    "title": "Date formats",
+    "description": "A test schema for different date formats",
+    "theme": "default",
+    "legal_basis": "StatisticsOfTradeAct",
+    "variables": {
+        "period": "{{ format_conditional_date (answers.period_from, exercise.start_date)}} to {{ format_conditional_date (answers.period_to, exercise.end_date)}}"
+    },
+    "sections": [{
+        "id": "default-section",
+        "groups": [{
+            "id": "dates",
+            "title": "Date Range Validation",
+            "blocks": [
+                {
+                    "type": "Question",
+                    "id": "date-range-block",
+                    "title": "Date Range",
+                    "questions": [{
+                        "id": "date-range-question",
+                        "title": "Enter Date Range",
+                        "type": "DateRange",
+                        "period_limits": {
+                            "minimum": {
+                                "days": 7,
+                                "months": 1
+                            },
+                            "maximum": {
+                                "days": 5,
+                                "months": 2
+                            }
+                        },
+                        "answers": [{
+                                "id": "date-range-from",
+                                "label": "Period from",
+                                "mandatory": true,
+                                "type": "MonthYearDate",
+                                "minimum": {
+                                    "meta": "ref_p_start_date",
+                                    "offset_by": {
+                                        "months": -1
+                                    }
+                                }
+                            },
+                            {
+                                "id": "date-range-to",
+                                "label": "Period to",
+                                "mandatory": true,
+                                "type": "MonthYearDate",
+                                "maximum": {
+                                    "meta": "ref_p_end_date",
+                                    "offset_by": {
+                                        "months": 2
+                                    }
+                                }
+                            }
+                        ]
+                    }]
+                },
+                {
+                    "type": "Summary",
+                    "id": "summary"
+                }
+            ]
+        }]
+    }]
+}

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -134,6 +134,17 @@ class TestSchemaValidation(unittest.TestCase):
         self.assertEqual(errors[0]['message'], 'Schema Integrity Error. The minimum period is greater than the maximum '
                                                'period for date-range-question')
 
+    def test_invalid_mm_yyyy_date_range_period(self):
+
+        file = 'schemas/test_invalid_mm_yyyy_date_range_period.json'
+        json_to_validate = self.open_and_load_schema_file(file)
+
+        errors = self.validator.validate_schema(json_to_validate)
+
+        self.assertEqual(len(errors), 1)
+        self.assertEqual(errors[0]['message'], 'Schema Integrity Error. Days can not be used in period_limit '
+                                               'for yyyy-mm date range for date-range-question')
+
     def test_invalid_single_date_period(self):
 
         file = 'schemas/test_invalid_single_date_min_max_period.json'


### PR DESCRIPTION
Allow date validation to be added to MM-YYYY date ranges. 
Days can not then be used to define offsets or period limits.