### PR TITLE
Add a Duration answer type

### DIFF
--- a/schemas/answers/duration.json
+++ b/schemas/answers/duration.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema",
+  "answer": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "$ref": "../common_definitions.json#/id"
+      },
+      "q_code": {
+        "$ref": "../common_definitions.json#/q_code"
+      },
+      "label": {
+        "type": "string"
+      },
+      "guidance": {
+        "$ref": "../common_definitions.json#/guidance"
+      },
+      "description": {
+        "type": "string"
+      },
+      "type": {
+        "type": "string",
+        "enum": ["Duration"]
+      },
+      "mandatory": {
+        "type": "boolean"
+      },
+      "units": {
+        "type": "array",
+        "minItems": 1,
+        "items": {
+          "type": "string",
+          "enum": ["years", "months"]
+        }
+      },
+      "validation": {
+        "type": "object",
+        "properties": {
+          "messages": {
+            "MANDATORY_DURATION": {
+              "type": "string"
+            },
+            "INVALID_DURATION": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "id",
+      "type",
+      "mandatory",
+      "units"
+    ]
+  }
+}

--- a/schemas/common_definitions.json
+++ b/schemas/common_definitions.json
@@ -209,6 +209,9 @@
       "MANDATORY_DATE": {
         "type": "string"
       },
+      "MANDATORY_DURATION": {
+        "type": "string"
+      },
       "NUMBER_TOO_SMALL": {
         "type": "string"
       },
@@ -237,6 +240,9 @@
         "type": "string"
       },
       "INVALID_DATE_RANGE": {
+        "type": "string"
+      },
+      "INVALID_DURATION": {
         "type": "string"
       }
     },

--- a/schemas/questions/general.json
+++ b/schemas/questions/general.json
@@ -60,6 +60,9 @@
               "$ref": "../answers/year_date.json#/answer"
             },
             {
+              "$ref": "../answers/duration.json#/answer"
+            },
+            {
               "$ref": "../answers/number.json#/answer"
             },
             {

--- a/schemas/questions/repeating_answer.json
+++ b/schemas/questions/repeating_answer.json
@@ -60,6 +60,9 @@
               "$ref": "../answers/year_date.json#/answer"
             },
             {
+              "$ref": "../answers/duration.json#/answer"
+            },
+            {
               "$ref": "../answers/number.json#/answer"
             },
             {


### PR DESCRIPTION
Add a Duration type.  Uses a field named `units` to define what the duration is made up of, currently only years/months are supported.