### PR TITLE
Add validation for `answer_count` in when clauses

### DIFF
--- a/schemas/common_definitions.json
+++ b/schemas/common_definitions.json
@@ -114,6 +114,10 @@
           "type": "string",
           "description": "Metadata provided by the calling service. This will vary between surveys."
         },
+        "answer_count": {
+          "type": "string",
+          "description": "A repeated group id, for which the count will be fetched."
+        },
         "condition": {
           "enum": [
             "equals",
@@ -179,6 +183,11 @@
         {
           "required": [
             "meta"
+          ]
+        },
+        {
+          "required": [
+            "answer_count"
           ]
         }
       ]

--- a/tests/schemas/test_invalid_routing_when_answer_count.json
+++ b/tests/schemas/test_invalid_routing_when_answer_count.json
@@ -1,0 +1,183 @@
+{
+    "mime_type": "application/json/ons/eq",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.2",
+    "survey_id": "023",
+    "title": "Test Routing Answer Count",
+    "description": "",
+    "theme": "default",
+    "legal_basis": "StatisticsOfTradeAct",
+    "metadata": {
+        "user_id": {
+            "validator": "string"
+        },
+        "period_id": {
+            "validator": "string"
+        },
+        "ru_name": {
+            "validator": "string"
+        }
+    },
+    "sections": [
+        {
+            "id": "intro-section",
+            "title": "Introduction",
+            "groups": [{
+                "blocks": [{
+                        "type": "Introduction",
+                        "id": "introduction",
+                        "title": "Introduction"
+                    },
+                    {
+                        "type": "Question",
+                        "id": "household-composition",
+                        "questions": [{
+                            "id": "household-composition-question",
+                            "title": "Who usually lives here?",
+                            "description": "<br> <div> <h3>Include:</h3> <ul> <li>Yourself, if this is your permanent or family home </li> <li>Family members including partners, children and babies born on or before 9 April 2017</li> <li>Students and/or school children who live away from home during term time</li> <li>Housemates, tenants or lodgers</li> </ul> </div>",
+                            "type": "RepeatingAnswer",
+                            "answers": [{
+                                    "id": "first-name",
+                                    "label": "First Name",
+                                    "mandatory": false,
+                                    "q_code": "1",
+                                    "type": "TextField"
+                                },
+                                {
+                                    "id": "middle-names",
+                                    "label": "Middle Names",
+                                    "mandatory": false,
+                                    "q_code": "1",
+                                    "type": "TextField"
+                                },
+                                {
+                                    "id": "last-name",
+                                    "label": "Last Name",
+                                    "mandatory": false,
+                                    "q_code": "1",
+                                    "type": "TextField"
+                                }
+                            ]
+                        }],
+                        "title": "Household",
+                        "routing_rules": [{
+                                "goto": {
+                                    "group": "group1",
+                                    "when": [{
+                                        "answer_count": "first-name",
+                                        "condition": "equals",
+                                        "value": 2
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "group": "group2",
+                                    "when": [{
+                                        "answer_count": "invalid-answer-id",
+                                        "condition": "greater than",
+                                        "value": 2
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "group": "group0",
+                                    "when": [{
+                                        "answer_count": "first-name",
+                                        "condition": "contains",
+                                        "value": 2
+                                    }]
+                                }
+                            }
+                        ]
+                    }
+                ],
+                "id": "multiple-questions-group",
+                "title": "Routing control group"
+            }]
+        },
+        {
+            "id": "main-section",
+            "title": "Conditional Groups section",
+            "groups": [
+            {
+                "id": "group0",
+                "title": "This is Group 0 - You answered less than \"2\"",
+                "blocks": [{
+                    "type": "Question",
+                    "id": "group0-block",
+                    "routing_rules": [],
+                    "description": "",
+                    "title": "Did you want Group 1?",
+                    "questions": [{
+                        "description": "",
+                        "id": "group0-question",
+                        "title": "Did you want Group 1?",
+                        "type": "General",
+                        "answers": [{
+                            "id": "group0-answer",
+                            "label": "Why did you choose Group 1?",
+                            "mandatory": true,
+                            "type": "TextArea"
+                        }]
+                    }]
+                }]
+            },
+            {
+                "id": "group1",
+                "title": "This is Group 1 - you answered \"2\"",
+                "blocks": [{
+                    "type": "Question",
+                    "id": "group1-block",
+                    "routing_rules": [],
+                    "description": "",
+                    "title": "Did you want Group 1?",
+                    "questions": [{
+                        "description": "",
+                        "id": "group1-question",
+                        "title": "Did you want Group 1?",
+                        "type": "General",
+                        "answers": [{
+                            "id": "group1-answer",
+                            "label": "Why did you choose Group 1?",
+                            "mandatory": true,
+                            "type": "TextArea"
+                        }]
+                    }]
+                }]
+            },
+            {
+                "id": "group2",
+                "title": "This is Group 2 - You answered greater than \"2\"",
+                "blocks": [{
+                    "type": "Question",
+                    "id": "group2-block",
+                    "routing_rules": [],
+                    "description": "",
+                    "title": "Did you want Group 2?",
+                    "questions": [{
+                        "description": "",
+                        "id": "group2-question",
+                        "title": "Did you want Group 2?",
+                        "type": "General",
+                        "answers": [{
+                            "id": "group2-answer",
+                            "label": "Why did you choose Group 2?",
+                            "mandatory": true,
+                            "type": "TextArea"
+                        }]
+                    }]
+                }]
+            },
+            {
+                "blocks": [{
+                    "type": "Summary",
+                    "id": "summary"
+                }],
+                "id": "summary-group",
+                "title": ""
+            }
+        ]
+    }]
+}

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -27,13 +27,13 @@ class TestSchemaValidation(unittest.TestCase):
         self.assertEqual(len(errors), 4)
         self.assertEqual(errors[0]['message'], 'Schema Integrity Error. Routing rule routes to invalid block '
                                                '[invalid-location]')
-        self.assertEqual(errors[1]['message'], 'Schema Integrity Error. The answer id - fake-answer in the "when" '
-                                               'clause for conditional-routing-block does not exist')
+        self.assertEqual(errors[1]['message'], 'Schema Integrity Error. The answer id - fake-answer in the id key of the '
+                                               '"when" clause for conditional-routing-block does not exist')
         self.assertEqual(errors[2]['message'], 'Schema Integrity Error. Routing rule not defined for all answers or '
                                                'default not defined for answer [conditional-routing-answer] '
                                                "missing options [\'no\']")
-        self.assertEqual(errors[3]['message'], 'Schema Integrity Error. The answer id - AnAnswerThatDoesNotExist in '
-                                               'the "when" clause for response-yes does not exist')
+        self.assertEqual(errors[3]['message'], 'Schema Integrity Error. The answer id - AnAnswerThatDoesNotExist in the id '
+                                               'key of the "when" clause for response-yes does not exist')
 
     def test_invalid_schema_group(self):
         file = 'schemas/test_invalid_routing_group.json'
@@ -198,7 +198,7 @@ class TestSchemaValidation(unittest.TestCase):
         self.assertEqual(errors[0]['message'], 'Schema Integrity Error. The last value must be the default value with '
                                                'no "when" clause for single-title-question')
         self.assertEqual(errors[1]['message'], 'Schema Integrity Error. The answer id - behalf-of-answer-fake in the '
-                                               '"when" clause for what-gender-question does not exist')
+                                               'id key of the "when" clause for what-gender-question does not exist')
 
     def test_invalid_survey_id_whitespace(self):
 
@@ -208,6 +208,19 @@ class TestSchemaValidation(unittest.TestCase):
         errors = self.validator.validate_schema(json_to_validate)
 
         self.assertEquals(errors.get('message'), "'lms ' does not match '^[0-9a-z]+$'")
+
+    def test_invalid_routing_when_answer_count(self):
+        """Asserts that invalid `when` routing_rules are caught for `answer_count`"""
+        file_name = 'schemas/test_invalid_routing_when_answer_count.json'
+        json_to_validate = self.open_and_load_schema_file(file_name)
+
+        errors = self.validator.validate_schema(json_to_validate)
+
+        self.assertEqual(errors[0]['message'], 'Schema Integrity Error. The answer id - invalid-answer-id in the '
+                                               'answer_count key of the "when" clause for household-composition '
+                                               'does not exist')
+        self.assertEqual(errors[1]['message'], 'Schema Integrity Error. The condition "contains" is not valid '
+                                               'for an answer_count based "when" clause')
 
     @staticmethod
     def open_and_load_schema_file(file):


### PR DESCRIPTION
This PR adds syntax validation for routing_rules which make use of the number of answers to a repeated question.

This PR:
1. Adds JSON schema defintions
2. Adds sanity checking which cannot be easily caught by the schema validation
3. Adds a test to ensure incorrect inputs are found