### PR TITLE
Eq 1990 different versions of question titles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,6 @@ ENV/
 .mypy_cache/
 
 secrets.yml
+
+#PyCharm
+.idea

--- a/schemas/common_definitions.json
+++ b/schemas/common_definitions.json
@@ -89,6 +89,9 @@
         "id": {
           "type": "string"
         },
+        "group_instance": {
+          "type": "integer"
+        },
         "meta": {
           "type": "string",
           "description": "Metadata provided by the calling service. This will vary between surveys."
@@ -335,6 +338,19 @@
             "repeat"
           ]
         }
+      ]
+    }
+  },
+  "titles": {
+    "type": "array",
+    "description": "Used to allow a title contents to be set based on conditional values",
+    "items": {
+      "value": "string",
+      "when": {
+        "$ref": "common_definitions.json#/when"
+      },
+      "required": [
+        "value"
       ]
     }
   }

--- a/schemas/questions/calculated.json
+++ b/schemas/questions/calculated.json
@@ -12,6 +12,9 @@
       "title": {
         "type": "string"
       },
+      "titles": {
+        "$ref": "../common_definitions.json#/titles"
+      },
       "number": {
         "type": "string"
       },
@@ -124,10 +127,13 @@
       "additionalProperties": false,
       "required": [
         "id",
-        "title",
         "type",
         "calculations",
         "answers"
+      ],
+      "oneOf": [
+        {"required": ["title"]},
+        {"required": ["titles"]}
       ]
     }
   }

--- a/schemas/questions/date_range.json
+++ b/schemas/questions/date_range.json
@@ -12,6 +12,9 @@
       "title": {
         "type": "string"
       },
+      "titles": {
+        "$ref": "../common_definitions.json#/titles"
+      },
       "number": {
         "type": "string"
       },
@@ -121,9 +124,12 @@
     "additionalProperties": false,
     "required": [
       "id",
-      "title",
       "type",
       "answers"
+    ],
+    "oneOf": [
+      {"required": ["title"]},
+      {"required": ["titles"]}
     ]
   }
 }

--- a/schemas/questions/general.json
+++ b/schemas/questions/general.json
@@ -12,6 +12,9 @@
       "title": {
         "type": "string"
       },
+      "titles": {
+        "$ref": "../common_definitions.json#/titles"
+      },
       "number": {
         "type": "string"
       },
@@ -80,9 +83,12 @@
     "additionalProperties": false,
     "required": [
       "id",
-      "title",
       "type",
       "answers"
+    ],
+    "oneOf": [
+      {"required": ["title"]},
+      {"required": ["titles"]}
     ]
   }
 }

--- a/schemas/questions/relationship.json
+++ b/schemas/questions/relationship.json
@@ -12,6 +12,9 @@
       "title": {
         "type": "string"
       },
+      "titles": {
+        "$ref": "../common_definitions.json#/titles"
+      },
       "number": {
         "type": "string"
       },
@@ -43,9 +46,12 @@
     "additionalProperties": false,
     "required": [
       "id",
-      "title",
       "type",
       "answers"
+    ],
+    "oneOf": [
+      {"required": ["title"]},
+      {"required": ["titles"]}
     ]
   }
 }

--- a/schemas/questions/repeating_answer.json
+++ b/schemas/questions/repeating_answer.json
@@ -12,6 +12,9 @@
       "title": {
         "type": "string"
       },
+      "titles": {
+        "$ref": "../common_definitions.json#/titles"
+      },
       "number": {
         "type": "string"
       },
@@ -77,9 +80,12 @@
     "additionalProperties": false,
     "required": [
       "id",
-      "title",
       "type",
       "answers"
+    ],
+    "oneOf": [
+      {"required": ["title"]},
+      {"required": ["titles"]}
     ]
   }
 }

--- a/tests/schemas/test_invalid_multiple_question_titles.json
+++ b/tests/schemas/test_invalid_multiple_question_titles.json
@@ -1,0 +1,215 @@
+{
+    "mime_type": "application/json/ons/eq",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.2",
+    "survey_id": "0",
+    "title": "Multiple Question Title Test",
+    "theme": "default",
+    "legal_basis": "StatisticsOfTradeAct",
+    "description": "A questionnaire to test multiple question title versions",
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        }
+    },
+    "sections": [{
+        "id": "default-section",
+        "groups": [{
+            "id": "group",
+            "title": "",
+            "blocks": [{
+                    "type": "Question",
+                    "id": "single-title-block",
+                    "title": "Single question title",
+                    "questions": [{
+                        "id": "single-title-question",
+                        "titles": [{
+                            "when": [{
+                                "id": "behalf-of-answer",
+                                "condition": "equals",
+                                "value": "kelly"
+                                }],
+                            "value": "How are you feeling??"
+                        }],
+                        "type": "General",
+                        "answers": [{
+                            "type": "Radio",
+                            "id": "feeling-answer",
+                            "mandatory": true,
+                            "options": [{
+                                    "label": "Good",
+                                    "value": "good"
+                                },
+                                {
+                                    "label": "Bad",
+                                    "value": "bad"
+                                }
+                            ]
+                        }]
+                    }]
+                },
+                {
+                    "type": "Question",
+                    "id": "who-is-answering-block",
+                    "questions": [{
+                        "id": "behalf-of-question",
+                        "title": "Who are you answering on behalf of?",
+                        "guidance": {
+                            "content": [{
+                                "description": "The answer you choose will have an affect on question titles in next question"
+                            }]
+                        },
+                        "type": "General",
+                        "answers": [{
+                            "type": "Radio",
+                            "id": "behalf-of-answer",
+                            "mandatory": true,
+                            "options": [{
+                                    "label": "Myself",
+                                    "value": "myself"
+                                },
+                                {
+                                    "label": "Chad",
+                                    "value": "chad"
+                                },
+                                {
+                                    "label": "Kelly",
+                                    "value": "kelly"
+                                },
+                                {
+                                    "label": "Someone else",
+                                    "value": "else"
+                                }
+                            ]
+                        }]
+                    }]
+                },
+                {
+                    "type": "Question",
+                    "id": "multiple-question-versions-block",
+                    "title": "Multiple question versions",
+                    "questions": [{
+                        "id": "what-gender-question",
+                        "titles": [{
+                            "value": "What is <em>{{[answers['behalf-of-answer']]|format_household_name_possessive}}</em> gender?",
+                            "when": [{
+                                "id": "behalf-of-answer-fake",
+                                "condition": "equals",
+                                "value": "chad"
+                                }]
+                            },
+                            {
+                            "value": "What is <em>{{[answers['behalf-of-answer']]|format_household_name_possessive}}</em> gender?",
+                            "when": [{
+                                "id": "behalf-of-answer",
+                                "condition": "equals",
+                                "value": "kelly"
+                                }]
+                            },
+                            {
+                                "value": "What is their gender?",
+                                "when": [{
+                                    "id": "behalf-of-answer",
+                                    "condition": "equals",
+                                    "value": "else"
+                                }]
+                            },
+                            {
+                            "value": "What is your gender?"
+                        }],
+                        "guidance": {
+                            "content": [{
+                                "description": "Your question should be phrased correctly depending on the answer selected in the previous question"
+                            }]
+                        },
+                        "type": "General",
+                        "answers": [{
+                            "type": "Radio",
+                            "id": "gender-answer",
+                            "mandatory": true,
+                            "options": [{
+                                    "label": "Male",
+                                    "value": "male"
+                                },
+                                {
+                                    "label": "Female",
+                                    "value": "female"
+                                }
+                            ]
+                        }]
+                    },
+                    {
+                        "id": "what-age-question",
+                        "titles": [{
+                            "value": "What is <em>{{[answers['behalf-of-answer']]|format_household_name_possessive}}</em> age?",
+                            "when": [{
+                                "id": "behalf-of-answer",
+                                "condition": "equals",
+                                "value": "chad"
+                                }]
+                            },
+                            {
+                            "value": "What is <em>{{[answers['behalf-of-answer']]|format_household_name_possessive}}</em> age?",
+                            "when": [{
+                                "id": "behalf-of-answer",
+                                "condition": "equals",
+                                "value": "kelly"
+                                }]
+                            },
+                            {
+                            "value": "What is their age?",
+                            "when": [{
+                                "id": "behalf-of-answer",
+                                "condition": "equals",
+                                "value": "else"
+                                }]
+                            },
+                            {
+                            "value": "What is your age?"
+                        }],
+                        "guidance": {
+                            "content": [{
+                                    "description": "Your question should be phrased correctly depending on the answer selected in the previous question"
+                                }
+                            ]
+                        },
+                        "type": "General",
+                        "answers": [{
+                            "type": "Number",
+                            "id": "age-answer",
+                            "mandatory": true
+                        }]
+                    },
+                    {
+                        "id": "sure-question",
+                        "titles": [{
+                            "value": "Are you sure??"
+                        }],
+                        "type": "General",
+                        "answers": [{
+                            "type": "Radio",
+                            "id": "sure-answer",
+                            "mandatory": true,
+                            "options": [{
+                                    "label": "Yes",
+                                    "value": "yes"
+                                },
+                                {
+                                    "label": "No",
+                                    "value": "no"
+                                }
+                            ]
+                        }]
+                    }]
+                },
+                {
+                    "type": "Summary",
+                    "id": "summary"
+                }
+            ]
+        }]
+    }]
+}

--- a/tests/schemas/test_invalid_routing_block.json
+++ b/tests/schemas/test_invalid_routing_block.json
@@ -67,7 +67,7 @@
                             "block": "invalid-location",
                             "when": [
                                 {
-                                    "id" : "conditional-routing-answer",
+                                    "id" : "fake-answer",
                                     "condition": "equals",
                                     "value":"no"
                                 }

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -24,10 +24,14 @@ class TestSchemaValidation(unittest.TestCase):
 
         errors = self.validator.validate_schema(json_to_validate)
 
-        self.assertEqual(len(errors), 1)
-        self.assertEqual(
-            errors[0]['message'],
-            'Schema Integrity Error. Routing rule routes to invalid block [invalid-location]')
+        self.assertEqual(len(errors), 3)
+        self.assertEqual(errors[0]['message'], 'Schema Integrity Error. Routing rule routes to invalid block '
+                                               '[invalid-location]')
+        self.assertEqual(errors[1]['message'], 'Schema Integrity Error. The answer id - fake-answer in the "when" '
+                                               'clause for conditional-routing-block does not exist')
+        self.assertEqual(errors[2]['message'], 'Schema Integrity Error. Routing rule not defined for all answers or '
+                                               'default not defined for answer [conditional-routing-answer] '
+                                               "missing options [\'no\']")
 
     def test_invalid_schema_group(self):
 
@@ -164,8 +168,23 @@ class TestSchemaValidation(unittest.TestCase):
         errors = self.validator.validate_schema(json_to_validate)
 
         self.assertEqual(len(errors), 2)
-        self.assertEqual(errors[0]['message'], 'Schema Integrity Error. Metadata - invalid not specified in metadata field')
-        self.assertEqual(errors[1]['message'], 'Schema Integrity Error. Unused metadata defined in metadata field - invalid_metadata')
+        self.assertEqual(errors[0]['message'], 'Schema Integrity Error. Metadata - invalid not specified in metadata '
+                                               'field')
+        self.assertEqual(errors[1]['message'], 'Schema Integrity Error. Unused metadata defined in metadata field - '
+                                               'invalid_metadata')
+
+    def test_invalid_question_titles_object(self):
+
+        file = 'schemas/test_invalid_multiple_question_titles.json'
+        json_to_validate = self.open_and_load_schema_file(file)
+
+        errors = self.validator.validate_schema(json_to_validate)
+
+        self.assertEqual(len(errors), 2)
+        self.assertEqual(errors[0]['message'], 'Schema Integrity Error. The last value must be the default value with '
+                                               'no "when" clause for single-title-question')
+        self.assertEqual(errors[1]['message'], 'Schema Integrity Error. The answer id - behalf-of-answer-fake in the '
+                                               '"when" clause for what-gender-question does not exist')
 
     @staticmethod
     def open_and_load_schema_file(file):


### PR DESCRIPTION
### What is the context of this PR?
We have defined a question `titles` object that allows for different versions of a question title depending on a given answer in a previous question. We also have defined the conditional(s) in the titles object to be exactly how when rules work. 

A question can now have a `title` string or `titles` object. Each `titles` object must have a default value, which is always the last value present, this cannot have any conditional with it as its the default value.

We have also added tests so that any answer id's in `when` conditions are valid answer id's.

### How to review 
Run SR branch https://github.com/ONSdigital/eq-survey-runner/tree/eq-1990-different-versions-of-question-titles against this branch, it should pass, and then try and break it based on our rules