### PR TITLE
Enforce metadata in schemas

### DIFF
--- a/app/validation/validator.py
+++ b/app/validation/validator.py
@@ -26,7 +26,7 @@ class Validator:
 
         errors = []
 
-        # errors.extend(self._validate_schema_contain_metadata(json_to_validate))
+        errors.extend(self._validate_schema_contain_metadata(json_to_validate))
 
         numeric_answer_ranges = {}
 

--- a/schemas/questionnaire_v1.json
+++ b/schemas/questionnaire_v1.json
@@ -9,7 +9,8 @@
     "title",
     "sections",
     "theme",
-    "legal_basis"
+    "legal_basis",
+    "metadata"
   ],
   "properties": {
     "eq_id": {

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -157,7 +157,7 @@ class TestSchemaValidation(unittest.TestCase):
                                                'maximum offset date')
 
     def test_invalid_metadata(self):
-        self.skipTest('Will enable once runner PR is merged.')
+
         file = 'schemas/test_invalid_metadata.json'
         json_to_validate = self.open_and_load_schema_file(file)
 


### PR DESCRIPTION
### What is the context of this PR?
Runner [PR](https://github.com/ONSdigital/eq-survey-runner/pull/1571) must be merged first. Refer to runner PR for more context.
This PR enforces that:
1. `metadata` is present in the schema.
2. the mandatory metadata is present in all schemas: `user_id`, `period_id`
2. metadata used within the schema for piping are defined in the `metadata` field.

### How to review
1. Ensure all schemas pass against the runner branch.
2. Edit a schema to ensure that if you do not define the piped metadata as required then it fails and vice versa.

Ways of piping metadata:

1. `metadata.ru_name`
2. `metadata['ru_name']`
3. `"meta": "ru_name"`