### PR TITLE
validating id in when of routing rules is a valid answer

### DIFF
--- a/tests/schemas/test_invalid_routing_block.json
+++ b/tests/schemas/test_invalid_routing_block.json
@@ -25,7 +25,7 @@
                 "type": "Question",
                 "id": "conditional-routing-block",
                     "title": "Conditional Routing Test",
-                    "description": "",
+                    "description": "Testing invalid routing with an options answer",
                     "questions": [{
                         "id": "conditional-routing-question",
                         "title": "Do you drink coffee?",
@@ -88,7 +88,7 @@
                     "questions": [{
                         "id": "response-yes-question",
                         "title": "How many cups of coffee do you drink a day?",
-                        "description": "",
+                        "description": "testing invalid answer in a non options answer",
                         "type": "General",
                         "answers": [{
                             "id": "response-yes-number-of-cups",
@@ -99,6 +99,19 @@
                         }]
                     }],
                 "routing_rules":[
+                    {
+                        "goto": {
+                            "block": "conditional-routing-block",
+                            "when": [
+                                {
+                                   "id": "AnAnswerThatDoesNotExist",
+                                    "condition": "equals",
+                                    "value": 17
+                                }
+                            ]
+
+                        }
+                    },
                     {
                         "goto": {
                             "block" : "summary"

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -24,7 +24,7 @@ class TestSchemaValidation(unittest.TestCase):
 
         errors = self.validator.validate_schema(json_to_validate)
 
-        self.assertEqual(len(errors), 3)
+        self.assertEqual(len(errors), 4)
         self.assertEqual(errors[0]['message'], 'Schema Integrity Error. Routing rule routes to invalid block '
                                                '[invalid-location]')
         self.assertEqual(errors[1]['message'], 'Schema Integrity Error. The answer id - fake-answer in the "when" '
@@ -32,9 +32,10 @@ class TestSchemaValidation(unittest.TestCase):
         self.assertEqual(errors[2]['message'], 'Schema Integrity Error. Routing rule not defined for all answers or '
                                                'default not defined for answer [conditional-routing-answer] '
                                                "missing options [\'no\']")
+        self.assertEqual(errors[3]['message'], 'Schema Integrity Error. The answer id - AnAnswerThatDoesNotExist in '
+                                               'the "when" clause for response-yes does not exist')
 
     def test_invalid_schema_group(self):
-
         file = 'schemas/test_invalid_routing_group.json'
         json_to_validate = self.open_and_load_schema_file(file)
 


### PR DESCRIPTION
Armed forces household census was throwing 500s, it had a when dependency on an id that does not exist , this was being missed by validator.
The root cause was that the id in the when was only being checked if an answer type was options. 
Code changed so as to validate that the independent variable is a known answer.

To Test:
Test schema changed to have invalid id for a non options answer type, so just run tests.