### PR TITLE
Added a minimum property of 1 to the answers rule

### DIFF
--- a/schemas/questions/general.json
+++ b/schemas/questions/general.json
@@ -41,6 +41,7 @@
       },
       "answers": {
         "type": "array",
+        "minItems": 1,
         "items": {
           "oneOf": [
             {


### PR DESCRIPTION
This PR has been created as if you try to include a Summary while a block has no answers you'll get a 500 error on the summary page. However as it stands a question without an answer does currently pass validation. 

This PR is intended to show a potential fix to this and to discuss wether this is the best fix for the issue.  