### PR TITLE
RU Name mandatory in metadata for Default/NI Themes

### DIFF
--- a/app/validation/validator.py
+++ b/app/validation/validator.py
@@ -95,9 +95,14 @@ class Validator:
         errors = []
 
         # user_id and period_id required downstream for receipting
-        # ru_name required for template rendering
+        # ru_name required for template rendering in default and NI theme
         default_metadata = ['user_id', 'period_id']
         schema_metadata = schema['metadata']
+
+        if schema['theme'] in ['default', 'northernireland']:
+            if 'ru_name' not in schema_metadata:
+                errors.append(self._error_message('Metadata - ru_name not specified in metadata field'))
+            default_metadata.append('ru_name')
 
         # Find all words that precede any of:
         all_metadata = set(re.findall(r"((?<=metadata\[\')\w+"  # metadata['

--- a/tests/schemas/test_invalid_date_range_period.json
+++ b/tests/schemas/test_invalid_date_range_period.json
@@ -13,6 +13,9 @@
         },
         "period_id": {
             "validator": "string"
+        },
+        "ru_name": {
+            "validator": "string"
         }
     },
     "sections": [{

--- a/tests/schemas/test_invalid_id_in_grouped_answers_to_calculate.json
+++ b/tests/schemas/test_invalid_id_in_grouped_answers_to_calculate.json
@@ -13,6 +13,9 @@
         },
         "period_id": {
             "validator": "string"
+        },
+        "ru_name": {
+            "validator": "string"
         }
     },
     "sections": [{

--- a/tests/schemas/test_invalid_metadata.json
+++ b/tests/schemas/test_invalid_metadata.json
@@ -14,9 +14,6 @@
         "period_id": {
             "validator": "string"
         },
-        "ru_name": {
-            "validator": "string"
-        },
         "trad_as": {
             "validator": "string"
         },
@@ -60,8 +57,6 @@
                         "title": "",
                         "content": [{
                             "title": "period_str: {{ metadata['period_str'] }}"
-                        }, {
-                            "title": "ru_name: {{ metadata['ru_name'] }}"
                         }, {
                             "title": "trad_as: {{ metadata['trad_as'] }}"
                         }, {

--- a/tests/schemas/test_invalid_mm_yyyy_date_range_period.json
+++ b/tests/schemas/test_invalid_mm_yyyy_date_range_period.json
@@ -14,6 +14,9 @@
         "period_id": {
             "validator": "string"
         },
+        "ru_name": {
+            "validator": "string"
+        },
         "ref_p_start_date": {
             "validator": "date"
         },

--- a/tests/schemas/test_invalid_multiple_question_titles.json
+++ b/tests/schemas/test_invalid_multiple_question_titles.json
@@ -13,6 +13,9 @@
         },
         "period_id": {
             "validator": "string"
+        },
+        "ru_name": {
+            "validator": "string"
         }
     },
     "sections": [{

--- a/tests/schemas/test_invalid_numeric_answers.json
+++ b/tests/schemas/test_invalid_numeric_answers.json
@@ -13,6 +13,9 @@
         },
         "period_id": {
             "validator": "string"
+        },
+        "ru_name": {
+            "validator": "string"
         }
     },
     "sections": [{

--- a/tests/schemas/test_invalid_routing_block.json
+++ b/tests/schemas/test_invalid_routing_block.json
@@ -13,6 +13,9 @@
         },
         "period_id": {
             "validator": "string"
+        },
+        "ru_name": {
+            "validator": "string"
         }
     },
     "sections": [{

--- a/tests/schemas/test_invalid_routing_group.json
+++ b/tests/schemas/test_invalid_routing_group.json
@@ -13,6 +13,9 @@
         },
         "period_id": {
             "validator": "string"
+        },
+        "ru_name": {
+            "validator": "string"
         }
     },
     "sections": [

--- a/tests/schemas/test_invalid_single_date_min_max_period.json
+++ b/tests/schemas/test_invalid_single_date_min_max_period.json
@@ -13,6 +13,9 @@
         },
         "period_id": {
             "validator": "string"
+        },
+        "ru_name": {
+            "validator": "string"
         }
     },
     "sections": [{

--- a/tests/schemas/test_numeric_default_with_routing.json
+++ b/tests/schemas/test_numeric_default_with_routing.json
@@ -13,6 +13,9 @@
         },
         "period_id": {
             "validator": "string"
+        },
+        "ru_name": {
+            "validator": "string"
         }
     },
     "sections": [{

--- a/tests/schemas/test_schema_id_regex.json
+++ b/tests/schemas/test_schema_id_regex.json
@@ -13,6 +13,9 @@
         },
         "period_id": {
             "validator": "string"
+        },
+        "ru_name": {
+            "validator": "string"
         }
     },
     "sections": [{

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -167,10 +167,12 @@ class TestSchemaValidation(unittest.TestCase):
 
         errors = self.validator.validate_schema(json_to_validate)
 
-        self.assertEqual(len(errors), 2)
-        self.assertEqual(errors[0]['message'], 'Schema Integrity Error. Metadata - invalid not specified in metadata '
+        self.assertEqual(len(errors), 3)
+        self.assertEqual(errors[0]['message'], 'Schema Integrity Error. Metadata - ru_name not specified in metadata '
                                                'field')
-        self.assertEqual(errors[1]['message'], 'Schema Integrity Error. Unused metadata defined in metadata field - '
+        self.assertEqual(errors[1]['message'], 'Schema Integrity Error. Metadata - invalid not specified in metadata '
+                                               'field')
+        self.assertEqual(errors[2]['message'], 'Schema Integrity Error. Unused metadata defined in metadata field - '
                                                'invalid_metadata')
 
     def test_invalid_question_titles_object(self):


### PR DESCRIPTION
The introduction page expects RU Name to be present for default and northernireland themes.

This PR ensures ru_name is specified as required metadata in the schemas.