### PR TITLE
Add a repeating type of 'until'

### DIFF
--- a/api.py
+++ b/api.py
@@ -8,4 +8,4 @@ application.register_blueprint(validate_blueprint)
 application.register_blueprint(status_blueprint)
 
 if __name__ == '__main__':
-    application.run()
+    application.run(port=5001)

--- a/schemas/common_definitions.json
+++ b/schemas/common_definitions.json
@@ -191,7 +191,8 @@
           ]
         }
       ]
-    }
+    },
+    "minItems": 1
   },
   "messages": {
     "type": "object",
@@ -349,24 +350,65 @@
           "additionalProperties": false
         },
         "repeat": {
-          "type": "object",
-          "properties": {
-            "answer_id": {
-              "type": "string"
-            },
-            "goto": {
-              "type": "string"
-            },
-            "type": {
-              "enum": [
-                "answer_value",
-                "answer_count",
-                "answer_count_minus_one"
-              ]
-            }
-          },
-          "required": [
-            "answer_id"
+          "oneOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "enum": [
+                      "until"
+                    ]
+                  },
+                  "when": {
+                    "$ref": "common_definitions.json#/when"
+                  }
+                },
+                "required": [
+                  "type",
+                  "when"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "enum": [
+                      "answer_value",
+                      "answer_count_minus_one"
+                    ]
+                  },
+                  "answer_id": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "type",
+                  "answer_id"
+                ],
+                "additionalProperties": false
+              },
+                          {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "enum": [
+                      "answer_count"
+                    ]
+                  },
+                  "offset": {
+                    "type": "integer"
+                  },
+                  "answer_id": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "type",
+                  "answer_id"
+                ],
+                "additionalProperties": false
+              }
           ]
         }
       },

--- a/schemas/questionnaire_v1.json
+++ b/schemas/questionnaire_v1.json
@@ -156,7 +156,7 @@
                   "$ref": "common_definitions.json#/skip_conditions"
                 },
                 "routing_rules": {
-                  "ref": "common_definitions.json#/routing_rules"
+                  "$ref": "common_definitions.json#/routing_rules"
                 },
                 "blocks": {
                   "type": "array",

--- a/tests/schemas/test_invalid_routing_block.json
+++ b/tests/schemas/test_invalid_routing_block.json
@@ -24,33 +24,33 @@
             "blocks": [{
                 "type": "Question",
                 "id": "conditional-routing-block",
-                    "title": "Conditional Routing Test",
-                    "description": "Testing invalid routing with an options answer",
-                    "questions": [{
-                        "id": "conditional-routing-question",
-                        "title": "Do you drink coffee?",
-                        "description": "",
-                        "type": "General",
-                        "answers": [{
-                            "options": [
-                                {
-                                    "label": "Yes",
-                                    "value": "yes",
-                                    "description": ""
-                                },
-                                {
-                                    "label": "No, I prefer tea",
-                                    "value": "no",
-                                    "description": ""
-                                }
-                            ],
-                            "q_code": "1",
-                            "id": "conditional-routing-answer",
-                            "label": "Which conditional question should we jump to?",
-                            "mandatory": true,
-                            "type": "Radio"
-                        }]
-                    }],
+                "title": "Conditional Routing Test",
+                "description": "Testing invalid routing with an options answer",
+                "questions": [{
+                    "id": "conditional-routing-question",
+                    "title": "Do you drink coffee?",
+                    "description": "",
+                    "type": "General",
+                    "answers": [{
+                        "options": [
+                            {
+                                "label": "Yes",
+                                "value": "yes",
+                                "description": ""
+                            },
+                            {
+                                "label": "No, I prefer tea",
+                                "value": "no",
+                                "description": ""
+                            }
+                        ],
+                        "q_code": "1",
+                        "id": "conditional-routing-answer",
+                        "label": "Which conditional question should we jump to?",
+                        "mandatory": true,
+                        "type": "Radio"
+                    }]
+                }],
                 "routing_rules":[
                     {
                         "goto": {
@@ -63,7 +63,6 @@
                                 }
                             ]
                         }
-
                     },
                     {
                         "goto": {
@@ -76,28 +75,27 @@
                                 }
                             ]
                         }
-
                     }
                 ]
             },
             {
                 "type": "Question",
                 "id": "response-yes",
-                    "title": "Yes, I do drink coffee",
-                    "description": "",
-                    "questions": [{
-                        "id": "response-yes-question",
-                        "title": "How many cups of coffee do you drink a day?",
-                        "description": "testing invalid answer in a non options answer",
-                        "type": "General",
-                        "answers": [{
-                            "id": "response-yes-number-of-cups",
-                            "label": "Number of cups",
-                            "mandatory": true,
-                            "q_code": "2",
-                            "type": "Number"
-                        }]
-                    }],
+                "title": "Yes, I do drink coffee",
+                "description": "",
+                "questions": [{
+                    "id": "response-yes-question",
+                    "title": "How many cups of coffee do you drink a day?",
+                    "description": "testing invalid answer in a non options answer",
+                    "type": "General",
+                    "answers": [{
+                        "id": "response-yes-number-of-cups",
+                        "label": "Number of cups",
+                        "mandatory": true,
+                        "q_code": "2",
+                        "type": "Number"
+                    }]
+                }],
                 "routing_rules":[
                     {
                         "goto": {
@@ -117,6 +115,18 @@
                             "block" : "summary"
                         }
 
+                    },
+                    {
+                        "repeat": {
+                            "type": "until",
+                            "when": [
+                                {
+                                    "id": "response-yes-number-of-cups",
+                                    "condition": "equals",
+                                    "value": 2
+                                }
+                            ]
+                        }
                     }
                 ]
             },

--- a/tests/schemas/test_invalid_routing_group.json
+++ b/tests/schemas/test_invalid_routing_group.json
@@ -25,6 +25,35 @@
                 {
                     "id": "which-group",
                     "title": "What group do you want to go to?",
+                    "routing_rules": [
+                        {
+                            "goto": {
+                                "group": "group1",
+                                "when": [{
+                                    "answer_count": "invalid-answer-id",
+                                    "condition": "equals",
+                                    "value": 2
+                                }]
+                            }
+                        },
+                        {
+                            "repeat": {
+                                "type": "until",
+                                "when": [
+                                    {
+                                        "id": "invalid-answer-id",
+                                        "condition": "equals",
+                                        "value": 2
+                                    },
+                                    {
+                                        "id": "group1-answer",
+                                        "condition": "equals",
+                                        "value": 2
+                                    }
+                                ]
+                            }
+                        }
+                    ],
                     "blocks": [
                         {
                             "type": "Question",

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -24,7 +24,7 @@ class TestSchemaValidation(unittest.TestCase):
 
         errors = self.validator.validate_schema(json_to_validate)
 
-        self.assertEqual(len(errors), 4)
+        self.assertEqual(len(errors), 5)
         self.assertEqual(errors[0]['message'], 'Schema Integrity Error. Routing rule routes to invalid block '
                                                '[invalid-location]')
         self.assertEqual(errors[1]['message'], 'Schema Integrity Error. The answer id - fake-answer in the id key of the '
@@ -34,6 +34,7 @@ class TestSchemaValidation(unittest.TestCase):
                                                "missing options [\'no\']")
         self.assertEqual(errors[3]['message'], 'Schema Integrity Error. The answer id - AnAnswerThatDoesNotExist in the id '
                                                'key of the "when" clause for response-yes does not exist')
+        self.assertEqual(errors[4]['message'], 'Schema Integrity Error. The block response-yes has a repeating routing rule')
 
     def test_invalid_schema_group(self):
         file = 'schemas/test_invalid_routing_group.json'
@@ -41,9 +42,21 @@ class TestSchemaValidation(unittest.TestCase):
 
         errors = self.validator.validate_schema(json_to_validate)
 
-        self.assertEqual(len(errors), 1)
+        self.assertEqual(len(errors), 5)
         self.assertEqual(
             errors[0]['message'],
+            'Schema Integrity Error. The answer id - invalid-answer-id in the answer_count key of the "when" clause for which-group does not exist')
+        self.assertEqual(
+            errors[1]['message'],
+            'Schema Integrity Error. The answer id - invalid-answer-id in the id key of the "when" clause for which-group does not exist')
+        self.assertEqual(
+            errors[2]['message'],
+            'Schema Integrity Error. The "when" clause in the repeat for which-group has more than one condition')
+        self.assertEqual(
+            errors[3]['message'],
+            'Schema Integrity Error. The answer id - group1-answer in the id key of the "when" clause for which-group is not in the same group')
+        self.assertEqual(
+            errors[4]['message'],
             'Schema Integrity Error. Routing rule routes to invalid group [invalid-group]')
 
     def test_schemas(self):


### PR DESCRIPTION
Under `routing_rules` in `repeat` we want to support a new type of `until` that will repeat until a condition is met (specified with a `when` clause).  The when clause only supports a subset of the behaviours it does elsewhere, only one is allowed in the list and only on `id`.