### PR TITLE
Validator required on metadata

### DIFF
--- a/schemas/questionnaire_v1.json
+++ b/schemas/questionnaire_v1.json
@@ -79,7 +79,10 @@
                 "object"
               ]
             }
-          }
+          },
+          "required": [
+            "validator"
+          ]
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
The `validator` attribute wasn't marked as required but is required in Runner