### PR TITLE
Refactor metadata structure

### DIFF
--- a/app/validation/validator.py
+++ b/app/validation/validator.py
@@ -113,7 +113,16 @@ class Validator:
         # user_id and period_id required downstream for receipting
         # ru_name required for template rendering in default and NI theme
         default_metadata = ['user_id', 'period_id']
-        schema_metadata = schema['metadata']
+        schema_metadata = [metadata_field['name'] for metadata_field in schema['metadata']]
+
+        if len(schema_metadata) != len(set(schema_metadata)):
+            errors.append(self._error_message('Mandatory Metadata - contains duplicates'))
+
+        required_metadata_names = ['user_id', 'period_id']
+        for metadata_name in required_metadata_names:
+            if metadata_name not in schema_metadata:
+                errors.append(self._error_message(
+                    'Mandatory Metadata - `{}` not specified in metadata field'.format(metadata_name)))
 
         if schema['theme'] in ['default', 'northernireland']:
             if 'ru_name' not in schema_metadata:
@@ -127,11 +136,11 @@ class Validator:
 
         # Checks if piped/routed metadata is defined in the schema
         for metadata in all_metadata:
-            if metadata not in schema_metadata.keys():
+            if metadata not in schema_metadata:
                 errors.append(self._error_message('Metadata - {} not specified in metadata field'.format(metadata)))
 
         # Checks if unused metadata is defined
-        for metadata in schema_metadata.keys():
+        for metadata in schema_metadata:
             if metadata not in all_metadata and metadata not in default_metadata:
                 errors.append(self._error_message('Unused metadata defined in metadata field - {}'.format(metadata)))
 

--- a/schemas/questionnaire_v1.json
+++ b/schemas/questionnaire_v1.json
@@ -62,30 +62,28 @@
       ]
     },
     "metadata": {
-      "type": "object",
-      "required": [
-        "user_id",
-        "period_id"
-      ],
-      "patternProperties": {
-        "^.*$": {
-          "type": "object",
-          "properties": {
-            "validator": {
-              "type": "string",
-              "enum": [
-                "date",
-                "string",
-                "object"
-              ]
-            }
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
           },
-          "required": [
-            "validator"
-          ]
-        }
-      },
-      "additionalProperties": false
+          "validator": {
+            "type": "string",
+            "enum": [
+              "date",
+              "string",
+              "object"
+            ]
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "validator"
+        ]
+      }
     },
     "view_submitted_response": {
       "type": "object",

--- a/tests/schemas/test_invalid_calculated_summary.json
+++ b/tests/schemas/test_invalid_calculated_summary.json
@@ -7,17 +7,20 @@
   "theme": "default",
   "legal_basis": "StatisticsOfTradeAct",
   "description": "A survey that tests grouped and calculated answers against a total",
-  "metadata": {
-    "user_id": {
+  "metadata": [
+    {
+      "name": "user_id",
       "validator": "string"
     },
-    "period_id": {
+    {
+      "name": "period_id",
       "validator": "string"
     },
-    "ru_name": {
+    {
+      "name": "ru_name",
       "validator": "string"
     }
-  },
+  ],
   "sections": [
     {
       "id": "default-section",

--- a/tests/schemas/test_invalid_date_range_period.json
+++ b/tests/schemas/test_invalid_date_range_period.json
@@ -1,66 +1,77 @@
 {
-    "mime_type": "application/json/ons/eq",
-    "schema_version": "0.0.1",
-    "data_version": "0.0.2",
-    "survey_id": "023",
-    "title": "Date formats",
-    "description": "A test schema for different date formats",
-    "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
-    "metadata": {
-        "user_id": {
-            "validator": "string"
-        },
-        "period_id": {
-            "validator": "string"
-        },
-        "ru_name": {
-            "validator": "string"
-        }
+  "data_version": "0.0.2",
+  "description": "A test schema for different date formats",
+  "legal_basis": "StatisticsOfTradeAct",
+  "metadata": [
+    {
+      "name": "user_id",
+      "validator": "string"
     },
-    "sections": [{
-        "id": "default-section",
-        "groups": [{
-            "id": "dates",
-            "title": "Date Range Validation",
-            "blocks": [{
-                    "type": "Question",
-                    "id": "date-range-block",
-                    "title": "Date Range",
-                    "questions": [{
-                        "id": "date-range-question",
-                        "title": "Enter Date Range",
-                        "type": "DateRange",
-                        "period_limits": {
-                            "minimum": {
-                                "years": 1,
-                                "days": 23
-                            },
-                            "maximum": {
-                                "months": 1,
-                                "days": 20
-                            }
-                        },
-                        "answers": [{
-                                "id": "date-range-from",
-                                "label": "Period from",
-                                "mandatory": true,
-                                "type": "Date"
-                            },
-                            {
-                                "id": "date-range-to",
-                                "label": "Period to",
-                                "mandatory": true,
-                                "type": "Date"
-                            }
-                        ]
-                    }]
-                },
+    {
+      "name": "ru_name",
+      "validator": "string"
+    },
+    {
+      "name": "period_id",
+      "validator": "string"
+    }
+  ],
+  "mime_type": "application/json/ons/eq",
+  "schema_version": "0.0.1",
+  "sections": [
+    {
+      "groups": [
+        {
+          "blocks": [
+            {
+              "id": "date-range-block",
+              "questions": [
                 {
-                    "type": "Summary",
-                    "id": "summary"
+                  "answers": [
+                    {
+                      "id": "date-range-from",
+                      "label": "Period from",
+                      "mandatory": true,
+                      "type": "Date"
+                    },
+                    {
+                      "id": "date-range-to",
+                      "label": "Period to",
+                      "mandatory": true,
+                      "type": "Date"
+                    }
+                  ],
+                  "id": "date-range-question",
+                  "period_limits": {
+                    "maximum": {
+                      "days": 20,
+                      "months": 1
+                    },
+                    "minimum": {
+                      "days": 23,
+                      "years": 1
+                    }
+                  },
+                  "title": "Enter Date Range",
+                  "type": "DateRange"
                 }
-            ]
-        }]
-    }]
+              ],
+              "title": "Date Range",
+              "type": "Question"
+            },
+            {
+              "id": "summary",
+              "type": "Summary"
+            }
+          ],
+          "id": "dates",
+          "title": "Date Range Validation"
+        }
+      ],
+      "id": "default-section"
+    }
+  ],
+  "survey_id": "023",
+  "theme": "default",
+  "title": "Date formats"
 }

--- a/tests/schemas/test_invalid_id_in_grouped_answers_to_calculate.json
+++ b/tests/schemas/test_invalid_id_in_grouped_answers_to_calculate.json
@@ -1,92 +1,109 @@
 {
-    "mime_type": "application/json/ons/eq",
-    "schema_version": "0.0.1",
-    "data_version": "0.0.1",
-    "survey_id": "0",
-    "title": "Grouped validation against total test survey",
-    "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
-    "description": "A survey that tests grouped and calculated answers against a total",
-    "metadata": {
-        "user_id": {
-            "validator": "string"
-        },
-        "period_id": {
-            "validator": "string"
-        },
-        "ru_name": {
-            "validator": "string"
-        }
+  "data_version": "0.0.1",
+  "description": "A survey that tests grouped and calculated answers against a total",
+  "legal_basis": "StatisticsOfTradeAct",
+  "metadata": [
+    {
+      "name": "user_id",
+      "validator": "string"
     },
-    "sections": [{
-        "id": "default-section",
-        "groups": [{
-            "id": "group",
-            "title": "Validate sum against total",
-            "blocks": [{
-                    "type": "Question",
-                    "title": "Target total",
-                    "id": "total-block",
-                    "description": "",
-                    "questions": [{
-                        "id": "total-question",
-                        "title": "Total",
-                        "type": "General",
-                        "answers": [{
-                            "id": "total-answer",
-                            "label": "Total",
-                            "mandatory": true,
-                            "type": "Number",
-                            "decimal_places": 2,
-                            "max_value": {
-                                "value": 100
-                            }
-                        }]
-                    }]
-                },
+    {
+      "name": "ru_name",
+      "validator": "string"
+    },
+    {
+      "name": "period_id",
+      "validator": "string"
+    }
+  ],
+  "mime_type": "application/json/ons/eq",
+  "schema_version": "0.0.1",
+  "sections": [
+    {
+      "groups": [
+        {
+          "blocks": [
+            {
+              "description": "",
+              "id": "total-block",
+              "questions": [
                 {
-                    "type": "Question",
-                    "title": "Calculated total",
-                    "id": "breakdown-block",
-                    "questions": [{
-                        "id": "breakdown-question",
-                        "title": "Breakdown",
-                        "type": "Calculated",
-                        "calculations": [{
-                            "calculation_type": "sum",
-                            "answer_id": "total-answer",
-                            "answers_to_calculate": [
-                                "breakdown-1",
-                                "breakdown-2",
-                                "breakdown-3",
-                                "breakdown-4"
-                            ],
-                            "conditions": [
-                                "equals"
-                            ]
-                        }],
-                        "answers": [{
-                                "id": "breakdown-1",
-                                "label": "Breakdown 1",
-                                "mandatory": false,
-                                "decimal_places": 2,
-                                "type": "Number"
-                            },
-                            {
-                                "id": "breakdown-2",
-                                "label": "Breakdown 2",
-                                "mandatory": false,
-                                "decimal_places": 2,
-                                "type": "Number"
-                            }
-                        ]
-                    }]
-                },
-                {
-                    "type": "Summary",
-                    "id": "summary"
+                  "answers": [
+                    {
+                      "decimal_places": 2,
+                      "id": "total-answer",
+                      "label": "Total",
+                      "mandatory": true,
+                      "max_value": {
+                        "value": 100
+                      },
+                      "type": "Number"
+                    }
+                  ],
+                  "id": "total-question",
+                  "title": "Total",
+                  "type": "General"
                 }
-            ]
-        }]
-    }]
+              ],
+              "title": "Target total",
+              "type": "Question"
+            },
+            {
+              "id": "breakdown-block",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "decimal_places": 2,
+                      "id": "breakdown-1",
+                      "label": "Breakdown 1",
+                      "mandatory": false,
+                      "type": "Number"
+                    },
+                    {
+                      "decimal_places": 2,
+                      "id": "breakdown-2",
+                      "label": "Breakdown 2",
+                      "mandatory": false,
+                      "type": "Number"
+                    }
+                  ],
+                  "calculations": [
+                    {
+                      "answer_id": "total-answer",
+                      "answers_to_calculate": [
+                        "breakdown-1",
+                        "breakdown-2",
+                        "breakdown-3",
+                        "breakdown-4"
+                      ],
+                      "calculation_type": "sum",
+                      "conditions": [
+                        "equals"
+                      ]
+                    }
+                  ],
+                  "id": "breakdown-question",
+                  "title": "Breakdown",
+                  "type": "Calculated"
+                }
+              ],
+              "title": "Calculated total",
+              "type": "Question"
+            },
+            {
+              "id": "summary",
+              "type": "Summary"
+            }
+          ],
+          "id": "group",
+          "title": "Validate sum against total"
+        }
+      ],
+      "id": "default-section"
+    }
+  ],
+  "survey_id": "0",
+  "theme": "default",
+  "title": "Grouped validation against total test survey"
 }

--- a/tests/schemas/test_invalid_metadata.json
+++ b/tests/schemas/test_invalid_metadata.json
@@ -1,110 +1,145 @@
 {
-    "data_version": "0.0.1",
-    "description": "Test Schema Context",
-    "mime_type": "application/json/ons/eq",
-    "schema_version": "0.0.1",
-    "survey_id": "144",
-    "theme": "default",
-    "legal_basis": "Voluntary",
-    "title": "Test Schema Context",
-    "metadata": {
-        "user_id": {
-            "validator": "string"
-        },
-        "period_id": {
-            "validator": "string"
-        },
-        "trad_as": {
-            "validator": "string"
-        },
-        "period_str": {
-            "validator": "string"
-        },
-        "trad_as_or_ru_name": {
-            "validator": "string"
-        },
-        "ref_p_start_date": {
-            "validator": "date"
-        },
-        "ref_p_end_date": {
-            "validator": "date"
-        },
-        "employment_date": {
-            "validator": "date"
-        },
-        "return_by": {
-            "validator": "date"
-        },
-        "region_code": {
-            "validator": "string"
-        },
-        "variant_flags": {
-            "validator": "object"
-        },
-        "invalid_metadata": {
-            "validator": "string"
-        }
+  "data_version": "0.0.1",
+  "description": "Test Schema Context",
+  "legal_basis": "Voluntary",
+  "metadata": [
+    {
+      "name": "return_by",
+      "validator": "date"
     },
-    "sections": [{
-        "id": "default-section",
-        "groups": [{
-                "blocks": [{
-                    "id": "introduction",
-                    "type": "Introduction",
-                    "primary_content": [{
-                        "type": "Preview",
-                        "id": "preview",
-                        "title": "",
-                        "content": [{
-                            "title": "period_str: {{ metadata['period_str'] }}"
-                        }, {
-                            "title": "trad_as: {{ metadata['trad_as'] }}"
-                        }, {
-                            "title": "trad_as_or_ru_name: {{ metadata['trad_as_or_ru_name'] }}"
-                        }, {
-                            "title": "ref_p_start_date: {{ metadata['ref_p_start_date'] }}"
-                        }, {
-                            "title": "ref_p_end_date: {{ metadata['ref_p_end_date'] }}"
-                        }, {
-                            "title": "employment_date: {{ metadata['employment_date'] }}"
-                        }, {
-                            "title": "return_by: {{ metadata['return_by'] }}"
-                        }, {
-                            "title": "region_code: {{ metadata['region_code'] }}"
-                        }, {
-                            "title": "variant_flags: {{ metadata['variant_flags'] }}"
-                        }, {
-
-                            "title": "Invalid: {{ metadata['invalid'] }}"
-                        }]
-                    }]
-                }],
-                "id": "general-business-information",
-                "title": "General Business Information"
-            },
+    {
+      "name": "period_id",
+      "validator": "string"
+    },
+    {
+      "name": "region_code",
+      "validator": "string"
+    },
+    {
+      "name": "invalid_metadata",
+      "validator": "string"
+    },
+    {
+      "name": "ref_p_start_date",
+      "validator": "date"
+    },
+    {
+      "name": "trad_as_or_ru_name",
+      "validator": "string"
+    },
+    {
+      "name": "trad_as",
+      "validator": "string"
+    },
+    {
+      "name": "user_id",
+      "validator": "string"
+    },
+    {
+      "name": "ref_p_end_date",
+      "validator": "date"
+    },
+    {
+      "name": "employment_date",
+      "validator": "date"
+    },
+    {
+      "name": "variant_flags",
+      "validator": "object"
+    },
+    {
+      "name": "period_str",
+      "validator": "string"
+    }
+  ],
+  "mime_type": "application/json/ons/eq",
+  "schema_version": "0.0.1",
+  "sections": [
+    {
+      "groups": [
+        {
+          "blocks": [
             {
-                "blocks": [{
-                    "id": "confirmation",
-                    "description": "",
-                    "questions": [{
-                        "id": "ready-to-submit-completed-question",
-                        "title": "Submission",
-                        "type": "Content",
-                        "guidance": {
-                            "content": [{
-                                "list": [
-                                    "You will not be able to access or change your answers on submitting the questionnaire",
-                                    "If you wish to review your answers please select the relevant completed sections"
-                                ]
-                            }]
-                        }
-                    }],
-                    "title": "You are now ready to submit this survey",
-                    "type": "Confirmation"
-                }],
-                "id": "ready-to-submit",
-                "title": "Submit answers"
+              "id": "introduction",
+              "primary_content": [
+                {
+                  "content": [
+                    {
+                      "title": "period_str: {{ metadata['period_str'] }}"
+                    },
+                    {
+                      "title": "trad_as: {{ metadata['trad_as'] }}"
+                    },
+                    {
+                      "title": "trad_as_or_ru_name: {{ metadata['trad_as_or_ru_name'] }}"
+                    },
+                    {
+                      "title": "ref_p_start_date: {{ metadata['ref_p_start_date'] }}"
+                    },
+                    {
+                      "title": "ref_p_end_date: {{ metadata['ref_p_end_date'] }}"
+                    },
+                    {
+                      "title": "employment_date: {{ metadata['employment_date'] }}"
+                    },
+                    {
+                      "title": "return_by: {{ metadata['return_by'] }}"
+                    },
+                    {
+                      "title": "region_code: {{ metadata['region_code'] }}"
+                    },
+                    {
+                      "title": "variant_flags: {{ metadata['variant_flags'] }}"
+                    },
+                    {
+                      "title": "Invalid: {{ metadata['invalid'] }}"
+                    }
+                  ],
+                  "id": "preview",
+                  "title": "",
+                  "type": "Preview"
+                }
+              ],
+              "type": "Introduction"
             }
-        ]
-    }]
+          ],
+          "id": "general-business-information",
+          "title": "General Business Information"
+        },
+        {
+          "blocks": [
+            {
+              "description": "",
+              "id": "confirmation",
+              "questions": [
+                {
+                  "guidance": {
+                    "content": [
+                      {
+                        "list": [
+                          "You will not be able to access or change your answers on submitting the questionnaire",
+                          "If you wish to review your answers please select the relevant completed sections"
+                        ]
+                      }
+                    ]
+                  },
+                  "id": "ready-to-submit-completed-question",
+                  "title": "Submission",
+                  "type": "Content"
+                }
+              ],
+              "title": "You are now ready to submit this survey",
+              "type": "Confirmation"
+            }
+          ],
+          "id": "ready-to-submit",
+          "title": "Submit answers"
+        }
+      ],
+      "id": "default-section"
+    }
+  ],
+  "survey_id": "144",
+  "theme": "default",
+  "title": "Test Schema Context"
 }

--- a/tests/schemas/test_invalid_mm_yyyy_date_range_period.json
+++ b/tests/schemas/test_invalid_mm_yyyy_date_range_period.json
@@ -1,85 +1,97 @@
 {
-    "mime_type": "application/json/ons/eq",
-    "schema_version": "0.0.1",
-    "data_version": "0.0.2",
-    "survey_id": "023",
-    "title": "Date formats",
-    "description": "A test schema for different date formats",
-    "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
-    "metadata": {
-        "user_id": {
-            "validator": "string"
-        },
-        "period_id": {
-            "validator": "string"
-        },
-        "ru_name": {
-            "validator": "string"
-        },
-        "ref_p_start_date": {
-            "validator": "date"
-        },
-        "ref_p_end_date": {
-            "validator": "date"
-        }
+  "data_version": "0.0.2",
+  "description": "A test schema for different date formats",
+  "legal_basis": "StatisticsOfTradeAct",
+  "metadata": [
+    {
+      "name": "user_id",
+      "validator": "string"
     },
-    "sections": [{
-        "id": "default-section",
-        "groups": [{
-            "id": "dates",
-            "title": "Date Range Validation",
-            "blocks": [
+    {
+      "name": "ref_p_end_date",
+      "validator": "date"
+    },
+    {
+      "name": "ref_p_start_date",
+      "validator": "date"
+    },
+    {
+      "name": "ru_name",
+      "validator": "string"
+    },
+    {
+      "name": "period_id",
+      "validator": "string"
+    }
+  ],
+  "mime_type": "application/json/ons/eq",
+  "schema_version": "0.0.1",
+  "sections": [
+    {
+      "groups": [
+        {
+          "blocks": [
+            {
+              "id": "date-range-block",
+              "questions": [
                 {
-                    "type": "Question",
-                    "id": "date-range-block",
-                    "title": "Date Range",
-                    "questions": [{
-                        "id": "date-range-question",
-                        "title": "Enter Date Range",
-                        "type": "DateRange",
-                        "period_limits": {
-                            "minimum": {
-                                "days": 7,
-                                "months": 1
-                            },
-                            "maximum": {
-                                "days": 5,
-                                "months": 2
-                            }
-                        },
-                        "answers": [{
-                                "id": "date-range-from",
-                                "label": "Period from",
-                                "mandatory": true,
-                                "type": "MonthYearDate",
-                                "minimum": {
-                                    "meta": "ref_p_start_date",
-                                    "offset_by": {
-                                        "months": -1
-                                    }
-                                }
-                            },
-                            {
-                                "id": "date-range-to",
-                                "label": "Period to",
-                                "mandatory": true,
-                                "type": "MonthYearDate",
-                                "maximum": {
-                                    "meta": "ref_p_end_date",
-                                    "offset_by": {
-                                        "months": 2
-                                    }
-                                }
-                            }
-                        ]
-                    }]
-                },
-                {
-                    "type": "Summary",
-                    "id": "summary"
+                  "answers": [
+                    {
+                      "id": "date-range-from",
+                      "label": "Period from",
+                      "mandatory": true,
+                      "minimum": {
+                        "meta": "ref_p_start_date",
+                        "offset_by": {
+                          "months": -1
+                        }
+                      },
+                      "type": "MonthYearDate"
+                    },
+                    {
+                      "id": "date-range-to",
+                      "label": "Period to",
+                      "mandatory": true,
+                      "maximum": {
+                        "meta": "ref_p_end_date",
+                        "offset_by": {
+                          "months": 2
+                        }
+                      },
+                      "type": "MonthYearDate"
+                    }
+                  ],
+                  "id": "date-range-question",
+                  "period_limits": {
+                    "maximum": {
+                      "days": 5,
+                      "months": 2
+                    },
+                    "minimum": {
+                      "days": 7,
+                      "months": 1
+                    }
+                  },
+                  "title": "Enter Date Range",
+                  "type": "DateRange"
                 }
-            ]
-        }]
-    }]
+              ],
+              "title": "Date Range",
+              "type": "Question"
+            },
+            {
+              "id": "summary",
+              "type": "Summary"
+            }
+          ],
+          "id": "dates",
+          "title": "Date Range Validation"
+        }
+      ],
+      "id": "default-section"
+    }
+  ],
+  "survey_id": "023",
+  "theme": "default",
+  "title": "Date formats"
 }

--- a/tests/schemas/test_invalid_multiple_question_titles.json
+++ b/tests/schemas/test_invalid_multiple_question_titles.json
@@ -1,218 +1,273 @@
 {
-    "mime_type": "application/json/ons/eq",
-    "schema_version": "0.0.1",
-    "data_version": "0.0.2",
-    "survey_id": "0",
-    "title": "Multiple Question Title Test",
-    "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
-    "description": "A questionnaire to test multiple question title versions",
-    "metadata": {
-        "user_id": {
-            "validator": "string"
-        },
-        "period_id": {
-            "validator": "string"
-        },
-        "ru_name": {
-            "validator": "string"
-        }
+  "data_version": "0.0.2",
+  "description": "A questionnaire to test multiple question title versions",
+  "legal_basis": "StatisticsOfTradeAct",
+  "metadata": [
+    {
+      "name": "user_id",
+      "validator": "string"
     },
-    "sections": [{
-        "id": "default-section",
-        "groups": [{
-            "id": "group",
-            "title": "",
-            "blocks": [{
-                    "type": "Question",
-                    "id": "single-title-block",
-                    "title": "Single question title",
-                    "questions": [{
-                        "id": "single-title-question",
-                        "titles": [{
-                            "when": [{
-                                "id": "behalf-of-answer",
-                                "condition": "equals",
-                                "value": "kelly"
-                                }],
-                            "value": "How are you feeling??"
-                        }],
-                        "type": "General",
-                        "answers": [{
-                            "type": "Radio",
-                            "id": "feeling-answer",
-                            "mandatory": true,
-                            "options": [{
-                                    "label": "Good",
-                                    "value": "good"
-                                },
-                                {
-                                    "label": "Bad",
-                                    "value": "bad"
-                                }
-                            ]
-                        }]
-                    }]
-                },
+    {
+      "name": "ru_name",
+      "validator": "string"
+    },
+    {
+      "name": "period_id",
+      "validator": "string"
+    }
+  ],
+  "mime_type": "application/json/ons/eq",
+  "schema_version": "0.0.1",
+  "sections": [
+    {
+      "groups": [
+        {
+          "blocks": [
+            {
+              "id": "single-title-block",
+              "questions": [
                 {
-                    "type": "Question",
-                    "id": "who-is-answering-block",
-                    "questions": [{
-                        "id": "behalf-of-question",
-                        "title": "Who are you answering on behalf of?",
-                        "guidance": {
-                            "content": [{
-                                "description": "The answer you choose will have an affect on question titles in next question"
-                            }]
-                        },
-                        "type": "General",
-                        "answers": [{
-                            "type": "Radio",
-                            "id": "behalf-of-answer",
-                            "mandatory": true,
-                            "options": [{
-                                    "label": "Myself",
-                                    "value": "myself"
-                                },
-                                {
-                                    "label": "Chad",
-                                    "value": "chad"
-                                },
-                                {
-                                    "label": "Kelly",
-                                    "value": "kelly"
-                                },
-                                {
-                                    "label": "Someone else",
-                                    "value": "else"
-                                }
-                            ]
-                        }]
-                    }]
-                },
-                {
-                    "type": "Question",
-                    "id": "multiple-question-versions-block",
-                    "title": "Multiple question versions",
-                    "questions": [{
-                        "id": "what-gender-question",
-                        "titles": [{
-                            "value": "What is <em>{{[answers['behalf-of-answer']]|format_household_name_possessive}}</em> gender?",
-                            "when": [{
-                                "id": "behalf-of-answer-fake",
-                                "condition": "equals",
-                                "value": "chad"
-                                }]
-                            },
-                            {
-                            "value": "What is <em>{{[answers['behalf-of-answer']]|format_household_name_possessive}}</em> gender?",
-                            "when": [{
-                                "id": "behalf-of-answer",
-                                "condition": "equals",
-                                "value": "kelly"
-                                }]
-                            },
-                            {
-                                "value": "What is their gender?",
-                                "when": [{
-                                    "id": "behalf-of-answer",
-                                    "condition": "equals",
-                                    "value": "else"
-                                }]
-                            },
-                            {
-                            "value": "What is your gender?"
-                        }],
-                        "guidance": {
-                            "content": [{
-                                "description": "Your question should be phrased correctly depending on the answer selected in the previous question"
-                            }]
-                        },
-                        "type": "General",
-                        "answers": [{
-                            "type": "Radio",
-                            "id": "gender-answer",
-                            "mandatory": true,
-                            "options": [{
-                                    "label": "Male",
-                                    "value": "male"
-                                },
-                                {
-                                    "label": "Female",
-                                    "value": "female"
-                                }
-                            ]
-                        }]
-                    },
+                  "answers": [
                     {
-                        "id": "what-age-question",
-                        "titles": [{
-                            "value": "What is <em>{{[answers['behalf-of-answer']]|format_household_name_possessive}}</em> age?",
-                            "when": [{
-                                "id": "behalf-of-answer",
-                                "condition": "equals",
-                                "value": "chad"
-                                }]
-                            },
-                            {
-                            "value": "What is <em>{{[answers['behalf-of-answer']]|format_household_name_possessive}}</em> age?",
-                            "when": [{
-                                "id": "behalf-of-answer",
-                                "condition": "equals",
-                                "value": "kelly"
-                                }]
-                            },
-                            {
-                            "value": "What is their age?",
-                            "when": [{
-                                "id": "behalf-of-answer",
-                                "condition": "equals",
-                                "value": "else"
-                                }]
-                            },
-                            {
-                            "value": "What is your age?"
-                        }],
-                        "guidance": {
-                            "content": [{
-                                    "description": "Your question should be phrased correctly depending on the answer selected in the previous question"
-                                }
-                            ]
+                      "id": "feeling-answer",
+                      "mandatory": true,
+                      "options": [
+                        {
+                          "label": "Good",
+                          "value": "good"
                         },
-                        "type": "General",
-                        "answers": [{
-                            "type": "Number",
-                            "id": "age-answer",
-                            "mandatory": true
-                        }]
-                    },
+                        {
+                          "label": "Bad",
+                          "value": "bad"
+                        }
+                      ],
+                      "type": "Radio"
+                    }
+                  ],
+                  "id": "single-title-question",
+                  "titles": [
                     {
-                        "id": "sure-question",
-                        "titles": [{
-                            "value": "Are you sure??"
-                        }],
-                        "type": "General",
-                        "answers": [{
-                            "type": "Radio",
-                            "id": "sure-answer",
-                            "mandatory": true,
-                            "options": [{
-                                    "label": "Yes",
-                                    "value": "yes"
-                                },
-                                {
-                                    "label": "No",
-                                    "value": "no"
-                                }
-                            ]
-                        }]
-                    }]
-                },
-                {
-                    "type": "Summary",
-                    "id": "summary"
+                      "value": "How are you feeling??",
+                      "when": [
+                        {
+                          "condition": "equals",
+                          "id": "behalf-of-answer",
+                          "value": "kelly"
+                        }
+                      ]
+                    }
+                  ],
+                  "type": "General"
                 }
-            ]
-        }]
-    }]
+              ],
+              "title": "Single question title",
+              "type": "Question"
+            },
+            {
+              "id": "who-is-answering-block",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "id": "behalf-of-answer",
+                      "mandatory": true,
+                      "options": [
+                        {
+                          "label": "Myself",
+                          "value": "myself"
+                        },
+                        {
+                          "label": "Chad",
+                          "value": "chad"
+                        },
+                        {
+                          "label": "Kelly",
+                          "value": "kelly"
+                        },
+                        {
+                          "label": "Someone else",
+                          "value": "else"
+                        }
+                      ],
+                      "type": "Radio"
+                    }
+                  ],
+                  "guidance": {
+                    "content": [
+                      {
+                        "description": "The answer you choose will have an affect on question titles in next question"
+                      }
+                    ]
+                  },
+                  "id": "behalf-of-question",
+                  "title": "Who are you answering on behalf of?",
+                  "type": "General"
+                }
+              ],
+              "type": "Question"
+            },
+            {
+              "id": "multiple-question-versions-block",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "id": "gender-answer",
+                      "mandatory": true,
+                      "options": [
+                        {
+                          "label": "Male",
+                          "value": "male"
+                        },
+                        {
+                          "label": "Female",
+                          "value": "female"
+                        }
+                      ],
+                      "type": "Radio"
+                    }
+                  ],
+                  "guidance": {
+                    "content": [
+                      {
+                        "description": "Your question should be phrased correctly depending on the answer selected in the previous question"
+                      }
+                    ]
+                  },
+                  "id": "what-gender-question",
+                  "titles": [
+                    {
+                      "value": "What is <em>{{[answers['behalf-of-answer']]|format_household_name_possessive}}</em> gender?",
+                      "when": [
+                        {
+                          "condition": "equals",
+                          "id": "behalf-of-answer-fake",
+                          "value": "chad"
+                        }
+                      ]
+                    },
+                    {
+                      "value": "What is <em>{{[answers['behalf-of-answer']]|format_household_name_possessive}}</em> gender?",
+                      "when": [
+                        {
+                          "condition": "equals",
+                          "id": "behalf-of-answer",
+                          "value": "kelly"
+                        }
+                      ]
+                    },
+                    {
+                      "value": "What is their gender?",
+                      "when": [
+                        {
+                          "condition": "equals",
+                          "id": "behalf-of-answer",
+                          "value": "else"
+                        }
+                      ]
+                    },
+                    {
+                      "value": "What is your gender?"
+                    }
+                  ],
+                  "type": "General"
+                },
+                {
+                  "answers": [
+                    {
+                      "id": "age-answer",
+                      "mandatory": true,
+                      "type": "Number"
+                    }
+                  ],
+                  "guidance": {
+                    "content": [
+                      {
+                        "description": "Your question should be phrased correctly depending on the answer selected in the previous question"
+                      }
+                    ]
+                  },
+                  "id": "what-age-question",
+                  "titles": [
+                    {
+                      "value": "What is <em>{{[answers['behalf-of-answer']]|format_household_name_possessive}}</em> age?",
+                      "when": [
+                        {
+                          "condition": "equals",
+                          "id": "behalf-of-answer",
+                          "value": "chad"
+                        }
+                      ]
+                    },
+                    {
+                      "value": "What is <em>{{[answers['behalf-of-answer']]|format_household_name_possessive}}</em> age?",
+                      "when": [
+                        {
+                          "condition": "equals",
+                          "id": "behalf-of-answer",
+                          "value": "kelly"
+                        }
+                      ]
+                    },
+                    {
+                      "value": "What is their age?",
+                      "when": [
+                        {
+                          "condition": "equals",
+                          "id": "behalf-of-answer",
+                          "value": "else"
+                        }
+                      ]
+                    },
+                    {
+                      "value": "What is your age?"
+                    }
+                  ],
+                  "type": "General"
+                },
+                {
+                  "answers": [
+                    {
+                      "id": "sure-answer",
+                      "mandatory": true,
+                      "options": [
+                        {
+                          "label": "Yes",
+                          "value": "yes"
+                        },
+                        {
+                          "label": "No",
+                          "value": "no"
+                        }
+                      ],
+                      "type": "Radio"
+                    }
+                  ],
+                  "id": "sure-question",
+                  "titles": [
+                    {
+                      "value": "Are you sure??"
+                    }
+                  ],
+                  "type": "General"
+                }
+              ],
+              "title": "Multiple question versions",
+              "type": "Question"
+            },
+            {
+              "id": "summary",
+              "type": "Summary"
+            }
+          ],
+          "id": "group",
+          "title": ""
+        }
+      ],
+      "id": "default-section"
+    }
+  ],
+  "survey_id": "0",
+  "theme": "default",
+  "title": "Multiple Question Title Test"
 }

--- a/tests/schemas/test_invalid_numeric_answers.json
+++ b/tests/schemas/test_invalid_numeric_answers.json
@@ -1,169 +1,198 @@
 {
-    "mime_type": "application/json/ons/eq",
-    "schema_version": "0.0.1",
-    "data_version": "0.0.1",
-    "survey_id": "0",
-    "title": "Minimum and maximum exclusivity",
-    "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
-    "description": "A questionnaire to test currency input type",
-    "metadata": {
-        "user_id": {
-            "validator": "string"
-        },
-        "period_id": {
-            "validator": "string"
-        },
-        "ru_name": {
-            "validator": "string"
-        }
+  "data_version": "0.0.1",
+  "description": "A questionnaire to test currency input type",
+  "legal_basis": "StatisticsOfTradeAct",
+  "metadata": [
+    {
+      "name": "user_id",
+      "validator": "string"
     },
-    "sections": [{
-        "id": "section-1",
-        "groups": [{
-            "id": "group",
-            "title": "Testing range of linked answers, with min/max_values",
-            "blocks": [{
-                    "type": "Question",
-                    "id": "block-1",
-                    "questions": [{
-                        "id": "question-1",
-                        "title": "Enter a value 1",
-                        "type": "General",
-                        "answers": [{
-                                "id": "answer-1",
-                                "type": "Number",
-                                "mandatory": false,
-                                "decimal_places": 2
-                            }
-                        ]
-                    }]
-                },
+    {
+      "name": "ru_name",
+      "validator": "string"
+    },
+    {
+      "name": "period_id",
+      "validator": "string"
+    }
+  ],
+  "mime_type": "application/json/ons/eq",
+  "schema_version": "0.0.1",
+  "sections": [
+    {
+      "groups": [
+        {
+          "blocks": [
+            {
+              "id": "block-1",
+              "questions": [
                 {
-                    "type": "Question",
-                    "id": "block-2",
-                    "questions": [{
-                        "type": "General",
-                        "id": "question-2",
-                        "title": "Enter a value 2",
-                        "answers": [{
-                                "id": "answer-2",
-                                "label": "Invalid Range",
-                                "type": "Currency",
-                                "mandatory": false,
-                                "currency": "GBP",
-                                "max_value": {
-                                    "answer_id": "answer-1",
-                                    "exclusive": true
-                                }
-                            }
-                        ]
-                    }]
-                },
-                {
-                    "type": "Question",
-                    "id": "block-3",
-                    "questions": [{
-                        "type": "General",
-                        "id": "question-3",
-                        "title": "Enter a value 3",
-                        "answers": [{
-                                "id": "answer-3",
-                                "label": "Invalid References",
-                                "type": "Percentage",
-                                "mandatory": false,
-                                "min_value": {
-                                    "answer_id": "answer-4"
-                                },
-                                "max_value": {
-                                    "answer_id": "answer-5"
-                                }
-                            }
-                        ]
-                    }]
-                },
-                {
-                    "type": "Question",
-                    "id": "block-4",
-                    "questions": [{
-                        "type": "General",
-                        "id": "question-4",
-                        "title": "Enter a value 4",
-                        "answers": [{
-                                "id": "answer-4",
-                                "label": "Max/Min out of system limits",
-                                "type": "Number",
-                                "mandatory": false,
-                                "min_value": {
-                                    "value": -99999999999
-                                },
-                                "max_value": {
-                                    "value": 99999999999
-                                }
-                            }
-                        ]
-                    }]
-                },
-                {
-                    "type": "Question",
-                    "id": "block-5",
-                    "questions": [{
-                        "type": "General",
-                        "id": "question-5",
-                        "title": "Enter a value 5",
-                        "answers": [{
-                                "id": "answer-5",
-                                "label": "Too many decimals declared",
-                                "type": "Number",
-                                "mandatory": false,
-                                "decimal_places": 10
-                            }
-                        ]
-                    }]
-                },
-                {
-                    "type": "Question",
-                    "id": "block-6",
-                    "questions": [{
-                        "type": "General",
-                        "id": "question-6",
-                        "title": "Enter a value 6",
-                        "answers": [{
-                                "id": "answer-6",
-                                "label": "Invalid Range",
-                                "type": "Currency",
-                                "mandatory": false,
-                                "currency": "GBP",
-                                "decimal_places": 1,
-                                "max_value": {
-                                    "answer_id": "answer-1"
-                                }
-                            }
-                        ]
-                    }]
-                },
-                {
-                    "type": "Question",
-                    "id": "block-7",
-                    "questions": [{
-                        "type": "General",
-                        "id": "question-7",
-                        "title": "Enter a value 7",
-                        "answers": [{
-                                "id": "answer-7",
-                                "label": "Default with Mandatory",
-                                "type": "Number",
-                                "mandatory": true,
-                                "default": 0
-                            }
-                        ]
-                    }]
-                },
-                {
-                    "type": "Summary",
-                    "id": "summary"
+                  "answers": [
+                    {
+                      "decimal_places": 2,
+                      "id": "answer-1",
+                      "mandatory": false,
+                      "type": "Number"
+                    }
+                  ],
+                  "id": "question-1",
+                  "title": "Enter a value 1",
+                  "type": "General"
                 }
-            ]
-        }]
-    }]
+              ],
+              "type": "Question"
+            },
+            {
+              "id": "block-2",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "currency": "GBP",
+                      "id": "answer-2",
+                      "label": "Invalid Range",
+                      "mandatory": false,
+                      "max_value": {
+                        "answer_id": "answer-1",
+                        "exclusive": true
+                      },
+                      "type": "Currency"
+                    }
+                  ],
+                  "id": "question-2",
+                  "title": "Enter a value 2",
+                  "type": "General"
+                }
+              ],
+              "type": "Question"
+            },
+            {
+              "id": "block-3",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "id": "answer-3",
+                      "label": "Invalid References",
+                      "mandatory": false,
+                      "max_value": {
+                        "answer_id": "answer-5"
+                      },
+                      "min_value": {
+                        "answer_id": "answer-4"
+                      },
+                      "type": "Percentage"
+                    }
+                  ],
+                  "id": "question-3",
+                  "title": "Enter a value 3",
+                  "type": "General"
+                }
+              ],
+              "type": "Question"
+            },
+            {
+              "id": "block-4",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "id": "answer-4",
+                      "label": "Max/Min out of system limits",
+                      "mandatory": false,
+                      "max_value": {
+                        "value": 99999999999
+                      },
+                      "min_value": {
+                        "value": -99999999999
+                      },
+                      "type": "Number"
+                    }
+                  ],
+                  "id": "question-4",
+                  "title": "Enter a value 4",
+                  "type": "General"
+                }
+              ],
+              "type": "Question"
+            },
+            {
+              "id": "block-5",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "decimal_places": 10,
+                      "id": "answer-5",
+                      "label": "Too many decimals declared",
+                      "mandatory": false,
+                      "type": "Number"
+                    }
+                  ],
+                  "id": "question-5",
+                  "title": "Enter a value 5",
+                  "type": "General"
+                }
+              ],
+              "type": "Question"
+            },
+            {
+              "id": "block-6",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "currency": "GBP",
+                      "decimal_places": 1,
+                      "id": "answer-6",
+                      "label": "Invalid Range",
+                      "mandatory": false,
+                      "max_value": {
+                        "answer_id": "answer-1"
+                      },
+                      "type": "Currency"
+                    }
+                  ],
+                  "id": "question-6",
+                  "title": "Enter a value 6",
+                  "type": "General"
+                }
+              ],
+              "type": "Question"
+            },
+            {
+              "id": "block-7",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "default": 0,
+                      "id": "answer-7",
+                      "label": "Default with Mandatory",
+                      "mandatory": true,
+                      "type": "Number"
+                    }
+                  ],
+                  "id": "question-7",
+                  "title": "Enter a value 7",
+                  "type": "General"
+                }
+              ],
+              "type": "Question"
+            },
+            {
+              "id": "summary",
+              "type": "Summary"
+            }
+          ],
+          "id": "group",
+          "title": "Testing range of linked answers, with min/max_values"
+        }
+      ],
+      "id": "section-1"
+    }
+  ],
+  "survey_id": "0",
+  "theme": "default",
+  "title": "Minimum and maximum exclusivity"
 }

--- a/tests/schemas/test_invalid_routing_block.json
+++ b/tests/schemas/test_invalid_routing_block.json
@@ -1,141 +1,156 @@
 {
-    "mime_type": "application/json/ons/eq",
-    "schema_version": "0.0.1",
-    "data_version": "0.0.1",
-    "survey_id": "023",
-    "title": "Test Invalid Routing Block ID",
-    "description": "",
-    "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
-    "metadata": {
-        "user_id": {
-            "validator": "string"
-        },
-        "period_id": {
-            "validator": "string"
-        },
-        "ru_name": {
-            "validator": "string"
-        }
+  "data_version": "0.0.1",
+  "description": "",
+  "legal_basis": "StatisticsOfTradeAct",
+  "metadata": [
+    {
+      "name": "user_id",
+      "validator": "string"
     },
-    "sections": [{
-        "id": "section1",
-        "groups": [{
-            "blocks": [{
-                "type": "Question",
-                "id": "conditional-routing-block",
-                "title": "Conditional Routing Test",
-                "description": "Testing invalid routing with an options answer",
-                "questions": [{
-                    "id": "conditional-routing-question",
-                    "title": "Do you drink coffee?",
-                    "description": "",
-                    "type": "General",
-                    "answers": [{
-                        "options": [
-                            {
-                                "label": "Yes",
-                                "value": "yes",
-                                "description": ""
-                            },
-                            {
-                                "label": "No, I prefer tea",
-                                "value": "no",
-                                "description": ""
-                            }
-                        ],
-                        "q_code": "1",
+    {
+      "name": "ru_name",
+      "validator": "string"
+    },
+    {
+      "name": "period_id",
+      "validator": "string"
+    }
+  ],
+  "mime_type": "application/json/ons/eq",
+  "schema_version": "0.0.1",
+  "sections": [
+    {
+      "groups": [
+        {
+          "blocks": [
+            {
+              "description": "Testing invalid routing with an options answer",
+              "id": "conditional-routing-block",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "id": "conditional-routing-answer",
+                      "label": "Which conditional question should we jump to?",
+                      "mandatory": true,
+                      "options": [
+                        {
+                          "description": "",
+                          "label": "Yes",
+                          "value": "yes"
+                        },
+                        {
+                          "description": "",
+                          "label": "No, I prefer tea",
+                          "value": "no"
+                        }
+                      ],
+                      "q_code": "1",
+                      "type": "Radio"
+                    }
+                  ],
+                  "description": "",
+                  "id": "conditional-routing-question",
+                  "title": "Do you drink coffee?",
+                  "type": "General"
+                }
+              ],
+              "routing_rules": [
+                {
+                  "goto": {
+                    "block": "response-yes",
+                    "when": [
+                      {
+                        "condition": "equals",
                         "id": "conditional-routing-answer",
-                        "label": "Which conditional question should we jump to?",
-                        "mandatory": true,
-                        "type": "Radio"
-                    }]
-                }],
-                "routing_rules":[
-                    {
-                        "goto": {
-                            "block" : "response-yes",
-                            "when": [
-                                {
-                                    "id" : "conditional-routing-answer",
-                                    "condition": "equals",
-                                    "value":"yes"
-                                }
-                            ]
-                        }
-                    },
-                    {
-                        "goto": {
-                            "block": "invalid-location",
-                            "when": [
-                                {
-                                    "id" : "fake-answer",
-                                    "condition": "equals",
-                                    "value":"no"
-                                }
-                            ]
-                        }
-                    }
-                ]
+                        "value": "yes"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "invalid-location",
+                    "when": [
+                      {
+                        "condition": "equals",
+                        "id": "fake-answer",
+                        "value": "no"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "title": "Conditional Routing Test",
+              "type": "Question"
             },
             {
-                "type": "Question",
-                "id": "response-yes",
-                "title": "Yes, I do drink coffee",
-                "description": "",
-                "questions": [{
-                    "id": "response-yes-question",
-                    "title": "How many cups of coffee do you drink a day?",
-                    "description": "testing invalid answer in a non options answer",
-                    "type": "General",
-                    "answers": [{
+              "description": "",
+              "id": "response-yes",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "id": "response-yes-number-of-cups",
+                      "label": "Number of cups",
+                      "mandatory": true,
+                      "q_code": "2",
+                      "type": "Number"
+                    }
+                  ],
+                  "description": "testing invalid answer in a non options answer",
+                  "id": "response-yes-question",
+                  "title": "How many cups of coffee do you drink a day?",
+                  "type": "General"
+                }
+              ],
+              "routing_rules": [
+                {
+                  "goto": {
+                    "block": "conditional-routing-block",
+                    "when": [
+                      {
+                        "condition": "equals",
+                        "id": "AnAnswerThatDoesNotExist",
+                        "value": 17
+                      }
+                    ]
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "summary"
+                  }
+                },
+                {
+                  "repeat": {
+                    "type": "until",
+                    "when": [
+                      {
+                        "condition": "equals",
                         "id": "response-yes-number-of-cups",
-                        "label": "Number of cups",
-                        "mandatory": true,
-                        "q_code": "2",
-                        "type": "Number"
-                    }]
-                }],
-                "routing_rules":[
-                    {
-                        "goto": {
-                            "block": "conditional-routing-block",
-                            "when": [
-                                {
-                                   "id": "AnAnswerThatDoesNotExist",
-                                    "condition": "equals",
-                                    "value": 17
-                                }
-                            ]
-
-                        }
-                    },
-                    {
-                        "goto": {
-                            "block" : "summary"
-                        }
-
-                    },
-                    {
-                        "repeat": {
-                            "type": "until",
-                            "when": [
-                                {
-                                    "id": "response-yes-number-of-cups",
-                                    "condition": "equals",
-                                    "value": 2
-                                }
-                            ]
-                        }
-                    }
-                ]
+                        "value": 2
+                      }
+                    ]
+                  }
+                }
+              ],
+              "title": "Yes, I do drink coffee",
+              "type": "Question"
             },
             {
-                "type": "Summary",
-                "id": "summary"
-            }],
-            "id": "conditional-routing-within-group",
-            "title": "Conditional routing within group"
-        }]
-    }]
+              "id": "summary",
+              "type": "Summary"
+            }
+          ],
+          "id": "conditional-routing-within-group",
+          "title": "Conditional routing within group"
+        }
+      ],
+      "id": "section1"
+    }
+  ],
+  "survey_id": "023",
+  "theme": "default",
+  "title": "Test Invalid Routing Block ID"
 }

--- a/tests/schemas/test_invalid_routing_group.json
+++ b/tests/schemas/test_invalid_routing_group.json
@@ -1,156 +1,170 @@
 {
-    "mime_type": "application/json/ons/eq",
-    "schema_version": "0.0.1",
-    "data_version": "0.0.1",
-    "survey_id": "0",
-    "title": "Test Invalid Routing To Group",
-    "description": "",
-    "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
-    "metadata": {
-        "user_id": {
-            "validator": "string"
-        },
-        "period_id": {
-            "validator": "string"
-        },
-        "ru_name": {
-            "validator": "string"
-        }
+  "data_version": "0.0.1",
+  "description": "",
+  "legal_basis": "StatisticsOfTradeAct",
+  "metadata": [
+    {
+      "name": "user_id",
+      "validator": "string"
     },
-    "sections": [
+    {
+      "name": "ru_name",
+      "validator": "string"
+    },
+    {
+      "name": "period_id",
+      "validator": "string"
+    }
+  ],
+  "mime_type": "application/json/ons/eq",
+  "schema_version": "0.0.1",
+  "sections": [
+    {
+      "groups": [
         {
-            "id": "section1",
-            "groups": [
+          "blocks": [
+            {
+              "description": "",
+              "id": "which-group-block",
+              "questions": [
                 {
-                    "id": "which-group",
-                    "title": "What group do you want to go to?",
-                    "routing_rules": [
+                  "answers": [
+                    {
+                      "id": "which-group-answer",
+                      "label": "Choose next group",
+                      "mandatory": true,
+                      "options": [
                         {
-                            "goto": {
-                                "group": "group1",
-                                "when": [{
-                                    "answer_count": "invalid-answer-id",
-                                    "condition": "equals",
-                                    "value": 2
-                                }]
-                            }
+                          "label": "Group 1",
+                          "value": "group1"
                         },
                         {
-                            "repeat": {
-                                "type": "until",
-                                "when": [
-                                    {
-                                        "id": "invalid-answer-id",
-                                        "condition": "equals",
-                                        "value": 2
-                                    },
-                                    {
-                                        "id": "group1-answer",
-                                        "condition": "equals",
-                                        "value": 2
-                                    }
-                                ]
-                            }
+                          "label": "Group 2",
+                          "value": "group2"
                         }
-                    ],
-                    "blocks": [
-                        {
-                            "type": "Question",
-                            "id": "which-group-block",
-                            "description": "",
-                            "title": "Pick your next group?",
-                            "questions": [
-                                {
-                                    "description": "",
-                                    "id": "which-group-question",
-                                    "title": "Select Group",
-                                    "type": "General",
-                                    "answers": [
-                                        {
-                                            "id": "which-group-answer",
-                                            "label": "Choose next group",
-                                            "mandatory": true,
-                                            "options": [
-                                                {
-                                                    "label": "Group 1",
-                                                    "value": "group1"
-                                                },
-                                                {
-                                                    "label": "Group 2",
-                                                    "value": "group2"
-                                                }
-                                            ],
-                                            "type": "Radio",
-                                            "validation": {
-                                                "messages": {}
-                                            }
-                                        }
-                                    ]
-                                }
-                            ],
-                            "routing_rules": [
-                                {
-                                    "goto": {
-                                        "group": "group1",
-                                        "when": [
-                                            {
-                                                "id": "which-group-answer",
-                                                "condition": "equals",
-                                                "value": "group1"
-                                            }
-                                        ]
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "group": "invalid-group",
-                                        "when": [
-                                            {
-                                                "id": "which-group-answer",
-                                                "condition": "equals",
-                                                "value": "group2"
-                                            }
-                                        ]
-                                    }
-                                }
-                            ]
-                        }
-                    ]
+                      ],
+                      "type": "Radio",
+                      "validation": {
+                        "messages": {}
+                      }
+                    }
+                  ],
+                  "description": "",
+                  "id": "which-group-question",
+                  "title": "Select Group",
+                  "type": "General"
                 }
-            ]
-        },
-        {
-            "id": "section2",
-            "groups": [
+              ],
+              "routing_rules": [
+                {
+                  "goto": {
+                    "group": "group1",
+                    "when": [
+                      {
+                        "condition": "equals",
+                        "id": "which-group-answer",
+                        "value": "group1"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "goto": {
+                    "group": "invalid-group",
+                    "when": [
+                      {
+                        "condition": "equals",
+                        "id": "which-group-answer",
+                        "value": "group2"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "title": "Pick your next group?",
+              "type": "Question"
+            }
+          ],
+          "id": "which-group",
+          "routing_rules": [
             {
-                "id": "group1",
-                "title": "This is Group 1",
-                "blocks": [{
-                    "type": "Question",
-                    "id": "group1-block",
-                    "title": "Did you want Group 1?",
-                    "questions": [{
-                        "id": "group1-question",
-                        "title": "Did you want Group 1?",
-                        "type": "General",
-                        "answers": [{
-                            "id": "group1-answer",
-                            "label": "Why did you choose Group 1?",
-                            "mandatory": true,
-                            "type": "TextArea"
-                        }]
-                    }]
-                }]
+              "goto": {
+                "group": "group1",
+                "when": [
+                  {
+                    "answer_count": "invalid-answer-id",
+                    "condition": "equals",
+                    "value": 2
+                  }
+                ]
+              }
             },
             {
-                "blocks": [{
-                    "type": "Summary",
-                    "id": "summary"
-                }],
-                "id": "summary-group",
-                "title": "Summary"
+              "repeat": {
+                "type": "until",
+                "when": [
+                  {
+                    "condition": "equals",
+                    "id": "invalid-answer-id",
+                    "value": 2
+                  },
+                  {
+                    "condition": "equals",
+                    "id": "group1-answer",
+                    "value": 2
+                  }
+                ]
+              }
             }
-        ]
-    }]
+          ],
+          "title": "What group do you want to go to?"
+        }
+      ],
+      "id": "section1"
+    },
+    {
+      "groups": [
+        {
+          "blocks": [
+            {
+              "id": "group1-block",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "id": "group1-answer",
+                      "label": "Why did you choose Group 1?",
+                      "mandatory": true,
+                      "type": "TextArea"
+                    }
+                  ],
+                  "id": "group1-question",
+                  "title": "Did you want Group 1?",
+                  "type": "General"
+                }
+              ],
+              "title": "Did you want Group 1?",
+              "type": "Question"
+            }
+          ],
+          "id": "group1",
+          "title": "This is Group 1"
+        },
+        {
+          "blocks": [
+            {
+              "id": "summary",
+              "type": "Summary"
+            }
+          ],
+          "id": "summary-group",
+          "title": "Summary"
+        }
+      ],
+      "id": "section2"
+    }
+  ],
+  "survey_id": "0",
+  "theme": "default",
+  "title": "Test Invalid Routing To Group"
 }

--- a/tests/schemas/test_invalid_routing_when_answer_count.json
+++ b/tests/schemas/test_invalid_routing_when_answer_count.json
@@ -1,183 +1,220 @@
 {
-    "mime_type": "application/json/ons/eq",
-    "schema_version": "0.0.1",
-    "data_version": "0.0.2",
-    "survey_id": "023",
-    "title": "Test Routing Answer Count",
-    "description": "",
-    "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
-    "metadata": {
-        "user_id": {
-            "validator": "string"
-        },
-        "period_id": {
-            "validator": "string"
-        },
-        "ru_name": {
-            "validator": "string"
-        }
+  "data_version": "0.0.2",
+  "description": "",
+  "legal_basis": "StatisticsOfTradeAct",
+  "metadata": [
+    {
+      "name": "user_id",
+      "validator": "string"
     },
-    "sections": [
+    {
+      "name": "ru_name",
+      "validator": "string"
+    },
+    {
+      "name": "period_id",
+      "validator": "string"
+    }
+  ],
+  "mime_type": "application/json/ons/eq",
+  "schema_version": "0.0.1",
+  "sections": [
+    {
+      "groups": [
         {
-            "id": "intro-section",
-            "title": "Introduction",
-            "groups": [{
-                "blocks": [{
-                        "type": "Introduction",
-                        "id": "introduction",
-                        "title": "Introduction"
+          "blocks": [
+            {
+              "id": "introduction",
+              "title": "Introduction",
+              "type": "Introduction"
+            },
+            {
+              "id": "household-composition",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "id": "first-name",
+                      "label": "First Name",
+                      "mandatory": false,
+                      "q_code": "1",
+                      "type": "TextField"
                     },
                     {
-                        "type": "Question",
-                        "id": "household-composition",
-                        "questions": [{
-                            "id": "household-composition-question",
-                            "title": "Who usually lives here?",
-                            "description": "<br> <div> <h3>Include:</h3> <ul> <li>Yourself, if this is your permanent or family home </li> <li>Family members including partners, children and babies born on or before 9 April 2017</li> <li>Students and/or school children who live away from home during term time</li> <li>Housemates, tenants or lodgers</li> </ul> </div>",
-                            "type": "RepeatingAnswer",
-                            "answers": [{
-                                    "id": "first-name",
-                                    "label": "First Name",
-                                    "mandatory": false,
-                                    "q_code": "1",
-                                    "type": "TextField"
-                                },
-                                {
-                                    "id": "middle-names",
-                                    "label": "Middle Names",
-                                    "mandatory": false,
-                                    "q_code": "1",
-                                    "type": "TextField"
-                                },
-                                {
-                                    "id": "last-name",
-                                    "label": "Last Name",
-                                    "mandatory": false,
-                                    "q_code": "1",
-                                    "type": "TextField"
-                                }
-                            ]
-                        }],
-                        "title": "Household",
-                        "routing_rules": [{
-                                "goto": {
-                                    "group": "group1",
-                                    "when": [{
-                                        "answer_count": "first-name",
-                                        "condition": "equals",
-                                        "value": 2
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "group": "group2",
-                                    "when": [{
-                                        "answer_count": "invalid-answer-id",
-                                        "condition": "greater than",
-                                        "value": 2
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "group": "group0",
-                                    "when": [{
-                                        "answer_count": "first-name",
-                                        "condition": "contains",
-                                        "value": 2
-                                    }]
-                                }
-                            }
-                        ]
+                      "id": "middle-names",
+                      "label": "Middle Names",
+                      "mandatory": false,
+                      "q_code": "1",
+                      "type": "TextField"
+                    },
+                    {
+                      "id": "last-name",
+                      "label": "Last Name",
+                      "mandatory": false,
+                      "q_code": "1",
+                      "type": "TextField"
                     }
-                ],
-                "id": "multiple-questions-group",
-                "title": "Routing control group"
-            }]
+                  ],
+                  "description": "<br> <div> <h3>Include:</h3> <ul> <li>Yourself, if this is your permanent or family home </li> <li>Family members including partners, children and babies born on or before 9 April 2017</li> <li>Students and/or school children who live away from home during term time</li> <li>Housemates, tenants or lodgers</li> </ul> </div>",
+                  "id": "household-composition-question",
+                  "title": "Who usually lives here?",
+                  "type": "RepeatingAnswer"
+                }
+              ],
+              "routing_rules": [
+                {
+                  "goto": {
+                    "group": "group1",
+                    "when": [
+                      {
+                        "answer_count": "first-name",
+                        "condition": "equals",
+                        "value": 2
+                      }
+                    ]
+                  }
+                },
+                {
+                  "goto": {
+                    "group": "group2",
+                    "when": [
+                      {
+                        "answer_count": "invalid-answer-id",
+                        "condition": "greater than",
+                        "value": 2
+                      }
+                    ]
+                  }
+                },
+                {
+                  "goto": {
+                    "group": "group0",
+                    "when": [
+                      {
+                        "answer_count": "first-name",
+                        "condition": "contains",
+                        "value": 2
+                      }
+                    ]
+                  }
+                }
+              ],
+              "title": "Household",
+              "type": "Question"
+            }
+          ],
+          "id": "multiple-questions-group",
+          "title": "Routing control group"
+        }
+      ],
+      "id": "intro-section",
+      "title": "Introduction"
+    },
+    {
+      "groups": [
+        {
+          "blocks": [
+            {
+              "description": "",
+              "id": "group0-block",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "id": "group0-answer",
+                      "label": "Why did you choose Group 1?",
+                      "mandatory": true,
+                      "type": "TextArea"
+                    }
+                  ],
+                  "description": "",
+                  "id": "group0-question",
+                  "title": "Did you want Group 1?",
+                  "type": "General"
+                }
+              ],
+              "routing_rules": [],
+              "title": "Did you want Group 1?",
+              "type": "Question"
+            }
+          ],
+          "id": "group0",
+          "title": "This is Group 0 - You answered less than \"2\""
         },
         {
-            "id": "main-section",
-            "title": "Conditional Groups section",
-            "groups": [
+          "blocks": [
             {
-                "id": "group0",
-                "title": "This is Group 0 - You answered less than \"2\"",
-                "blocks": [{
-                    "type": "Question",
-                    "id": "group0-block",
-                    "routing_rules": [],
-                    "description": "",
-                    "title": "Did you want Group 1?",
-                    "questions": [{
-                        "description": "",
-                        "id": "group0-question",
-                        "title": "Did you want Group 1?",
-                        "type": "General",
-                        "answers": [{
-                            "id": "group0-answer",
-                            "label": "Why did you choose Group 1?",
-                            "mandatory": true,
-                            "type": "TextArea"
-                        }]
-                    }]
-                }]
-            },
-            {
-                "id": "group1",
-                "title": "This is Group 1 - you answered \"2\"",
-                "blocks": [{
-                    "type": "Question",
-                    "id": "group1-block",
-                    "routing_rules": [],
-                    "description": "",
-                    "title": "Did you want Group 1?",
-                    "questions": [{
-                        "description": "",
-                        "id": "group1-question",
-                        "title": "Did you want Group 1?",
-                        "type": "General",
-                        "answers": [{
-                            "id": "group1-answer",
-                            "label": "Why did you choose Group 1?",
-                            "mandatory": true,
-                            "type": "TextArea"
-                        }]
-                    }]
-                }]
-            },
-            {
-                "id": "group2",
-                "title": "This is Group 2 - You answered greater than \"2\"",
-                "blocks": [{
-                    "type": "Question",
-                    "id": "group2-block",
-                    "routing_rules": [],
-                    "description": "",
-                    "title": "Did you want Group 2?",
-                    "questions": [{
-                        "description": "",
-                        "id": "group2-question",
-                        "title": "Did you want Group 2?",
-                        "type": "General",
-                        "answers": [{
-                            "id": "group2-answer",
-                            "label": "Why did you choose Group 2?",
-                            "mandatory": true,
-                            "type": "TextArea"
-                        }]
-                    }]
-                }]
-            },
-            {
-                "blocks": [{
-                    "type": "Summary",
-                    "id": "summary"
-                }],
-                "id": "summary-group",
-                "title": ""
+              "description": "",
+              "id": "group1-block",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "id": "group1-answer",
+                      "label": "Why did you choose Group 1?",
+                      "mandatory": true,
+                      "type": "TextArea"
+                    }
+                  ],
+                  "description": "",
+                  "id": "group1-question",
+                  "title": "Did you want Group 1?",
+                  "type": "General"
+                }
+              ],
+              "routing_rules": [],
+              "title": "Did you want Group 1?",
+              "type": "Question"
             }
-        ]
-    }]
+          ],
+          "id": "group1",
+          "title": "This is Group 1 - you answered \"2\""
+        },
+        {
+          "blocks": [
+            {
+              "description": "",
+              "id": "group2-block",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "id": "group2-answer",
+                      "label": "Why did you choose Group 2?",
+                      "mandatory": true,
+                      "type": "TextArea"
+                    }
+                  ],
+                  "description": "",
+                  "id": "group2-question",
+                  "title": "Did you want Group 2?",
+                  "type": "General"
+                }
+              ],
+              "routing_rules": [],
+              "title": "Did you want Group 2?",
+              "type": "Question"
+            }
+          ],
+          "id": "group2",
+          "title": "This is Group 2 - You answered greater than \"2\""
+        },
+        {
+          "blocks": [
+            {
+              "id": "summary",
+              "type": "Summary"
+            }
+          ],
+          "id": "summary-group",
+          "title": ""
+        }
+      ],
+      "id": "main-section",
+      "title": "Conditional Groups section"
+    }
+  ],
+  "survey_id": "023",
+  "theme": "default",
+  "title": "Test Routing Answer Count"
 }

--- a/tests/schemas/test_invalid_single_date_min_max_period.json
+++ b/tests/schemas/test_invalid_single_date_min_max_period.json
@@ -1,68 +1,79 @@
 {
-    "mime_type": "application/json/ons/eq",
-    "schema_version": "0.0.1",
-    "data_version": "0.0.2",
-    "survey_id": "023",
-    "title": "Date formats",
-    "description": "A test schema for different date formats",
-    "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
-    "metadata": {
-        "user_id": {
-            "validator": "string"
-        },
-        "period_id": {
-            "validator": "string"
-        },
-        "ru_name": {
-            "validator": "string"
-        }
+  "data_version": "0.0.2",
+  "description": "A test schema for different date formats",
+  "legal_basis": "StatisticsOfTradeAct",
+  "metadata": [
+    {
+      "name": "user_id",
+      "validator": "string"
     },
-    "sections": [{
-        "id": "default-section",
-        "groups": [{
-            "id": "dates",
-            "title": "Date Range Validation",
-            "blocks": [{
-                    "type": "Question",
-                    "id": "date-range-block",
-                    "title": "Date Range",
-                    "questions": [{
-                        "id": "date-range-question",
-                        "title": "Enter Date Range",
-                        "type": "DateRange",
-                        "answers": [{
-                                "id": "date-range-from",
-                                "label": "Period from",
-                                "mandatory": true,
-                                "type": "Date",
-                                "minimum": {
-                                    "value": "now",
-                                    "offset_by": {
-                                      "days": -19
-                                    }
-                                },
-                                "maximum": {
-                                  "value": "2017-06-11",
-                                  "offset_by": {
-                                      "days": 2
-                                    }
-                                }
-                            },
-                            {
-                                "id": "date-range-to",
-                                "label": "Period to",
-                                "mandatory": true,
-                                "type": "Date"
-                            }
-                        ]
-                    }]
-                },
+    {
+      "name": "ru_name",
+      "validator": "string"
+    },
+    {
+      "name": "period_id",
+      "validator": "string"
+    }
+  ],
+  "mime_type": "application/json/ons/eq",
+  "schema_version": "0.0.1",
+  "sections": [
+    {
+      "groups": [
+        {
+          "blocks": [
+            {
+              "id": "date-range-block",
+              "questions": [
                 {
-                    "type": "Summary",
-                    "id": "summary"
+                  "answers": [
+                    {
+                      "id": "date-range-from",
+                      "label": "Period from",
+                      "mandatory": true,
+                      "maximum": {
+                        "offset_by": {
+                          "days": 2
+                        },
+                        "value": "2017-06-11"
+                      },
+                      "minimum": {
+                        "offset_by": {
+                          "days": -19
+                        },
+                        "value": "now"
+                      },
+                      "type": "Date"
+                    },
+                    {
+                      "id": "date-range-to",
+                      "label": "Period to",
+                      "mandatory": true,
+                      "type": "Date"
+                    }
+                  ],
+                  "id": "date-range-question",
+                  "title": "Enter Date Range",
+                  "type": "DateRange"
                 }
-            ]
-        }]
-    }]
+              ],
+              "title": "Date Range",
+              "type": "Question"
+            },
+            {
+              "id": "summary",
+              "type": "Summary"
+            }
+          ],
+          "id": "dates",
+          "title": "Date Range Validation"
+        }
+      ],
+      "id": "default-section"
+    }
+  ],
+  "survey_id": "023",
+  "theme": "default",
+  "title": "Date formats"
 }

--- a/tests/schemas/test_invalid_survey_id_whitespace.json
+++ b/tests/schemas/test_invalid_survey_id_whitespace.json
@@ -1,3364 +1,3858 @@
 {
-    "mime_type": "application/json/ons/eq",
-    "schema_version": "0.0.1",
-    "data_version": "0.0.2",
-    "survey_id": "lms ",
-    "title": "Labour Market Survey (Alpha)",
-    "description": "Labour Market Survey Schema (Alpha)",
-    "theme": "default",
-    "legal_basis": "Voluntary",
-    "eq_id": "lms",
-    "form_type": "1",
-    "navigation": {
-        "visible": true
+  "data_version": "0.0.2",
+  "description": "Labour Market Survey Schema (Alpha)",
+  "eq_id": "lms",
+  "form_type": "1",
+  "legal_basis": "Voluntary",
+  "metadata": [
+    {
+      "name": "region_code",
+      "validator": "string"
     },
-    "metadata": {
-        "user_id": {
-            "validator": "string"
-        },
-        "period_id": {
-            "validator": "string"
-        },
-        "ru_name": {
-            "validator": "string"
-        },
-        "region_code": {
-            "validator": "string"
-        }
+    {
+      "name": "user_id",
+      "validator": "string"
     },
-    "sections": [{
-            "id": "household-section",
-            "title": "About the household",
-            "groups": [{
-                    "id": "about-household-group",
-                    "title": "About the household",
-                    "blocks": [{
-                            "type": "Interstitial",
-                            "id": "about-household",
-                            "title": "About you and people who live at {{ metadata['ru_name'] }}",
-                            "description": "In this section, we’re going to ask about you, and the people that live with you.",
-                            "content": [{
-                                "title": "Information you need",
-                                "list": [
-                                    "Names of the people living in your household",
-                                    "How they are related to you and one another"
-                                ]
-                            }]
-                        },
-                        {
-                            "type": "Question",
-                            "id": "address-check-block",
-                            "title": "Your address:",
-                            "description": "{{metadata['ru_name']}}",
-                            "questions": [{
-                                "id": "address-check-question",
-                                "title": "Is the address above your main residence?",
-                                "description": "",
-                                "type": "General",
-                                "answers": [{
-                                    "id": "address-check-answer",
-                                    "mandatory": false,
-                                    "options": [{
-                                            "label": "Yes",
-                                            "value": "Yes",
-                                            "description": "The address above is my main residence"
-                                        },
-                                        {
-                                            "label": "No",
-                                            "value": "No",
-                                            "description": "The address above is not my main residence.  For example it is my old address, second home, holiday home or business address"
-                                        }
-                                    ],
-                                    "type": "Radio"
-                                }]
-                            }],
-                            "routing_rules": [{
-                                    "goto": {
-                                        "block": "household-composition",
-                                        "when": [{
-                                            "id": "address-check-answer",
-                                            "condition": "equals",
-                                            "value": "Yes"
-                                        }]
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "block": "household-composition",
-                                        "when": [{
-                                            "id": "address-check-answer",
-                                            "condition": "not set"
-                                        }]
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "block": "address-type-check-block"
-                                    }
-                                }
-                            ]
-                        },
-                        {
-                            "type": "Question",
-                            "id": "address-type-check-block",
-                            "title": "You said {{ metadata['ru_name'] }} is not your main residence",
-                            "description": "",
-                            "questions": [{
-                                "id": "address-type-check-question",
-                                "title": "What type of address is it?",
-                                "type": "General",
-                                "answers": [{
-                                        "id": "address-type-check-answer",
-                                        "mandatory": false,
-                                        "type": "Radio",
-                                        "options": [{
-                                                "label": "A previous address from which mail has been redirected",
-                                                "value": "A previous address from which mail has been redirected"
-                                            },
-                                            {
-                                                "label": "My second or holiday home",
-                                                "value": "My second or holiday home"
-                                            },
-                                            {
-                                                "label": "A business or non-residential address",
-                                                "value": "A business or non-residential address"
-                                            },
-                                            {
-                                                "label": "A communal establishment",
-                                                "value": "A communal establishment"
-                                            },
-                                            {
-                                                "label": "The address above is not on your letter",
-                                                "value": "The address above is not on your letter"
-                                            },
-                                            {
-                                                "label": "Other",
-                                                "value": "Other",
-                                                "child_answer_id": "address-type-check-answer-other"
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        "id": "address-type-check-answer-other",
-                                        "parent_answer_id": "address-type-check-answer",
-                                        "type": "TextField",
-                                        "mandatory": false,
-                                        "label": "Please describe"
-                                    }
-                                ]
-                            }],
-                            "routing_rules": [{
-                                "goto": {
-                                    "group": "questionnaire-completed"
-                                }
-                            }]
-                        },
-                        {
-                            "id": "household-composition",
-                            "type": "Question",
-                            "questions": [{
-                                "id": "household-composition-question",
-                                "title": "What are the names of everyone who lives in the <em>{{ metadata['ru_name'] }}</em> household?",
-                                "type": "RepeatingAnswer",
-                                "answers": [{
-                                        "id": "first-name",
-                                        "label": "First name",
-                                        "mandatory": true,
-                                        "type": "TextField",
-                                        "validation": {
-                                            "messages": {
-                                                "MANDATORY_TEXTFIELD": "Please enter a name or remove the person to continue"
-                                            }
-                                        }
-                                    },
-                                    {
-                                        "id": "middle-names",
-                                        "label": "Middle names",
-                                        "mandatory": false,
-                                        "type": "TextField"
-                                    },
-                                    {
-                                        "id": "last-name",
-                                        "label": "Last name",
-                                        "mandatory": true,
-                                        "type": "TextField",
-                                        "validation": {
-                                            "messages": {
-                                                "MANDATORY_TEXTFIELD": "Please enter a name or remove the person to continue"
-                                            }
-                                        }
-                                    }
-                                ]
-                            }]
-                        },
-                        {
-                            "type": "Question",
-                            "id": "everyone-at-address-confirmation",
-                            "description": "<h2 class='neptune'>You have added...</h2> {{ [answers['first-name'], answers['middle-names'], answers['last-name']]|format_household_summary }}",
-                            "questions": [{
-                                "id": "everyone-at-address-confirmation-question",
-                                "title": "Is that everyone?",
-                                "description": "",
-                                "type": "General",
-                                "answers": [{
-                                    "id": "everyone-at-address-confirmation-answer",
-                                    "mandatory": false,
-                                    "options": [{
-                                            "label": "Yes",
-                                            "value": "Yes",
-                                            "description": "That is everyone who classes this address as their main residence"
-                                        },
-                                        {
-                                            "label": "No",
-                                            "value": "No",
-                                            "description": "I need to add someone else"
-                                        }
-                                    ],
-                                    "type": "Radio"
-                                }]
-                            }],
-                            "routing_rules": [{
-                                    "goto": {
-                                        "block": "household-composition",
-                                        "when": [{
-                                            "id": "everyone-at-address-confirmation-answer",
-                                            "condition": "equals",
-                                            "value": "No"
-                                        }]
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "group": "who-lives-here-relationship-group"
-                                    }
-                                }
-                            ]
-                        }
-                    ]
-                },
+    {
+      "name": "ru_name",
+      "validator": "string"
+    },
+    {
+      "name": "period_id",
+      "validator": "string"
+    }
+  ],
+  "mime_type": "application/json/ons/eq",
+  "navigation": {
+    "visible": true
+  },
+  "schema_version": "0.0.1",
+  "sections": [
+    {
+      "groups": [
+        {
+          "blocks": [
+            {
+              "content": [
                 {
-                    "id": "who-lives-here-relationship-group",
-                    "title": "Relationships",
-                    "routing_rules": [{
-                        "repeat": {
-                            "type": "answer_count_minus_one",
-                            "answer_id": "first-name"
-                        }
-                    }],
-                    "blocks": [{
-                        "type": "Question",
-                        "id": "household-relationships",
-                        "questions": [{
-                            "id": "household-relationships-question",
-                            "title": "How is <em>{{[answers['first-name'][group_instance], answers['last-name'][group_instance]] | format_household_name}}</em> related to the people below?",
-                            "description": "",
-                            "type": "Relationship",
-                            "answers": [{
-                                "id": "household-relationships-answer",
-                                "label": "%(current_person)s is the … of %(other_person)s",
-                                "mandatory": false,
-                                "type": "Relationship",
-                                "options": [{
-                                        "label": "Husband, wife or civil partner",
-                                        "value": "Husband, wife or civil partner"
-                                    },
-                                    {
-                                        "label": "Partner",
-                                        "value": "Partner"
-                                    },
-                                    {
-                                        "label": "Parent, including adoptive parent",
-                                        "value": "Parent, including adoptive parent"
-                                    },
-                                    {
-                                        "label": "Step parent",
-                                        "value": "Step parent"
-                                    },
-                                    {
-                                        "label": "Parent-in-law",
-                                        "value": "Parent-in-law"
-                                    },
-                                    {
-                                        "label": "Son or daughter, including adopted",
-                                        "value": "Son or daughter, including adopted"
-                                    },
-                                    {
-                                        "label": "Step son or daughter",
-                                        "value": "Step son or daughter"
-                                    },
-                                    {
-                                        "label": "Son or daughter-in-law",
-                                        "value": "Son or daughter-in-law"
-                                    },
-                                    {
-                                        "label": "Brother or sister",
-                                        "value": "Brother or sister"
-                                    },
-                                    {
-                                        "label": "Step brother or sister",
-                                        "value": "Step brother or sister"
-                                    },
-                                    {
-                                        "label": "Grand parent",
-                                        "value": "Grand parent"
-                                    },
-                                    {
-                                        "label": "Grand child",
-                                        "value": "Grand child"
-                                    },
-                                    {
-                                        "label": "Other relative",
-                                        "value": "Other relative"
-                                    },
-                                    {
-                                        "label": "Other non relative including foster child or foster parent",
-                                        "value": "Other non relative including foster child or foster parent"
-                                    }
-                                ]
-                            }]
-                        }]
-                    }]
-                },
-                {
-                    "id": "who-lives-here-completed-group",
-                    "title": "Who lives here?",
-                    "blocks": [{
-                        "id": "who-lives-here-completed",
-                        "title": "",
-                        "content": [{
-                                "description": "We would now like to ask some questions of each individual.  An adult should answer on behalf of anyone aged 15 or younger."
-                            },
-                            {
-                                "description": "Please answer your questions first.  Once you have completed your section, you will return to this screen so that the other household members can complete their section.  They can also access it at a later time using the link and unique code given in your letter.  You may answer on behalf of another adult if needed."
-                            }
-                        ],
-                        "type": "Interstitial"
-                    }]
+                  "list": [
+                    "Names of the people living in your household",
+                    "How they are related to you and one another"
+                  ],
+                  "title": "Information you need"
                 }
-            ]
+              ],
+              "description": "In this section, we\u2019re going to ask about you, and the people that live with you.",
+              "id": "about-household",
+              "title": "About you and people who live at {{ metadata['ru_name'] }}",
+              "type": "Interstitial"
+            },
+            {
+              "description": "{{metadata['ru_name']}}",
+              "id": "address-check-block",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "id": "address-check-answer",
+                      "mandatory": false,
+                      "options": [
+                        {
+                          "description": "The address above is my main residence",
+                          "label": "Yes",
+                          "value": "Yes"
+                        },
+                        {
+                          "description": "The address above is not my main residence.  For example it is my old address, second home, holiday home or business address",
+                          "label": "No",
+                          "value": "No"
+                        }
+                      ],
+                      "type": "Radio"
+                    }
+                  ],
+                  "description": "",
+                  "id": "address-check-question",
+                  "title": "Is the address above your main residence?",
+                  "type": "General"
+                }
+              ],
+              "routing_rules": [
+                {
+                  "goto": {
+                    "block": "household-composition",
+                    "when": [
+                      {
+                        "condition": "equals",
+                        "id": "address-check-answer",
+                        "value": "Yes"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "household-composition",
+                    "when": [
+                      {
+                        "condition": "not set",
+                        "id": "address-check-answer"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "address-type-check-block"
+                  }
+                }
+              ],
+              "title": "Your address:",
+              "type": "Question"
+            },
+            {
+              "description": "",
+              "id": "address-type-check-block",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "id": "address-type-check-answer",
+                      "mandatory": false,
+                      "options": [
+                        {
+                          "label": "A previous address from which mail has been redirected",
+                          "value": "A previous address from which mail has been redirected"
+                        },
+                        {
+                          "label": "My second or holiday home",
+                          "value": "My second or holiday home"
+                        },
+                        {
+                          "label": "A business or non-residential address",
+                          "value": "A business or non-residential address"
+                        },
+                        {
+                          "label": "A communal establishment",
+                          "value": "A communal establishment"
+                        },
+                        {
+                          "label": "The address above is not on your letter",
+                          "value": "The address above is not on your letter"
+                        },
+                        {
+                          "child_answer_id": "address-type-check-answer-other",
+                          "label": "Other",
+                          "value": "Other"
+                        }
+                      ],
+                      "type": "Radio"
+                    },
+                    {
+                      "id": "address-type-check-answer-other",
+                      "label": "Please describe",
+                      "mandatory": false,
+                      "parent_answer_id": "address-type-check-answer",
+                      "type": "TextField"
+                    }
+                  ],
+                  "id": "address-type-check-question",
+                  "title": "What type of address is it?",
+                  "type": "General"
+                }
+              ],
+              "routing_rules": [
+                {
+                  "goto": {
+                    "group": "questionnaire-completed"
+                  }
+                }
+              ],
+              "title": "You said {{ metadata['ru_name'] }} is not your main residence",
+              "type": "Question"
+            },
+            {
+              "id": "household-composition",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "id": "first-name",
+                      "label": "First name",
+                      "mandatory": true,
+                      "type": "TextField",
+                      "validation": {
+                        "messages": {
+                          "MANDATORY_TEXTFIELD": "Please enter a name or remove the person to continue"
+                        }
+                      }
+                    },
+                    {
+                      "id": "middle-names",
+                      "label": "Middle names",
+                      "mandatory": false,
+                      "type": "TextField"
+                    },
+                    {
+                      "id": "last-name",
+                      "label": "Last name",
+                      "mandatory": true,
+                      "type": "TextField",
+                      "validation": {
+                        "messages": {
+                          "MANDATORY_TEXTFIELD": "Please enter a name or remove the person to continue"
+                        }
+                      }
+                    }
+                  ],
+                  "id": "household-composition-question",
+                  "title": "What are the names of everyone who lives in the <em>{{ metadata['ru_name'] }}</em> household?",
+                  "type": "RepeatingAnswer"
+                }
+              ],
+              "type": "Question"
+            },
+            {
+              "description": "<h2 class='neptune'>You have added...</h2> {{ [answers['first-name'], answers['middle-names'], answers['last-name']]|format_household_summary }}",
+              "id": "everyone-at-address-confirmation",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "id": "everyone-at-address-confirmation-answer",
+                      "mandatory": false,
+                      "options": [
+                        {
+                          "description": "That is everyone who classes this address as their main residence",
+                          "label": "Yes",
+                          "value": "Yes"
+                        },
+                        {
+                          "description": "I need to add someone else",
+                          "label": "No",
+                          "value": "No"
+                        }
+                      ],
+                      "type": "Radio"
+                    }
+                  ],
+                  "description": "",
+                  "id": "everyone-at-address-confirmation-question",
+                  "title": "Is that everyone?",
+                  "type": "General"
+                }
+              ],
+              "routing_rules": [
+                {
+                  "goto": {
+                    "block": "household-composition",
+                    "when": [
+                      {
+                        "condition": "equals",
+                        "id": "everyone-at-address-confirmation-answer",
+                        "value": "No"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "goto": {
+                    "group": "who-lives-here-relationship-group"
+                  }
+                }
+              ],
+              "type": "Question"
+            }
+          ],
+          "id": "about-household-group",
+          "title": "About the household"
         },
         {
-            "id": "household-members-section",
-            "title_from_answers": [
-                "first-name",
-                "last-name"
-            ],
-            "groups": [{
-                "id": "household-member-group",
-                "title": "Household Member Details",
-                "routing_rules": [{
-                    "repeat": {
-                        "type": "answer_count",
-                        "answer_id": "first-name"
+          "blocks": [
+            {
+              "id": "household-relationships",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "id": "household-relationships-answer",
+                      "label": "%(current_person)s is the \u2026 of %(other_person)s",
+                      "mandatory": false,
+                      "options": [
+                        {
+                          "label": "Husband, wife or civil partner",
+                          "value": "Husband, wife or civil partner"
+                        },
+                        {
+                          "label": "Partner",
+                          "value": "Partner"
+                        },
+                        {
+                          "label": "Parent, including adoptive parent",
+                          "value": "Parent, including adoptive parent"
+                        },
+                        {
+                          "label": "Step parent",
+                          "value": "Step parent"
+                        },
+                        {
+                          "label": "Parent-in-law",
+                          "value": "Parent-in-law"
+                        },
+                        {
+                          "label": "Son or daughter, including adopted",
+                          "value": "Son or daughter, including adopted"
+                        },
+                        {
+                          "label": "Step son or daughter",
+                          "value": "Step son or daughter"
+                        },
+                        {
+                          "label": "Son or daughter-in-law",
+                          "value": "Son or daughter-in-law"
+                        },
+                        {
+                          "label": "Brother or sister",
+                          "value": "Brother or sister"
+                        },
+                        {
+                          "label": "Step brother or sister",
+                          "value": "Step brother or sister"
+                        },
+                        {
+                          "label": "Grand parent",
+                          "value": "Grand parent"
+                        },
+                        {
+                          "label": "Grand child",
+                          "value": "Grand child"
+                        },
+                        {
+                          "label": "Other relative",
+                          "value": "Other relative"
+                        },
+                        {
+                          "label": "Other non relative including foster child or foster parent",
+                          "value": "Other non relative including foster child or foster parent"
+                        }
+                      ],
+                      "type": "Relationship"
                     }
-                }],
-                "blocks": [{
-                        "type": "Interstitial",
-                        "id": "household-member-begin",
-                        "title": "{{[answers['first-name'][group_instance], answers['last-name'][group_instance]] | format_household_name}}",
-                        "description": "In this section, we’re going to ask questions about <em>{{[answers['first-name'][group_instance], answers['last-name'][group_instance]] | format_household_name}}</em>.",
-                        "content": [{
-                            "title": "Information you need",
-                            "list": [
-                                "Personal details such as date of birth, nationality, country of birth",
-                                "How long <em>{{[answers['first-name'][group_instance], answers['last-name'][group_instance]] | format_household_name}}</em> has lived in the UK",
-                                "Their national identity, ethnicity and religion"
-                            ]
-                        }]
-                    },
-                    {
-                        "type": "Question",
-                        "id": "proxy-check",
-                        "questions": [{
-                            "id": "proxy-check-question",
-                            "title": "Are you {{ [answers['first-name'][group_instance], answers['middle-names'][group_instance], answers['last-name'][group_instance]] | format_household_name }}?",
-                            "type": "General",
-                            "guidance": {
-                                "content": [{
-                                    "description": "An adult should answer on behalf of anyone aged 15 or younger."
-                                }]
-                            },
-                            "answers": [{
-                                "id": "proxy-check-answer",
-                                "mandatory": false,
-                                "type": "Radio",
-                                "options": [{
-                                        "label": "Yes, I am",
-                                        "value": "no proxy"
-                                    },
-                                    {
-                                        "label": "No, I am answering on their behalf",
-                                        "value": "proxy"
-                                    }
-                                ]
-                            }]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "date-of-birth",
-                                    "when": [{
-                                        "id": "proxy-check-answer",
-                                        "condition": "equals",
-                                        "value": "proxy"
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "date-of-birth-no-proxy"
-                                }
-                            }
-                        ]
-                    },
-                    {
-                        "type": "Question",
-                        "id": "date-of-birth",
-                        "questions": [{
-                            "id": "date-of-birth-question",
-                            "title": "What is <em>{{[answers['first-name'][group_instance], answers['last-name'][group_instance]] | format_household_name_possessive }}</em> date of birth?",
-                            "type": "General",
-                            "answers": [{
-                                "id": "date-of-birth-answer",
-                                "mandatory": false,
-                                "type": "Date",
-                                "maximum": {
-                                    "value": "now"
-                                }
-                            }]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "date-of-birth-check",
-                                    "when": [{
-                                        "id": "date-of-birth-answer",
-                                        "condition": "not set"
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "sex"
-                                }
-                            }
-                        ]
-                    },
-                    {
-                        "type": "ConfirmationQuestion",
-                        "id": "date-of-birth-check",
-                        "questions": [{
-                            "id": "dob-check-question",
-                            "title": "Is <em>{{[answers['first-name'][group_instance], answers['last-name'][group_instance]] | format_household_name }}</em> aged 16 or over?",
-                            "type": "General",
-                            "answers": [{
-                                "id": "dob-check-answer",
-                                "mandatory": false,
-                                "type": "Radio",
-                                "options": [{
-                                        "label": "Yes",
-                                        "value": "Yes"
-                                    },
-                                    {
-                                        "label": "No",
-                                        "value": "No"
-                                    }
-                                ]
-                            }]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "household-member-completed",
-                                    "when": [{
-                                        "id": "dob-check-answer",
-                                        "condition": "equals",
-                                        "value": "No"
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "household-member-completed",
-                                    "when": [{
-                                        "id": "dob-check-answer",
-                                        "condition": "not set"
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "sex"
-                                }
-                            }
-                        ]
-                    },
-                    {
-                        "type": "Question",
-                        "id": "sex",
-                        "questions": [{
-                            "id": "sex-question",
-                            "title": "What is <em>{{[answers['first-name'][group_instance], answers['last-name'][group_instance]] | format_household_name_possessive }}</em> sex?",
-                            "type": "General",
-                            "answers": [{
-                                "id": "sex-answer",
-                                "mandatory": true,
-                                "type": "Radio",
-                                "options": [{
-                                        "label": "Male",
-                                        "value": "Male"
-                                    },
-                                    {
-                                        "label": "Female",
-                                        "value": "Female"
-                                    }
-                                ]
-                            }]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "marital-status",
-                                    "when": [{
-                                        "id": "date-of-birth-answer",
-                                        "condition": "less than",
-                                        "date_comparison": {
-                                            "value": "now",
-                                            "offset_by": {
-                                                "years": -16
-                                            }
-                                        }
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "marital-status",
-                                    "when": [{
-                                        "id": "date-of-birth-answer",
-                                        "condition": "not set"
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "nationality"
-                                }
-                            }
-                        ]
-                    },
-                    {
-                        "type": "Question",
-                        "id": "marital-status",
-                        "questions": [{
-                            "id": "marital-status-question",
-                            "title": "What is <em>{{[answers['first-name'][group_instance], answers['last-name'][group_instance]] | format_household_name_possessive }}</em> legal marital status?",
-                            "type": "General",
-                            "answers": [{
-                                "id": "marital-status-answer",
-                                "mandatory": false,
-                                "type": "Radio",
-                                "options": [{
-                                        "label": "Never married",
-                                        "value": "Never married"
-                                    },
-                                    {
-                                        "label": "Married",
-                                        "value": "Married"
-                                    },
-                                    {
-                                        "label": "In a registered same-sex civil partnership",
-                                        "value": "In a registered same-sex civil partnership"
-                                    },
-                                    {
-                                        "label": "Separated, but still legally married",
-                                        "value": "Separated, but still legally married"
-                                    },
-                                    {
-                                        "label": "Separated, but still legally in a same-sex civil partnership",
-                                        "value": "Separated, but still legally in a same-sex civil partnership"
-                                    },
-                                    {
-                                        "label": "Divorced",
-                                        "value": "Divorced"
-                                    },
-                                    {
-                                        "label": "Formerly in a same-sex civil partnership which is now legally dissolved",
-                                        "value": "Formerly in a same-sex civil partnership which is now legally dissolved"
-                                    },
-                                    {
-                                        "label": "Widowed",
-                                        "value": "Widowed"
-                                    },
-                                    {
-                                        "label": "Surviving member of a same-sex civil partnership",
-                                        "value": "Surviving member of a same-sex civil partnership"
-                                    }
-                                ]
-                            }]
-                        }]
-                    },
-                    {
-                        "type": "Question",
-                        "id": "nationality",
-                        "questions": [{
-                            "id": "nationality-question",
-                            "title": "What is <em>{{[answers['first-name'][group_instance], answers['last-name'][group_instance]] | format_household_name_possessive}}</em> nationality?",
-                            "type": "General",
-                            "answers": [{
-                                    "id": "nationality-answer",
-                                    "mandatory": false,
-                                    "type": "Radio",
-                                    "options": [{
-                                            "label": "British",
-                                            "value": "British"
-                                        },
-                                        {
-                                            "label": "Irish",
-                                            "value": "Irish"
-                                        },
-                                        {
-                                            "label": "Indian",
-                                            "value": "Indian"
-                                        },
-                                        {
-                                            "label": "Pakistani",
-                                            "value": "Pakistani"
-                                        },
-                                        {
-                                            "label": "Polish",
-                                            "value": "Polish"
-                                        },
-                                        {
-                                            "label": "Other",
-                                            "value": "Other",
-                                            "child_answer_id": "nationality-answer-other"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "id": "nationality-answer-other",
-                                    "parent_answer_id": "nationality-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Please enter nationality"
-                                }
-                            ]
-                        }]
-                    },
-                    {
-                        "type": "Question",
-                        "id": "country-of-birth",
-                        "questions": [{
-                            "id": "country-of-birth-question",
-                            "title": "In which country was <em>{{[answers['first-name'][group_instance], answers['last-name'][group_instance]]|format_household_name}}</em> born?",
-                            "type": "General",
-                            "answers": [{
-                                    "id": "country-of-birth-answer",
-                                    "mandatory": false,
-                                    "type": "Radio",
-                                    "options": [{
-                                            "label": "England",
-                                            "value": "England"
-                                        },
-                                        {
-                                            "label": "Wales",
-                                            "value": "Wales"
-                                        },
-                                        {
-                                            "label": "Scotland",
-                                            "value": "Scotland"
-                                        },
-                                        {
-                                            "label": "Northern Ireland",
-                                            "value": "Northern Ireland"
-                                        },
-                                        {
-                                            "label": "Republic of Ireland",
-                                            "value": "Republic of Ireland"
-                                        },
-                                        {
-                                            "label": "Isle of Man or Channel Islands",
-                                            "value": "Isle of Man or Channel Islands"
-                                        },
-                                        {
-                                            "label": "India",
-                                            "value": "India"
-                                        },
-                                        {
-                                            "label": "Pakistan",
-                                            "value": "Pakistan"
-                                        },
-                                        {
-                                            "label": "Poland",
-                                            "value": "Poland"
-                                        },
-                                        {
-                                            "label": "Other",
-                                            "value": "Other",
-                                            "child_answer_id": "country-of-birth-answer-other"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "id": "country-of-birth-answer-other",
-                                    "parent_answer_id": "country-of-birth-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Please enter country of birth"
-                                }
-                            ]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "national-identity",
-                                    "when": [{
-                                        "id": "country-of-birth-answer",
-                                        "condition": "equals",
-                                        "value": "England"
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "national-identity",
-                                    "when": [{
-                                        "id": "country-of-birth-answer",
-                                        "condition": "equals",
-                                        "value": "Wales"
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "national-identity",
-                                    "when": [{
-                                        "id": "country-of-birth-answer",
-                                        "condition": "equals",
-                                        "value": "Scotland"
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "national-identity",
-                                    "when": [{
-                                        "id": "country-of-birth-answer",
-                                        "condition": "equals",
-                                        "value": "Northern Ireland"
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "national-identity",
-                                    "when": [{
-                                        "id": "country-of-birth-answer",
-                                        "condition": "not set"
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "arrive-in-uk"
-                                }
-                            }
-                        ]
-                    },
-                    {
-                        "type": "Question",
-                        "id": "arrive-in-uk",
-                        "questions": [{
-                            "id": "arrive-in-uk-question",
-                            "title": "When did <em>{{[answers['first-name'][group_instance], answers['last-name'][group_instance]] | format_household_name}}</em> first arrive to live in the UK?",
-                            "type": "General",
-                            "answers": [{
-                                "id": "arrive-in-uk-answer",
-                                "mandatory": false,
-                                "type": "MonthYearDate",
-                                "maximum": {
-                                    "value": "now"
-                                }
-                            }]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "arrive-date-in-uk-invalid",
-                                    "when": [{
-                                        "id": "arrive-in-uk-answer",
-                                        "condition": "greater than",
-                                        "date_comparison": {
-                                            "value": "now"
-                                        }
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "arrive-date-in-uk-invalid",
-                                    "when": [{
-                                        "id": "arrive-in-uk-answer",
-                                        "condition": "less than",
-                                        "date_comparison": {
-                                            "id": "date-of-birth-answer"
-                                        }
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "national-identity",
-                                    "when": [{
-                                        "id": "arrive-in-uk-answer",
-                                        "condition": "not set"
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "continuous-in-uk"
-                                }
-                            }
-                        ]
-                    },
-                    {
-                        "type": "Question",
-                        "id": "arrive-date-in-uk-invalid",
-                        "questions": [{
-                            "id": "arrive-date-in-uk-invalid-question",
-                            "title": "Invalid date entered",
-                            "description": "The date <em>{{[answers['first-name'][group_instance], answers['last-name'][group_instance]] | format_household_name}}</em> first arrived in the UK must be after their date of birth and not in the future.",
-                            "guidance": {
-                                "content": [{
-                                    "description": "Correct either their date of birth or the date they arrived in the UK."
-                                }]
-                            },
-                            "type": "General",
-                            "answers": [{
-                                "id": "arrive-date-in-uk-invalid-answer",
-                                "mandatory": true,
-                                "type": "Radio",
-                                "options": [{
-                                        "label": "I&apos;d like to correct their date of birth",
-                                        "value": "change dob"
-                                    },
-                                    {
-                                        "label": "I&apos;d like to correct their date of arrival in the UK",
-                                        "value": "change arrival"
-                                    }
-                                ]
-                            }]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "date-of-birth",
-                                    "when": [{
-                                        "id": "arrive-date-in-uk-invalid-answer",
-                                        "condition": "equals",
-                                        "value": "change dob"
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "arrive-in-uk",
-                                    "when": [{
-                                        "id": "arrive-date-in-uk-invalid-answer",
-                                        "condition": "equals",
-                                        "value": "change arrival"
-                                    }]
-                                }
-                            }
-                        ]
-                    },
-                    {
-                        "type": "Question",
-                        "id": "continuous-in-uk",
-                        "questions": [{
-                            "id": "continuous-in-uk-question",
-                            "title": "Apart from holidays and short visits abroad, has <em>{{[answers['first-name'][group_instance], answers['last-name'][group_instance]] | format_household_name}}</em> lived in the UK continuously since {{ answers['arrive-in-uk-answer'][group_instance]|format_date }}?",
-                            "type": "General",
-                            "answers": [{
-                                "id": "continuous-in-uk-answer",
-                                "mandatory": false,
-                                "type": "Radio",
-                                "options": [{
-                                        "label": "Yes",
-                                        "value": "Yes"
-                                    },
-                                    {
-                                        "label": "No",
-                                        "value": "No"
-                                    }
-                                ]
-                            }]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "national-identity",
-                                    "when": [{
-                                            "id": "continuous-in-uk-answer",
-                                            "condition": "equals",
-                                            "value": "Yes"
-                                        },
-                                        {
-                                            "id": "date-of-birth-answer",
-                                            "condition": "greater than",
-                                            "date_comparison": {
-                                                "value": "now",
-                                                "offset_by": {
-                                                    "years": -16
-                                                }
-                                            }
-                                        }
-                                    ]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "why-uk-continuous",
-                                    "when": [{
-                                            "id": "continuous-in-uk-answer",
-                                            "condition": "equals",
-                                            "value": "Yes"
-                                        },
-                                        {
-                                            "id": "date-of-birth-answer",
-                                            "condition": "less than",
-                                            "date_comparison": {
-                                                "value": "now",
-                                                "offset_by": {
-                                                    "years": -16
-                                                }
-                                            }
-                                        }
-                                    ]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "why-uk-continuous",
-                                    "when": [{
-                                            "id": "continuous-in-uk-answer",
-                                            "condition": "equals",
-                                            "value": "Yes"
-                                        },
-                                        {
-                                            "id": "date-of-birth-answer",
-                                            "condition": "not set"
-                                        }
-                                    ]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "camyr2-block",
-                                    "when": [{
-                                        "id": "continuous-in-uk-answer",
-                                        "condition": "equals",
-                                        "value": "No"
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "national-identity"
-                                }
-                            }
-                        ]
-                    },
-                    {
-                        "type": "Question",
-                        "id": "camyr2-block",
-                        "questions": [{
-                            "id": "camyr2-question",
-                            "title": "When did <em>{{[answers['first-name'][group_instance], answers['last-name'][group_instance]] | format_household_name}}</em> most recently arrive in the United Kingdom?",
-                            "type": "General",
-                            "answers": [{
-                                "id": "first-arrive-in-uk-answer",
-                                "mandatory": false,
-                                "type": "MonthYearDate",
-                                "maximum": {
-                                    "value": "now"
-                                }
-                            }]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "first-arrive-date-in-uk-invalid",
-                                    "when": [{
-                                        "id": "first-arrive-in-uk-answer",
-                                        "condition": "less than",
-                                        "date_comparison": {
-                                            "id": "date-of-birth-answer"
-                                        }
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "national-identity",
-                                    "when": [{
-                                        "id": "first-arrive-in-uk-answer",
-                                        "condition": "not set"
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "why-uk",
-                                    "when": [{
-                                        "id": "date-of-birth-answer",
-                                        "condition": "less than",
-                                        "date_comparison": {
-                                            "value": "now",
-                                            "offset_by": {
-                                                "years": -16
-                                            }
-                                        }
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "why-uk",
-                                    "when": [{
-                                        "id": "date-of-birth-answer",
-                                        "condition": "not set"
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "national-identity"
-                                }
-                            }
-                        ]
-                    },
-                    {
-                        "type": "Question",
-                        "id": "first-arrive-date-in-uk-invalid",
-                        "questions": [{
-                            "id": "first-arrive-date-in-uk-invalid-question",
-                            "title": "Invalid date entered",
-                            "description": "The date <em>{{[answers['first-name'][group_instance], answers['last-name'][group_instance]] | format_household_name}}</em> most recently arrived in the UK must be after their date of birth.",
-                            "guidance": {
-                                "content": [{
-                                    "description": "Correct either their date of birth or the date they most recently arrived in the UK."
-                                }]
-                            },
-                            "type": "General",
-                            "answers": [{
-                                "id": "first-arrive-date-in-uk-invalid-answer",
-                                "mandatory": true,
-                                "type": "Radio",
-                                "options": [{
-                                        "label": "I&apos;d like to correct their date of birth",
-                                        "value": "change dob"
-                                    },
-                                    {
-                                        "label": "I&apos;d like to correct the date they most recently arrived in the UK",
-                                        "value": "change first arrival"
-                                    }
-                                ]
-                            }]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "date-of-birth",
-                                    "when": [{
-                                        "id": "first-arrive-date-in-uk-invalid-answer",
-                                        "condition": "equals",
-                                        "value": "change dob"
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "camyr2-block",
-                                    "when": [{
-                                        "id": "first-arrive-date-in-uk-invalid-answer",
-                                        "condition": "equals",
-                                        "value": "change first arrival"
-                                    }]
-                                }
-                            }
-                        ]
-                    },
-                    {
-                        "type": "Question",
-                        "id": "why-uk",
-                        "questions": [{
-                            "id": "why-uk-question",
-                            "title": "What was <em>{{[answers['first-name'][group_instance], answers['last-name'][group_instance]] | format_household_name_possessive}}</em> main reason for coming to the UK in {{ max_value(answers['arrive-in-uk-answer'][group_instance], answers['first-arrive-in-uk-answer'][group_instance])|format_date }}?",
-                            "type": "General",
-                            "answers": [{
-                                "id": "why-uk-answer",
-                                "mandatory": false,
-                                "type": "Radio",
-                                "options": [{
-                                        "label": "For employment",
-                                        "value": "For employment"
-                                    },
-                                    {
-                                        "label": "For study",
-                                        "value": "For study"
-                                    },
-                                    {
-                                        "label": "As a spouse or dependent of a UK citizen or settled person",
-                                        "value": "As a spouse or dependent of a UK citizen or settled person"
-                                    },
-                                    {
-                                        "label": "As a spouse or dependent of someone who is coming to or is already in the UK for work or study reasons",
-                                        "value": "As a spouse or dependent of someone who is coming to or is already in the UK for work or study reasons"
-                                    },
-                                    {
-                                        "label": "To get married or form a civil partnership in the UK with a non-UK citizen",
-                                        "value": "To get married or form a civil partnership in the UK with a non-UK citizen"
-                                    },
-                                    {
-                                        "label": "Seeking asylum",
-                                        "value": "Seeking asylum"
-                                    },
-                                    {
-                                        "label": "As a visitor",
-                                        "value": "As a visitor"
-                                    },
-                                    {
-                                        "label": "Another reason",
-                                        "value": "Another reason"
-                                    }
-                                ]
-                            }]
-                        }],
-                        "routing_rules": [{
-                            "goto": {
-                                "block": "national-identity"
-                            }
-                        }]
-                    },
-                    {
-                        "type": "Question",
-                        "id": "why-uk-continuous",
-                        "questions": [{
-                            "id": "why-uk-continuous-question",
-                            "title": "What was <em>{{[answers['first-name'][group_instance], answers['last-name'][group_instance]] | format_household_name_possessive}}</em> main reason for coming to the UK in {{ answers['arrive-in-uk-answer'][group_instance]|format_date }}?",
-                            "type": "General",
-                            "answers": [{
-                                "id": "why-uk-continuous-answer",
-                                "mandatory": false,
-                                "type": "Radio",
-                                "options": [{
-                                        "label": "For employment",
-                                        "value": "For employment"
-                                    },
-                                    {
-                                        "label": "For study",
-                                        "value": "For study"
-                                    },
-                                    {
-                                        "label": "As a spouse or dependent of a UK citizen or settled person",
-                                        "value": "As a spouse or dependent of a UK citizen or settled person"
-                                    },
-                                    {
-                                        "label": "As a spouse or dependent of someone who is coming to or is already in the UK for work or study reasons",
-                                        "value": "As a spouse or dependent of someone who is coming to or is already in the UK for work or study reasons"
-                                    },
-                                    {
-                                        "label": "To get married or form a civil partnership in the UK with a non-UK citizen",
-                                        "value": "To get married or form a civil partnership in the UK with a non-UK citizen"
-                                    },
-                                    {
-                                        "label": "Seeking asylum",
-                                        "value": "Seeking asylum"
-                                    },
-                                    {
-                                        "label": "As a visitor",
-                                        "value": "As a visitor"
-                                    },
-                                    {
-                                        "label": "Another reason",
-                                        "value": "Another reason"
-                                    }
-                                ]
-                            }]
-                        }],
-                        "routing_rules": [{
-                            "goto": {
-                                "block": "national-identity"
-                            }
-                        }]
-                    },
-                    {
-                        "type": "Question",
-                        "id": "national-identity",
-                        "questions": [{
-                                "id": "national-identity-england-question",
-                                "title": "What does <em>{{[answers['first-name'][group_instance], answers['last-name'][group_instance]]|format_household_name}}</em> consider their national identity to be?",
-                                "type": "General",
-                                "answers": [{
-                                        "id": "national-identity-england-answer",
-                                        "mandatory": false,
-                                        "type": "Checkbox",
-                                        "options": [{
-                                                "label": "English",
-                                                "value": "English"
-                                            },
-                                            {
-                                                "label": "Welsh",
-                                                "value": "Welsh"
-                                            },
-                                            {
-                                                "label": "Scottish",
-                                                "value": "Scottish"
-                                            },
-                                            {
-                                                "label": "Northern Irish",
-                                                "value": "Northern Irish"
-                                            },
-                                            {
-                                                "label": "British",
-                                                "value": "British"
-                                            },
-                                            {
-                                                "label": "Other",
-                                                "value": "Other",
-                                                "child_answer_id": "national-identity-england-answer-other"
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        "id": "national-identity-england-answer-other",
-                                        "parent_answer_id": "national-identity-england-answer",
-                                        "type": "TextField",
-                                        "mandatory": false,
-                                        "label": "Please enter national identity"
-                                    }
-                                ],
-                                "skip_conditions": [{
-                                    "when": [{
-                                        "meta": "region_code",
-                                        "condition": "equals",
-                                        "value": "GB-WLS"
-                                    }]
-                                }]
-                            },
-                            {
-                                "id": "national-identity-wales-question",
-                                "title": "What does <em>{{[answers['first-name'][group_instance], answers['last-name'][group_instance]]|format_household_name}}</em> consider their national identity to be?",
-                                "type": "General",
-                                "answers": [{
-                                        "id": "national-identity-wales-answer",
-                                        "mandatory": false,
-                                        "type": "Checkbox",
-                                        "options": [{
-                                                "label": "Welsh",
-                                                "value": "Welsh"
-                                            },
-                                            {
-                                                "label": "English",
-                                                "value": "English"
-                                            },
-                                            {
-                                                "label": "Scottish",
-                                                "value": "Scottish"
-                                            },
-                                            {
-                                                "label": "Northern Irish",
-                                                "value": "Northern Irish"
-                                            },
-                                            {
-                                                "label": "British",
-                                                "value": "British"
-                                            },
-                                            {
-                                                "label": "Other",
-                                                "value": "Other",
-                                                "child_answer_id": "national-identity-wales-answer-other"
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        "id": "national-identity-wales-answer-other",
-                                        "parent_answer_id": "national-identity-wales-answer",
-                                        "type": "TextField",
-                                        "mandatory": false,
-                                        "label": "Please enter national identity"
-                                    }
-                                ],
-                                "skip_conditions": [{
-                                    "when": [{
-                                        "meta": "region_code",
-                                        "condition": "not equals",
-                                        "value": "GB-WLS"
-                                    }]
-                                }]
-                            }
-                        ],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "understand-welsh",
-                                    "when": [{
-                                        "meta": "region_code",
-                                        "condition": "equals",
-                                        "value": "GB-WLS"
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "ethnic-group"
-                                }
-                            }
-                        ]
-                    },
-                    {
-                        "type": "Question",
-                        "id": "understand-welsh",
-                        "questions": [{
-                            "id": "understand-welsh-question",
-                            "title": "Can <em>{{[answers['first-name'][group_instance], answers['last-name'][group_instance]] | format_household_name}}</em>...",
-                            "type": "General",
-                            "answers": [{
-                                "id": "understand-welsh-answer",
-                                "mandatory": false,
-                                "type": "Checkbox",
-                                "options": [{
-                                        "label": "Understand spoken Welsh",
-                                        "value": "Understand spoken Welsh"
-                                    },
-                                    {
-                                        "label": "Read Welsh",
-                                        "value": "Read Welsh"
-                                    },
-                                    {
-                                        "label": "Write in Welsh",
-                                        "value": "Write in Welsh"
-                                    },
-                                    {
-                                        "label": "Speak Welsh",
-                                        "value": "Speak Welsh"
-                                    },
-                                    {
-                                        "label": "None of the above",
-                                        "value": "None of the above"
-                                    }
-                                ]
-                            }]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "welsh-frequency",
-                                    "when": [{
-                                        "id": "understand-welsh-answer",
-                                        "condition": "contains",
-                                        "value": "Speak Welsh"
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "ethnic-group"
-                                }
-                            }
-                        ]
-                    },
-                    {
-                        "type": "Question",
-                        "id": "welsh-frequency",
-                        "questions": [{
-                            "id": "welsh-frequency-question",
-                            "title": "How often does <em>{{[answers['first-name'][group_instance], answers['last-name'][group_instance]] | format_household_name}}</em> speak Welsh?",
-                            "type": "General",
-                            "answers": [{
-                                "id": "welsh-frequency-answer",
-                                "mandatory": false,
-                                "type": "Radio",
-                                "options": [{
-                                        "label": "Daily",
-                                        "value": "Daily"
-                                    },
-                                    {
-                                        "label": "Weekly",
-                                        "value": "Weekly"
-                                    },
-                                    {
-                                        "label": "Less often",
-                                        "value": "Less often"
-                                    },
-                                    {
-                                        "label": "Never",
-                                        "value": "Never"
-                                    }
-                                ]
-                            }]
-                        }]
-                    },
-                    {
-                        "type": "Question",
-                        "id": "ethnic-group",
-                        "questions": [{
-                            "id": "ethnic-group-question",
-                            "title": "What is <em>{{[answers['first-name'][group_instance], answers['last-name'][group_instance]] | format_household_name_possessive}}</em> ethnic group?",
-                            "type": "General",
-                            "answers": [{
-                                "id": "ethnic-group-answer",
-                                "mandatory": false,
-                                "type": "Radio",
-                                "options": [{
-                                        "label": "White",
-                                        "value": "White",
-                                        "description": "Includes any White background"
-                                    },
-                                    {
-                                        "label": "Mixed or multiple ethnic groups",
-                                        "value": "Mixed or multiple ethnic groups",
-                                        "description": "Includes White and Black Caribbean, White and Black African, White and Asian or any other Mixed ethnic group"
-                                    },
-                                    {
-                                        "label": "Asian or Asian British",
-                                        "value": "Asian or Asian British",
-                                        "description": "Includes Indian, Pakistani, Bangladeshi, Chinese or any other Asian background"
-                                    },
-                                    {
-                                        "label": "Black, African, Caribbean or Black British",
-                                        "value": "Black, African, Caribbean or Black British",
-                                        "description": "Includes African, Caribbean or any other Black background"
-                                    },
-                                    {
-                                        "label": "Other",
-                                        "value": "Other",
-                                        "description": "For example Arab or any other background"
-                                    }
-                                ]
-                            }]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "white-ethnic-group",
-                                    "when": [{
-                                        "id": "ethnic-group-answer",
-                                        "condition": "equals",
-                                        "value": "White"
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "mixed-ethnic-group",
-                                    "when": [{
-                                        "id": "ethnic-group-answer",
-                                        "condition": "equals",
-                                        "value": "Mixed or multiple ethnic groups"
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "asian-ethnic-group",
-                                    "when": [{
-                                        "id": "ethnic-group-answer",
-                                        "condition": "equals",
-                                        "value": "Asian or Asian British"
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "black-ethnic-group",
-                                    "when": [{
-                                        "id": "ethnic-group-answer",
-                                        "condition": "equals",
-                                        "value": "Black, African, Caribbean or Black British"
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "other-ethnic-group",
-                                    "when": [{
-                                        "id": "ethnic-group-answer",
-                                        "condition": "equals",
-                                        "value": "Other"
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "religion"
-                                }
-                            }
-                        ]
-                    },
-                    {
-                        "type": "Question",
-                        "id": "white-ethnic-group",
-                        "questions": [{
-                            "id": "white-ethnic-group-question",
-                            "title": "Which one best describes <em>{{[answers['first-name'][group_instance], answers['last-name'][group_instance]] | format_household_name_possessive}}</em> White ethnic group or background?",
-                            "type": "General",
-                            "answers": [{
-                                    "id": "white-ethnic-group-answer",
-                                    "mandatory": false,
-                                    "options": [{
-                                            "label": "English, Welsh, Scottish, Northern Irish or British",
-                                            "value": "English, Welsh, Scottish, Northern Irish or British"
-                                        },
-                                        {
-                                            "label": "Irish",
-                                            "value": "Irish"
-                                        },
-                                        {
-                                            "label": "Gypsy or Irish Traveller",
-                                            "value": "Gypsy or Irish Traveller"
-                                        },
-                                        {
-                                            "label": "Any other White background",
-                                            "value": "Other",
-                                            "child_answer_id": "white-ethnic-group-answer-other"
-                                        }
-                                    ],
-                                    "type": "Radio"
-                                },
-                                {
-                                    "id": "white-ethnic-group-answer-other",
-                                    "parent_answer_id": "white-ethnic-group-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Please enter ethnic background"
-                                }
-                            ]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "household-member-completed",
-                                    "when": [{
-                                        "id": "date-of-birth-answer",
-                                        "condition": "greater than",
-                                        "date_comparison": {
-                                            "value": "now",
-                                            "offset_by": {
-                                                "years": -16
-                                            }
-                                        }
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "religion"
-                                }
-                            }
-                        ]
-                    },
-                    {
-                        "type": "Question",
-                        "id": "mixed-ethnic-group",
-                        "questions": [{
-                            "id": "mixed-ethnic-group-question",
-                            "title": "Which one best describes <em>{{[answers['first-name'][group_instance], answers['last-name'][group_instance]] | format_household_name_possessive}}</em> Mixed, multiple ethnic group or background?",
-                            "type": "General",
-                            "answers": [{
-                                    "id": "mixed-ethnic-group-answer",
-                                    "mandatory": false,
-                                    "options": [{
-                                            "label": "White and Black Caribbean",
-                                            "value": "White and Black Caribbean"
-                                        },
-                                        {
-                                            "label": "White and Black African",
-                                            "value": "White and Black African"
-                                        },
-                                        {
-                                            "label": "White and Asian",
-                                            "value": "White and Asian"
-                                        },
-                                        {
-                                            "label": "Any other Mixed or multiple ethnic background",
-                                            "value": "Other",
-                                            "child_answer_id": "mixed-ethnic-group-answer-other"
-                                        }
-                                    ],
-                                    "type": "Radio"
-                                },
-                                {
-                                    "id": "mixed-ethnic-group-answer-other",
-                                    "parent_answer_id": "mixed-ethnic-group-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Please enter ethnic background"
-                                }
-                            ]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "household-member-completed",
-                                    "when": [{
-                                        "id": "date-of-birth-answer",
-                                        "condition": "greater than",
-                                        "date_comparison": {
-                                            "value": "now",
-                                            "offset_by": {
-                                                "years": -16
-                                            }
-                                        }
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "religion"
-                                }
-                            }
-                        ]
-                    },
-                    {
-                        "type": "Question",
-                        "id": "asian-ethnic-group",
-                        "questions": [{
-                            "id": "asian-ethnic-group-question",
-                            "title": "Which one best describes <em>{{[answers['first-name'][group_instance], answers['last-name'][group_instance]] | format_household_name_possessive}}</em> Asian, Asian British ethnic group or background?",
-                            "type": "General",
-                            "answers": [{
-                                    "id": "asian-ethnic-group-answer",
-                                    "mandatory": false,
-                                    "options": [{
-                                            "label": "Indian",
-                                            "value": "Indian"
-                                        },
-                                        {
-                                            "label": "Pakistani",
-                                            "value": "Pakistani"
-                                        },
-                                        {
-                                            "label": "Bangladeshi",
-                                            "value": "Bangladeshi"
-                                        },
-                                        {
-                                            "label": "Chinese",
-                                            "value": "Chinese"
-                                        },
-                                        {
-                                            "label": "Any other Asian background",
-                                            "value": "Other",
-                                            "child_answer_id": "asian-ethnic-group-answer-other"
-                                        }
-                                    ],
-                                    "type": "Radio"
-                                },
-                                {
-                                    "id": "asian-ethnic-group-answer-other",
-                                    "parent_answer_id": "asian-ethnic-group-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Please enter ethnic background"
-                                }
-                            ]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "household-member-completed",
-                                    "when": [{
-                                        "id": "date-of-birth-answer",
-                                        "condition": "greater than",
-                                        "date_comparison": {
-                                            "value": "now",
-                                            "offset_by": {
-                                                "years": -16
-                                            }
-                                        }
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "religion"
-                                }
-                            }
-                        ]
-                    },
-                    {
-                        "type": "Question",
-                        "id": "black-ethnic-group",
-                        "questions": [{
-                            "id": "black-ethnic-group-question",
-                            "title": "Which one best describes <em>{{[answers['first-name'][group_instance], answers['last-name'][group_instance]] | format_household_name_possessive}}</em> Black, African, Caribbean, Black British ethnic group or background?",
-                            "type": "General",
-                            "answers": [{
-                                    "id": "black-ethnic-group-answer",
-                                    "mandatory": false,
-                                    "options": [{
-                                            "label": "African",
-                                            "value": "African"
-                                        },
-                                        {
-                                            "label": "Caribbean",
-                                            "value": "Caribbean"
-                                        },
-                                        {
-                                            "label": "Any other Black, African or Caribbean background",
-                                            "value": "Other",
-                                            "child_answer_id": "black-ethnic-group-answer-other"
-                                        }
-                                    ],
-                                    "type": "Radio"
-                                },
-                                {
-                                    "id": "black-ethnic-group-answer-other",
-                                    "parent_answer_id": "black-ethnic-group-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Please enter ethnic background"
-                                }
-                            ]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "household-member-completed",
-                                    "when": [{
-                                        "id": "date-of-birth-answer",
-                                        "condition": "greater than",
-                                        "date_comparison": {
-                                            "value": "now",
-                                            "offset_by": {
-                                                "years": -16
-                                            }
-                                        }
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "religion"
-                                }
-                            }
-                        ]
-                    },
-                    {
-                        "type": "Question",
-                        "id": "other-ethnic-group",
-                        "questions": [{
-                            "id": "other-ethnic-group-question",
-                            "title": "Which one best describes <em>{{[answers['first-name'][group_instance], answers['last-name'][group_instance]] | format_household_name_possessive}}</em> Other ethnic group or background?",
-                            "type": "General",
-                            "answers": [{
-                                    "id": "other-ethnic-group-answer",
-                                    "mandatory": false,
-                                    "options": [{
-                                            "label": "Arab",
-                                            "value": "Arab"
-                                        },
-                                        {
-                                            "label": "Any other ethnic group",
-                                            "value": "Other",
-                                            "child_answer_id": "other-ethnic-group-answer-other"
-                                        }
-                                    ],
-                                    "type": "Radio"
-                                },
-                                {
-                                    "id": "other-ethnic-group-answer-other",
-                                    "parent_answer_id": "other-ethnic-group-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Please enter ethnic background"
-                                }
-                            ]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "household-member-completed",
-                                    "when": [{
-                                        "id": "date-of-birth-answer",
-                                        "condition": "greater than",
-                                        "date_comparison": {
-                                            "value": "now",
-                                            "offset_by": {
-                                                "years": -16
-                                            }
-                                        }
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "religion"
-                                }
-                            }
-                        ]
-                    },
-                    {
-                        "type": "Question",
-                        "id": "religion",
-                        "questions": [{
-                            "id": "religion-question",
-                            "title": "What is <em>{{[answers['first-name'][group_instance], answers['last-name'][group_instance]] | format_household_name_possessive}}</em> religion?",
-                            "description": "",
-                            "type": "General",
-                            "answers": [{
-                                    "id": "religion-answer",
-                                    "mandatory": false,
-                                    "type": "Radio",
-                                    "options": [{
-                                            "label": "No religion",
-                                            "value": "No religion"
-                                        },
-                                        {
-                                            "label": "Christian",
-                                            "value": "Christian",
-                                            "description": "Including Church of England, Catholic, Protestant and other Christian denominations"
-                                        },
-                                        {
-                                            "label": "Buddhist",
-                                            "value": "Buddhist"
-                                        },
-                                        {
-                                            "label": "Hindu",
-                                            "value": "Hindu"
-                                        },
-                                        {
-                                            "label": "Jewish",
-                                            "value": "Jewish"
-                                        },
-                                        {
-                                            "label": "Muslim",
-                                            "value": "Muslim"
-                                        },
-                                        {
-                                            "label": "Sikh",
-                                            "value": "Sikh"
-                                        },
-                                        {
-                                            "label": "Other religion",
-                                            "value": "Other",
-                                            "child_answer_id": "religion-answer-other"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "id": "religion-answer-other",
-                                    "parent_answer_id": "religion-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Please enter religion"
-                                }
-                            ]
-                        }],
-                        "routing_rules": [{
-                            "goto": {
-                                "block": "household-member-completed"
-                            }
-                        }]
-                    },
-                    {
-                        "type": "Question",
-                        "id": "date-of-birth-no-proxy",
-                        "questions": [{
-                            "id": "date-of-birth-question-np",
-                            "title": "What is your date of birth?",
-                            "type": "General",
-                            "answers": [{
-                                "id": "date-of-birth-answer-np",
-                                "mandatory": false,
-                                "type": "Date",
-                                "maximum": {
-                                    "value": "now"
-                                }
-                            }]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "date-of-birth-check-np",
-                                    "when": [{
-                                        "id": "date-of-birth-answer-np",
-                                        "condition": "not set"
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "sex-np"
-                                }
-                            }
-                        ]
-                    },
-                    {
-                        "type": "ConfirmationQuestion",
-                        "id": "date-of-birth-check-np",
-                        "questions": [{
-                            "id": "dob-check-question-np",
-                            "title": "Are you aged 16 or over?",
-                            "type": "General",
-                            "answers": [{
-                                "id": "dob-check-answer-np",
-                                "mandatory": false,
-                                "type": "Radio",
-                                "options": [{
-                                        "label": "Yes",
-                                        "value": "Yes"
-                                    },
-                                    {
-                                        "label": "No",
-                                        "value": "No"
-                                    }
-                                ]
-                            }]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "household-member-completed",
-                                    "when": [{
-                                        "id": "dob-check-answer-np",
-                                        "condition": "equals",
-                                        "value": "No"
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "household-member-completed",
-                                    "when": [{
-                                        "id": "dob-check-answer-np",
-                                        "condition": "not set"
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "sex-np"
-                                }
-                            }
-                        ]
-                    },
-                    {
-                        "type": "Question",
-                        "id": "sex-np",
-                        "questions": [{
-                            "id": "sex-question-np",
-                            "title": "What is your sex?",
-                            "type": "General",
-                            "answers": [{
-                                "id": "sex-answer-np",
-                                "mandatory": true,
-                                "type": "Radio",
-                                "options": [{
-                                        "label": "Male",
-                                        "value": "Male"
-                                    },
-                                    {
-                                        "label": "Female",
-                                        "value": "Female"
-                                    }
-                                ]
-                            }]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "marital-status-no-proxy",
-                                    "when": [{
-                                        "id": "date-of-birth-answer-np",
-                                        "condition": "less than",
-                                        "date_comparison": {
-                                            "value": "now",
-                                            "offset_by": {
-                                                "years": -16
-                                            }
-                                        }
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "marital-status-no-proxy",
-                                    "when": [{
-                                        "id": "date-of-birth-answer-np",
-                                        "condition": "not set"
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "nationality-no-proxy"
-                                }
-                            }
-                        ]
-                    },
-                    {
-                        "type": "Question",
-                        "id": "marital-status-no-proxy",
-                        "questions": [{
-                            "id": "marital-status-question-np",
-                            "title": "What is your legal marital status?",
-                            "type": "General",
-                            "answers": [{
-                                "id": "marital-status-answer-np",
-                                "mandatory": false,
-                                "type": "Radio",
-                                "options": [{
-                                        "label": "Never married",
-                                        "value": "Never married"
-                                    },
-                                    {
-                                        "label": "Married",
-                                        "value": "Married"
-                                    },
-                                    {
-                                        "label": "In a registered same-sex civil partnership",
-                                        "value": "In a registered same-sex civil partnership"
-                                    },
-                                    {
-                                        "label": "Separated, but still legally married",
-                                        "value": "Separated, but still legally married"
-                                    },
-                                    {
-                                        "label": "Separated, but still legally in a same-sex civil partnership",
-                                        "value": "Separated, but still legally in a same-sex civil partnership"
-                                    },
-                                    {
-                                        "label": "Divorced",
-                                        "value": "Divorced"
-                                    },
-                                    {
-                                        "label": "Formerly in a same-sex civil partnership which is now legally dissolved",
-                                        "value": "Formerly in a same-sex civil partnership which is now legally dissolved"
-                                    },
-                                    {
-                                        "label": "Widowed",
-                                        "value": "Widowed"
-                                    },
-                                    {
-                                        "label": "Surviving member of a same-sex civil partnership",
-                                        "value": "Surviving member of a same-sex civil partnership"
-                                    }
-                                ]
-                            }]
-                        }]
-                    },
-                    {
-                        "type": "Question",
-                        "id": "nationality-no-proxy",
-                        "questions": [{
-                            "id": "nationality-question-np",
-                            "title": "What is your nationality?",
-                            "type": "General",
-                            "answers": [{
-                                    "id": "nationality-answer-np",
-                                    "mandatory": false,
-                                    "type": "Radio",
-                                    "options": [{
-                                            "label": "British",
-                                            "value": "British"
-                                        },
-                                        {
-                                            "label": "Irish",
-                                            "value": "Irish"
-                                        },
-                                        {
-                                            "label": "Indian",
-                                            "value": "Indian"
-                                        },
-                                        {
-                                            "label": "Pakistani",
-                                            "value": "Pakistani"
-                                        },
-                                        {
-                                            "label": "Polish",
-                                            "value": "Polish"
-                                        },
-                                        {
-                                            "label": "Other",
-                                            "value": "Other",
-                                            "child_answer_id": "nationality-answer-other-np"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "id": "nationality-answer-other-np",
-                                    "parent_answer_id": "nationality-answer-np",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Please enter nationality"
-                                }
-                            ]
-                        }]
-                    },
-                    {
-                        "type": "Question",
-                        "id": "country-of-birth-no-proxy",
-                        "questions": [{
-                            "id": "country-of-birth-question-np",
-                            "title": "In which country were you born?",
-                            "type": "General",
-                            "answers": [{
-                                    "id": "country-of-birth-answer-np",
-                                    "mandatory": false,
-                                    "type": "Radio",
-                                    "options": [{
-                                            "label": "England",
-                                            "value": "England"
-                                        },
-                                        {
-                                            "label": "Wales",
-                                            "value": "Wales"
-                                        },
-                                        {
-                                            "label": "Scotland",
-                                            "value": "Scotland"
-                                        },
-                                        {
-                                            "label": "Northern Ireland",
-                                            "value": "Northern Ireland"
-                                        },
-                                        {
-                                            "label": "Republic of Ireland",
-                                            "value": "Republic of Ireland"
-                                        },
-                                        {
-                                            "label": "Isle of Man or Channel Islands",
-                                            "value": "Isle of Man or Channel Islands"
-                                        },
-                                        {
-                                            "label": "India",
-                                            "value": "India"
-                                        },
-                                        {
-                                            "label": "Pakistan",
-                                            "value": "Pakistan"
-                                        },
-                                        {
-                                            "label": "Poland",
-                                            "value": "Poland"
-                                        },
-                                        {
-                                            "label": "Other",
-                                            "value": "Other",
-                                            "child_answer_id": "country-of-birth-answer-other-np"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "id": "country-of-birth-answer-other-np",
-                                    "parent_answer_id": "country-of-birth-answer-np",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Please enter your country of birth"
-                                }
-                            ]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "national-identity-no-proxy",
-                                    "when": [{
-                                        "id": "country-of-birth-answer-np",
-                                        "condition": "equals",
-                                        "value": "England"
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "national-identity-no-proxy",
-                                    "when": [{
-                                        "id": "country-of-birth-answer-np",
-                                        "condition": "equals",
-                                        "value": "Wales"
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "national-identity-no-proxy",
-                                    "when": [{
-                                        "id": "country-of-birth-answer-np",
-                                        "condition": "equals",
-                                        "value": "Scotland"
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "national-identity-no-proxy",
-                                    "when": [{
-                                        "id": "country-of-birth-answer-np",
-                                        "condition": "equals",
-                                        "value": "Northern Ireland"
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "national-identity-no-proxy",
-                                    "when": [{
-                                        "id": "country-of-birth-answer-np",
-                                        "condition": "not set"
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "arrive-in-uk-no-proxy"
-                                }
-                            }
-                        ]
-                    },
-                    {
-                        "type": "Question",
-                        "id": "arrive-in-uk-no-proxy",
-                        "questions": [{
-                            "id": "arrive-in-uk-question-np",
-                            "title": "When did you first arrive to live in the UK?",
-                            "type": "General",
-                            "answers": [{
-                                "id": "arrive-in-uk-answer-np",
-                                "mandatory": false,
-                                "type": "MonthYearDate",
-                                "maximum": {
-                                    "value": "now"
-                                }
-                            }]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "arrive-date-in-uk-invalid-no-proxy",
-                                    "when": [{
-                                        "id": "arrive-in-uk-answer-np",
-                                        "condition": "greater than",
-                                        "date_comparison": {
-                                            "value": "now"
-                                        }
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "arrive-date-in-uk-invalid-no-proxy",
-                                    "when": [{
-                                        "id": "arrive-in-uk-answer-np",
-                                        "condition": "less than",
-                                        "date_comparison": {
-                                            "id": "date-of-birth-answer-np"
-                                        }
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "national-identity-no-proxy",
-                                    "when": [{
-                                        "id": "arrive-in-uk-answer-np",
-                                        "condition": "not set"
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "continuous-in-uk-no-proxy"
-                                }
-                            }
-                        ]
-                    },
-                    {
-                        "type": "Question",
-                        "id": "arrive-date-in-uk-invalid-no-proxy",
-                        "questions": [{
-                            "id": "arrive-date-in-uk-invalid-question-np",
-                            "title": "Invalid date entered",
-                            "description": "The date you first arrived in the UK must be after your date of birth and not in the future.",
-                            "guidance": {
-                                "content": [{
-                                    "description": "Correct either your date of birth or the date you arrived in the UK."
-                                }]
-                            },
-                            "type": "General",
-                            "answers": [{
-                                "id": "arrive-date-in-uk-invalid-answer-np",
-                                "mandatory": true,
-                                "type": "Radio",
-                                "options": [{
-                                        "label": "I&apos;d like to correct my date of birth",
-                                        "value": "change dob"
-                                    },
-                                    {
-                                        "label": "I&apos;d like to correct my date of arrival in the UK",
-                                        "value": "change arrival"
-                                    }
-                                ]
-                            }]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "date-of-birth-no-proxy",
-                                    "when": [{
-                                        "id": "arrive-date-in-uk-invalid-answer-np",
-                                        "condition": "equals",
-                                        "value": "change dob"
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "arrive-in-uk-no-proxy",
-                                    "when": [{
-                                        "id": "arrive-date-in-uk-invalid-answer-np",
-                                        "condition": "equals",
-                                        "value": "change arrival"
-                                    }]
-                                }
-                            }
-                        ]
-                    },
-                    {
-                        "type": "Question",
-                        "id": "continuous-in-uk-no-proxy",
-                        "questions": [{
-                            "id": "continuous-in-uk-question-np",
-                            "title": "Apart from holidays and short visits abroad, have you lived in the UK continuously since {{answers['arrive-in-uk-answer-np'][group_instance]|format_date}}?",
-                            "type": "General",
-                            "answers": [{
-                                "id": "continuous-in-uk-answer-np",
-                                "mandatory": false,
-                                "type": "Radio",
-                                "options": [{
-                                        "label": "Yes",
-                                        "value": "Yes"
-                                    },
-                                    {
-                                        "label": "No",
-                                        "value": "No"
-                                    }
-                                ]
-                            }]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "national-identity-no-proxy",
-                                    "when": [{
-                                            "id": "continuous-in-uk-answer-np",
-                                            "condition": "equals",
-                                            "value": "Yes"
-                                        },
-                                        {
-                                            "id": "date-of-birth-answer-np",
-                                            "condition": "greater than",
-                                            "date_comparison": {
-                                                "value": "now",
-                                                "offset_by": {
-                                                    "years": -16
-                                                }
-                                            }
-                                        }
-                                    ]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "why-uk-continuous-no-proxy",
-                                    "when": [{
-                                            "id": "continuous-in-uk-answer-np",
-                                            "condition": "equals",
-                                            "value": "Yes"
-                                        },
-                                        {
-                                            "id": "date-of-birth-answer-np",
-                                            "condition": "less than",
-                                            "date_comparison": {
-                                                "value": "now",
-                                                "offset_by": {
-                                                    "years": -16
-                                                }
-                                            }
-                                        }
-                                    ]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "why-uk-continuous-no-proxy",
-                                    "when": [{
-                                            "id": "continuous-in-uk-answer-np",
-                                            "condition": "equals",
-                                            "value": "Yes"
-                                        },
-                                        {
-                                            "id": "date-of-birth-answer-np",
-                                            "condition": "not set"
-                                        }
-                                    ]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "camyr2-block-no-proxy",
-                                    "when": [{
-                                        "id": "continuous-in-uk-answer-np",
-                                        "condition": "equals",
-                                        "value": "No"
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "national-identity-no-proxy"
-                                }
-                            }
-                        ]
-                    },
-                    {
-                        "type": "Question",
-                        "id": "camyr2-block-no-proxy",
-                        "questions": [{
-                            "id": "camyr2-question-np",
-                            "title": "When did you most recently arrive in the United Kingdom?",
-                            "type": "General",
-                            "answers": [{
-                                "id": "first-arrive-in-uk-answer-np",
-                                "mandatory": false,
-                                "type": "MonthYearDate",
-                                "maximum": {
-                                    "value": "now"
-                                }
-                            }]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "first-arrive-date-in-uk-invalid-no-proxy",
-                                    "when": [{
-                                        "id": "first-arrive-in-uk-answer-np",
-                                        "condition": "less than",
-                                        "date_comparison": {
-                                            "id": "date-of-birth-answer-np"
-                                        }
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "national-identity-no-proxy",
-                                    "when": [{
-                                        "id": "first-arrive-in-uk-answer-np",
-                                        "condition": "not set"
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "why-uk-no-proxy",
-                                    "when": [{
-                                        "id": "date-of-birth-answer-np",
-                                        "condition": "less than",
-                                        "date_comparison": {
-                                            "value": "now",
-                                            "offset_by": {
-                                                "years": -16
-                                            }
-                                        }
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "why-uk-no-proxy",
-                                    "when": [{
-                                        "id": "date-of-birth-answer-np",
-                                        "condition": "not set"
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "national-identity-no-proxy"
-                                }
-                            }
-                        ]
-                    },
-                    {
-                        "type": "Question",
-                        "id": "first-arrive-date-in-uk-invalid-no-proxy",
-                        "questions": [{
-                            "id": "first-arrive-date-in-uk-invalid-question-np",
-                            "title": "Invalid date entered",
-                            "description": "The date you most recently arrived in the UK must be after your date of birth.",
-                            "guidance": {
-                                "content": [{
-                                    "description": "Correct either your date of birth or the date you most recently arrived in the UK."
-                                }]
-                            },
-                            "type": "General",
-                            "answers": [{
-                                "id": "first-arrive-date-in-uk-invalid-answer-np",
-                                "mandatory": true,
-                                "type": "Radio",
-                                "options": [{
-                                        "label": "I&apos;d like to correct my date of birth",
-                                        "value": "change dob"
-                                    },
-                                    {
-                                        "label": "I&apos;d like to correct the date of my most recent arrival in the UK",
-                                        "value": "change arrival"
-                                    }
-                                ]
-                            }]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "date-of-birth-no-proxy",
-                                    "when": [{
-                                        "id": "first-arrive-date-in-uk-invalid-answer-np",
-                                        "condition": "equals",
-                                        "value": "change dob"
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "camyr2-block-no-proxy",
-                                    "when": [{
-                                        "id": "first-arrive-date-in-uk-invalid-answer-np",
-                                        "condition": "equals",
-                                        "value": "change arrival"
-                                    }]
-                                }
-                            }
-                        ]
-                    },
-                    {
-                        "type": "Question",
-                        "id": "why-uk-no-proxy",
-                        "questions": [{
-                            "id": "why-uk-question-np",
-                            "title": "What was the main reason for you coming to the UK in {{ max_value(answers['arrive-in-uk-answer-np'][group_instance], answers['first-arrive-in-uk-answer-np'][group_instance])|format_date }}?",
-                            "type": "General",
-                            "answers": [{
-                                "id": "why-uk-answer-np",
-                                "mandatory": false,
-                                "type": "Radio",
-                                "options": [{
-                                        "label": "For employment",
-                                        "value": "For employment"
-                                    },
-                                    {
-                                        "label": "For study",
-                                        "value": "For study"
-                                    },
-                                    {
-                                        "label": "As a spouse or dependent of a UK citizen or settled person",
-                                        "value": "As a spouse or dependent of a UK citizen or settled person"
-                                    },
-                                    {
-                                        "label": "As a spouse or dependent of someone who is coming to or is already in the UK for work or study reasons",
-                                        "value": "As a spouse or dependent of someone who is coming to or is already in the UK for work or study reasons"
-                                    },
-                                    {
-                                        "label": "To get married or form a civil partnership in the UK with a non-UK citizen",
-                                        "value": "To get married or form a civil partnership in the UK with a non-UK citizen"
-                                    },
-                                    {
-                                        "label": "Seeking asylum",
-                                        "value": "Seeking asylum"
-                                    },
-                                    {
-                                        "label": "As a visitor",
-                                        "value": "As a visitor"
-                                    },
-                                    {
-                                        "label": "Another reason",
-                                        "value": "Another reason"
-                                    }
-                                ]
-                            }]
-                        }],
-                        "routing_rules": [{
-                            "goto": {
-                                "block": "national-identity-no-proxy"
-                            }
-                        }]
-                    },
-                    {
-                        "type": "Question",
-                        "id": "why-uk-continuous-no-proxy",
-                        "questions": [{
-                            "id": "why-uk-continuous-question-np",
-                            "title": "What was the main reason for you coming to the UK in {{ answers['arrive-in-uk-answer-np'][group_instance]|format_date }}?",
-                            "type": "General",
-                            "answers": [{
-                                "id": "why-uk-continuous-answer-np",
-                                "mandatory": false,
-                                "type": "Radio",
-                                "options": [{
-                                        "label": "For employment",
-                                        "value": "For employment"
-                                    },
-                                    {
-                                        "label": "For study",
-                                        "value": "For study"
-                                    },
-                                    {
-                                        "label": "As a spouse or dependent of a UK citizen or settled person",
-                                        "value": "As a spouse or dependent of a UK citizen or settled person"
-                                    },
-                                    {
-                                        "label": "As a spouse or dependent of someone who is coming to or is already in the UK for work or study reasons",
-                                        "value": "As a spouse or dependent of someone who is coming to or is already in the UK for work or study reasons"
-                                    },
-                                    {
-                                        "label": "To get married or form a civil partnership in the UK with a non-UK citizen",
-                                        "value": "To get married or form a civil partnership in the UK with a non-UK citizen"
-                                    },
-                                    {
-                                        "label": "Seeking asylum",
-                                        "value": "Seeking asylum"
-                                    },
-                                    {
-                                        "label": "As a visitor",
-                                        "value": "As a visitor"
-                                    },
-                                    {
-                                        "label": "Another reason",
-                                        "value": "Another reason"
-                                    }
-                                ]
-                            }]
-                        }],
-                        "routing_rules": [{
-                            "goto": {
-                                "block": "national-identity"
-                            }
-                        }]
-                    },
-                    {
-                        "type": "Question",
-                        "id": "national-identity-no-proxy",
-                        "questions": [{
-                                "id": "national-identity-england-question-np",
-                                "title": "What do you consider your national identity to be?",
-                                "type": "General",
-                                "answers": [{
-                                        "id": "national-identity-england-answer-np",
-                                        "mandatory": false,
-                                        "type": "Checkbox",
-                                        "options": [{
-                                                "label": "English",
-                                                "value": "English"
-                                            },
-                                            {
-                                                "label": "Welsh",
-                                                "value": "Welsh"
-                                            },
-                                            {
-                                                "label": "Scottish",
-                                                "value": "Scottish"
-                                            },
-                                            {
-                                                "label": "Northern Irish",
-                                                "value": "Northern Irish"
-                                            },
-                                            {
-                                                "label": "British",
-                                                "value": "British"
-                                            },
-                                            {
-                                                "label": "Other",
-                                                "value": "Other",
-                                                "child_answer_id": "national-identity-england-answer-other-np"
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        "id": "national-identity-england-answer-other-np",
-                                        "parent_answer_id": "national-identity-england-answer-np",
-                                        "type": "TextField",
-                                        "mandatory": false,
-                                        "label": "Please enter your national identity"
-                                    }
-                                ],
-                                "skip_conditions": [{
-                                    "when": [{
-                                        "meta": "region_code",
-                                        "condition": "equals",
-                                        "value": "GB-WLS"
-                                    }]
-                                }]
-                            },
-                            {
-                                "id": "national-identity-wales-question-no-proxy",
-                                "title": "What do you consider your national identity to be?",
-                                "type": "General",
-                                "answers": [{
-                                        "id": "national-identity-wales-answer-np",
-                                        "mandatory": false,
-                                        "type": "Checkbox",
-                                        "options": [{
-                                                "label": "Welsh",
-                                                "value": "Welsh"
-                                            },
-                                            {
-                                                "label": "English",
-                                                "value": "English"
-                                            },
-                                            {
-                                                "label": "Scottish",
-                                                "value": "Scottish"
-                                            },
-                                            {
-                                                "label": "Northern Irish",
-                                                "value": "Northern Irish"
-                                            },
-                                            {
-                                                "label": "British",
-                                                "value": "British"
-                                            },
-                                            {
-                                                "label": "Other",
-                                                "value": "Other",
-                                                "child_answer_id": "national-identity-wales-answer-other-np"
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        "id": "national-identity-wales-answer-other-np",
-                                        "parent_answer_id": "national-identity-wales-answer-np",
-                                        "type": "TextField",
-                                        "mandatory": false,
-                                        "label": "Please enter your national identity"
-                                    }
-                                ],
-                                "skip_conditions": [{
-                                    "when": [{
-                                        "meta": "region_code",
-                                        "condition": "not equals",
-                                        "value": "GB-WLS"
-                                    }]
-                                }]
-                            }
-                        ],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "understand-welsh-no-proxy",
-                                    "when": [{
-                                        "meta": "region_code",
-                                        "condition": "equals",
-                                        "value": "GB-WLS"
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "ethnic-group-no-proxy"
-                                }
-                            }
-                        ]
-                    },
-                    {
-                        "type": "Question",
-                        "id": "understand-welsh-no-proxy",
-                        "questions": [{
-                            "id": "understand-welsh-question-np",
-                            "title": "Can you...",
-                            "type": "General",
-                            "answers": [{
-                                "id": "understand-welsh-answer-np",
-                                "mandatory": false,
-                                "type": "Checkbox",
-                                "options": [{
-                                        "label": "Understand spoken Welsh",
-                                        "value": "Understand spoken Welsh"
-                                    },
-                                    {
-                                        "label": "Read Welsh",
-                                        "value": "Read Welsh"
-                                    },
-                                    {
-                                        "label": "Write in Welsh",
-                                        "value": "Write in Welsh"
-                                    },
-                                    {
-                                        "label": "Speak Welsh",
-                                        "value": "Speak Welsh"
-                                    },
-                                    {
-                                        "label": "None of the above",
-                                        "value": "None of the above"
-                                    }
-                                ]
-                            }]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "welsh-frequency-no-proxy",
-                                    "when": [{
-                                        "id": "understand-welsh-answer-np",
-                                        "condition": "contains",
-                                        "value": "Speak Welsh"
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "ethnic-group-no-proxy"
-                                }
-                            }
-                        ]
-                    },
-                    {
-                        "type": "Question",
-                        "id": "welsh-frequency-no-proxy",
-                        "questions": [{
-                            "id": "welsh-frequency-question-np",
-                            "title": "How often do you speak Welsh?",
-                            "type": "General",
-                            "answers": [{
-                                "id": "welsh-frequency-answer-np",
-                                "mandatory": false,
-                                "type": "Radio",
-                                "options": [{
-                                        "label": "Daily",
-                                        "value": "Daily"
-                                    },
-                                    {
-                                        "label": "Weekly",
-                                        "value": "Weekly"
-                                    },
-                                    {
-                                        "label": "Less often",
-                                        "value": "Less often"
-                                    },
-                                    {
-                                        "label": "Never",
-                                        "value": "Never"
-                                    }
-                                ]
-                            }]
-                        }]
-                    },
-                    {
-                        "type": "Question",
-                        "id": "ethnic-group-no-proxy",
-                        "questions": [{
-                            "id": "ethnic-group-question-np",
-                            "title": "What is your ethnic group?",
-                            "type": "General",
-                            "answers": [{
-                                "id": "ethnic-group-answer-np",
-                                "mandatory": false,
-                                "type": "Radio",
-                                "options": [{
-                                        "label": "White",
-                                        "value": "White",
-                                        "description": "Includes any White background"
-                                    },
-                                    {
-                                        "label": "Mixed or multiple ethnic groups",
-                                        "value": "Mixed or multiple ethnic groups",
-                                        "description": "Includes White and Black Caribbean, White and Black African, White and Asian or any other Mixed ethnic group"
-                                    },
-                                    {
-                                        "label": "Asian or Asian British",
-                                        "value": "Asian or Asian British",
-                                        "description": "Includes Indian, Pakistani, Bangladeshi, Chinese or any other Asian background"
-                                    },
-                                    {
-                                        "label": "Black, African, Caribbean or Black British",
-                                        "value": "Black, African, Caribbean or Black British",
-                                        "description": "Includes African, Caribbean or any other Black background"
-                                    },
-                                    {
-                                        "label": "Other",
-                                        "value": "Other",
-                                        "description": "For example Arab or any other background"
-                                    }
-                                ]
-                            }]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "white-ethnic-group-no-proxy",
-                                    "when": [{
-                                        "id": "ethnic-group-answer-np",
-                                        "condition": "equals",
-                                        "value": "White"
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "mixed-ethnic-group-no-proxy",
-                                    "when": [{
-                                        "id": "ethnic-group-answer-np",
-                                        "condition": "equals",
-                                        "value": "Mixed or multiple ethnic groups"
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "asian-ethnic-group-no-proxy",
-                                    "when": [{
-                                        "id": "ethnic-group-answer-np",
-                                        "condition": "equals",
-                                        "value": "Asian or Asian British"
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "black-ethnic-group-no-proxy",
-                                    "when": [{
-                                        "id": "ethnic-group-answer-np",
-                                        "condition": "equals",
-                                        "value": "Black, African, Caribbean or Black British"
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "other-ethnic-group-no-proxy",
-                                    "when": [{
-                                        "id": "ethnic-group-answer-np",
-                                        "condition": "equals",
-                                        "value": "Other"
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "household-member-completed",
-                                    "when": [{
-                                            "id": "date-of-birth-answer-np",
-                                            "condition": "greater than",
-                                            "date_comparison": {
-                                                "value": "now",
-                                                "offset_by": {
-                                                    "years": -16
-                                                }
-                                            }
-                                        },
-                                        {
-                                            "id": "ethnic-group-answer-np",
-                                            "condition": "not set"
-                                        }
-                                    ]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "religion-no-proxy"
-                                }
-                            }
-                        ]
-                    },
-                    {
-                        "type": "Question",
-                        "id": "white-ethnic-group-no-proxy",
-                        "questions": [{
-                            "id": "white-ethnic-group-question-np",
-                            "title": "Which one best describes your White ethnic group or background?",
-                            "type": "General",
-                            "answers": [{
-                                    "id": "white-ethnic-group-answer-np",
-                                    "mandatory": false,
-                                    "options": [{
-                                            "label": "English, Welsh, Scottish, Northern Irish or British",
-                                            "value": "English, Welsh, Scottish, Northern Irish or British"
-                                        },
-                                        {
-                                            "label": "Irish",
-                                            "value": "Irish"
-                                        },
-                                        {
-                                            "label": "Gypsy or Irish Traveller",
-                                            "value": "Gypsy or Irish Traveller"
-                                        },
-                                        {
-                                            "label": "Any other White background",
-                                            "value": "Other",
-                                            "child_answer_id": "white-ethnic-group-answer-other-np"
-                                        }
-                                    ],
-                                    "type": "Radio"
-                                },
-                                {
-                                    "id": "white-ethnic-group-answer-other-np",
-                                    "parent_answer_id": "white-ethnic-group-answer-np",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Please enter ethnic background"
-                                }
-                            ]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "household-member-completed",
-                                    "when": [{
-                                        "id": "date-of-birth-answer-np",
-                                        "condition": "greater than",
-                                        "date_comparison": {
-                                            "value": "now",
-                                            "offset_by": {
-                                                "years": -16
-                                            }
-                                        }
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "religion-no-proxy"
-                                }
-                            }
-                        ]
-                    },
-                    {
-                        "type": "Question",
-                        "id": "mixed-ethnic-group-no-proxy",
-                        "questions": [{
-                            "id": "mixed-ethnic-group-question-np",
-                            "title": "Which one best describes your Mixed, multiple ethnic group or background?",
-                            "type": "General",
-                            "answers": [{
-                                    "id": "mixed-ethnic-group-answer-np",
-                                    "mandatory": false,
-                                    "options": [{
-                                            "label": "White and Black Caribbean",
-                                            "value": "White and Black Caribbean"
-                                        },
-                                        {
-                                            "label": "White and Black African",
-                                            "value": "White and Black African"
-                                        },
-                                        {
-                                            "label": "White and Asian",
-                                            "value": "White and Asian"
-                                        },
-                                        {
-                                            "label": "Any other Mixed or multiple ethnic background",
-                                            "value": "Other",
-                                            "child_answer_id": "mixed-ethnic-group-answer-other-np"
-                                        }
-                                    ],
-                                    "type": "Radio"
-                                },
-                                {
-                                    "id": "mixed-ethnic-group-answer-other-np",
-                                    "parent_answer_id": "mixed-ethnic-group-answer-np",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Please enter ethnic background"
-                                }
-                            ]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "household-member-completed",
-                                    "when": [{
-                                        "id": "date-of-birth-answer-np",
-                                        "condition": "greater than",
-                                        "date_comparison": {
-                                            "value": "now",
-                                            "offset_by": {
-                                                "years": -16
-                                            }
-                                        }
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "religion-no-proxy"
-                                }
-                            }
-                        ]
-                    },
-                    {
-                        "type": "Question",
-                        "id": "asian-ethnic-group-no-proxy",
-                        "questions": [{
-                            "id": "asian-ethnic-group-question-np",
-                            "title": "Which one best describes your Asian, Asian British ethnic group or background?",
-                            "type": "General",
-                            "answers": [{
-                                    "id": "asian-ethnic-group-answer-np",
-                                    "mandatory": false,
-                                    "options": [{
-                                            "label": "Indian",
-                                            "value": "Indian"
-                                        },
-                                        {
-                                            "label": "Pakistani",
-                                            "value": "Pakistani"
-                                        },
-                                        {
-                                            "label": "Bangladeshi",
-                                            "value": "Bangladeshi"
-                                        },
-                                        {
-                                            "label": "Chinese",
-                                            "value": "Chinese"
-                                        },
-                                        {
-                                            "label": "Any other Asian background",
-                                            "value": "Other",
-                                            "child_answer_id": "asian-ethnic-group-answer-other-np"
-                                        }
-                                    ],
-                                    "type": "Radio"
-                                },
-                                {
-                                    "id": "asian-ethnic-group-answer-other-np",
-                                    "parent_answer_id": "asian-ethnic-group-answer-np",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Please enter ethnic background"
-                                }
-                            ]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "household-member-completed",
-                                    "when": [{
-                                        "id": "date-of-birth-answer-np",
-                                        "condition": "greater than",
-                                        "date_comparison": {
-                                            "value": "now",
-                                            "offset_by": {
-                                                "years": -16
-                                            }
-                                        }
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "religion-no-proxy"
-                                }
-                            }
-                        ]
-                    },
-                    {
-                        "type": "Question",
-                        "id": "black-ethnic-group-no-proxy",
-                        "questions": [{
-                            "id": "black-ethnic-group-question-np",
-                            "title": "Which one best describes your Black, African, Caribbean, Black British ethnic group or background?",
-                            "type": "General",
-                            "answers": [{
-                                    "id": "black-ethnic-group-answer-np",
-                                    "mandatory": false,
-                                    "options": [{
-                                            "label": "African",
-                                            "value": "African"
-                                        },
-                                        {
-                                            "label": "Caribbean",
-                                            "value": "Caribbean"
-                                        },
-                                        {
-                                            "label": "Any other Black, African or Caribbean background",
-                                            "value": "Other",
-                                            "child_answer_id": "black-ethnic-group-answer-other-np"
-                                        }
-                                    ],
-                                    "type": "Radio"
-                                },
-                                {
-                                    "id": "black-ethnic-group-answer-other-np",
-                                    "parent_answer_id": "black-ethnic-group-answer-np",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Please enter ethnic background"
-                                }
-                            ]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "household-member-completed",
-                                    "when": [{
-                                        "id": "date-of-birth-answer-np",
-                                        "condition": "greater than",
-                                        "date_comparison": {
-                                            "value": "now",
-                                            "offset_by": {
-                                                "years": -16
-                                            }
-                                        }
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "religion-no-proxy"
-                                }
-                            }
-                        ]
-                    },
-                    {
-                        "type": "Question",
-                        "id": "other-ethnic-group-no-proxy",
-                        "questions": [{
-                            "id": "other-ethnic-group-question-np",
-                            "title": "Which one best describes your ethnic group or background?",
-                            "type": "General",
-                            "answers": [{
-                                    "id": "other-ethnic-group-answer-np",
-                                    "mandatory": false,
-                                    "options": [{
-                                            "label": "Arab",
-                                            "value": "Arab"
-                                        },
-                                        {
-                                            "label": "Any other ethnic group",
-                                            "value": "Other",
-                                            "child_answer_id": "other-ethnic-group-answer-other-np"
-                                        }
-                                    ],
-                                    "type": "Radio"
-                                },
-                                {
-                                    "id": "other-ethnic-group-answer-other-np",
-                                    "parent_answer_id": "other-ethnic-group-answer-np",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Please enter ethnic background"
-                                }
-                            ]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "household-member-completed",
-                                    "when": [{
-                                        "id": "date-of-birth-answer-np",
-                                        "condition": "greater than",
-                                        "date_comparison": {
-                                            "value": "now",
-                                            "offset_by": {
-                                                "years": -16
-                                            }
-                                        }
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "religion-no-proxy"
-                                }
-                            }
-                        ]
-                    },
-                    {
-                        "type": "Question",
-                        "id": "religion-no-proxy",
-                        "questions": [{
-                            "id": "religion-question-np",
-                            "title": "What is your religion?",
-                            "type": "General",
-                            "answers": [{
-                                    "id": "religion-answer-np",
-                                    "mandatory": false,
-                                    "type": "Radio",
-                                    "options": [{
-                                            "label": "No religion",
-                                            "value": "No religion"
-                                        },
-                                        {
-                                            "label": "Christian",
-                                            "value": "Christian",
-                                            "description": "Including Church of England, Catholic, Protestant and other Christian denominations"
-                                        },
-                                        {
-                                            "label": "Buddhist",
-                                            "value": "Buddhist"
-                                        },
-                                        {
-                                            "label": "Hindu",
-                                            "value": "Hindu"
-                                        },
-                                        {
-                                            "label": "Jewish",
-                                            "value": "Jewish"
-                                        },
-                                        {
-                                            "label": "Muslim",
-                                            "value": "Muslim"
-                                        },
-                                        {
-                                            "label": "Sikh",
-                                            "value": "Sikh"
-                                        },
-                                        {
-                                            "label": "Other religion",
-                                            "value": "Other religion",
-                                            "child_answer_id": "religion-answer-other-np"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "id": "religion-answer-other-np",
-                                    "parent_answer_id": "religion-answer-np",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Please enter religion"
-                                }
-                            ]
-                        }],
-                        "routing_rules": [{
-                            "goto": {
-                                "block": "household-member-completed"
-                            }
-                        }]
-                    },
-                    {
-                        "id": "household-member-completed",
-                        "title": "There are no more questions for {{[answers['first-name'][group_instance], answers['last-name'][group_instance]] | format_household_name}}",
-                        "description": "",
-                        "type": "Interstitial"
-                    }
-                ]
-            }]
+                  ],
+                  "description": "",
+                  "id": "household-relationships-question",
+                  "title": "How is <em>{{[answers['first-name'][group_instance], answers['last-name'][group_instance]] | format_household_name}}</em> related to the people below?",
+                  "type": "Relationship"
+                }
+              ],
+              "type": "Question"
+            }
+          ],
+          "id": "who-lives-here-relationship-group",
+          "routing_rules": [
+            {
+              "repeat": {
+                "answer_id": "first-name",
+                "type": "answer_count_minus_one"
+              }
+            }
+          ],
+          "title": "Relationships"
         },
         {
-            "id": "submit-answers",
-            "title": "Submit answers",
-            "groups": [{
-                "id": "questionnaire-completed",
-                "title": "Submit answers",
-                "blocks": [{
-                        "id": "thank-you-block",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "thank-you-question",
-                            "title": "Thank you, you're almost done.",
-                            "description": "Your contribution so far has been invaluable. Before you submit your answers, please provide an email address and/or a phone number - you may be re-contacted to take part in future research to help us to improve this service.",
-                            "type": "General",
-                            "answers": [{
-                                    "id": "phone-number",
-                                    "label": "Phone number",
-                                    "mandatory": false,
-                                    "type": "TextField"
-                                },
-                                {
-                                    "id": "email",
-                                    "label": "Email address",
-                                    "mandatory": false,
-                                    "type": "TextField"
-                                },
-                                {
-                                    "id": "confirm-email",
-                                    "label": "Confirm email address",
-                                    "mandatory": false,
-                                    "type": "TextField"
-                                }
-                            ]
-                        }]
-                    },
-                    {
-                        "type": "Confirmation",
-                        "id": "confirmation",
-                        "title": "",
-                        "questions": [{
-                            "answers": [],
-                            "id": "questionnaire-completed-question",
-                            "title": "Thank you, please submit your answers.",
-                            "type": "General",
-                            "description": "<p>Thank you for taking the time to provide your answers to these questions. The information you have provided will be held securely and treated as confidential as directed by the Code of Practice for Official Statistics.</p><p>Please submit your responses by using the <em>Submit answers</em> button below. This will lock your questionnaire so that it will not be possible to re-enter the survey.</p>"
-                        }]
-                    }
-                ]
-            }]
+          "blocks": [
+            {
+              "content": [
+                {
+                  "description": "We would now like to ask some questions of each individual.  An adult should answer on behalf of anyone aged 15 or younger."
+                },
+                {
+                  "description": "Please answer your questions first.  Once you have completed your section, you will return to this screen so that the other household members can complete their section.  They can also access it at a later time using the link and unique code given in your letter.  You may answer on behalf of another adult if needed."
+                }
+              ],
+              "id": "who-lives-here-completed",
+              "title": "",
+              "type": "Interstitial"
+            }
+          ],
+          "id": "who-lives-here-completed-group",
+          "title": "Who lives here?"
         }
-    ]
+      ],
+      "id": "household-section",
+      "title": "About the household"
+    },
+    {
+      "groups": [
+        {
+          "blocks": [
+            {
+              "content": [
+                {
+                  "list": [
+                    "Personal details such as date of birth, nationality, country of birth",
+                    "How long <em>{{[answers['first-name'][group_instance], answers['last-name'][group_instance]] | format_household_name}}</em> has lived in the UK",
+                    "Their national identity, ethnicity and religion"
+                  ],
+                  "title": "Information you need"
+                }
+              ],
+              "description": "In this section, we\u2019re going to ask questions about <em>{{[answers['first-name'][group_instance], answers['last-name'][group_instance]] | format_household_name}}</em>.",
+              "id": "household-member-begin",
+              "title": "{{[answers['first-name'][group_instance], answers['last-name'][group_instance]] | format_household_name}}",
+              "type": "Interstitial"
+            },
+            {
+              "id": "proxy-check",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "id": "proxy-check-answer",
+                      "mandatory": false,
+                      "options": [
+                        {
+                          "label": "Yes, I am",
+                          "value": "no proxy"
+                        },
+                        {
+                          "label": "No, I am answering on their behalf",
+                          "value": "proxy"
+                        }
+                      ],
+                      "type": "Radio"
+                    }
+                  ],
+                  "guidance": {
+                    "content": [
+                      {
+                        "description": "An adult should answer on behalf of anyone aged 15 or younger."
+                      }
+                    ]
+                  },
+                  "id": "proxy-check-question",
+                  "title": "Are you {{ [answers['first-name'][group_instance], answers['middle-names'][group_instance], answers['last-name'][group_instance]] | format_household_name }}?",
+                  "type": "General"
+                }
+              ],
+              "routing_rules": [
+                {
+                  "goto": {
+                    "block": "date-of-birth",
+                    "when": [
+                      {
+                        "condition": "equals",
+                        "id": "proxy-check-answer",
+                        "value": "proxy"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "date-of-birth-no-proxy"
+                  }
+                }
+              ],
+              "type": "Question"
+            },
+            {
+              "id": "date-of-birth",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "id": "date-of-birth-answer",
+                      "mandatory": false,
+                      "maximum": {
+                        "value": "now"
+                      },
+                      "type": "Date"
+                    }
+                  ],
+                  "id": "date-of-birth-question",
+                  "title": "What is <em>{{[answers['first-name'][group_instance], answers['last-name'][group_instance]] | format_household_name_possessive }}</em> date of birth?",
+                  "type": "General"
+                }
+              ],
+              "routing_rules": [
+                {
+                  "goto": {
+                    "block": "date-of-birth-check",
+                    "when": [
+                      {
+                        "condition": "not set",
+                        "id": "date-of-birth-answer"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "sex"
+                  }
+                }
+              ],
+              "type": "Question"
+            },
+            {
+              "id": "date-of-birth-check",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "id": "dob-check-answer",
+                      "mandatory": false,
+                      "options": [
+                        {
+                          "label": "Yes",
+                          "value": "Yes"
+                        },
+                        {
+                          "label": "No",
+                          "value": "No"
+                        }
+                      ],
+                      "type": "Radio"
+                    }
+                  ],
+                  "id": "dob-check-question",
+                  "title": "Is <em>{{[answers['first-name'][group_instance], answers['last-name'][group_instance]] | format_household_name }}</em> aged 16 or over?",
+                  "type": "General"
+                }
+              ],
+              "routing_rules": [
+                {
+                  "goto": {
+                    "block": "household-member-completed",
+                    "when": [
+                      {
+                        "condition": "equals",
+                        "id": "dob-check-answer",
+                        "value": "No"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "household-member-completed",
+                    "when": [
+                      {
+                        "condition": "not set",
+                        "id": "dob-check-answer"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "sex"
+                  }
+                }
+              ],
+              "type": "ConfirmationQuestion"
+            },
+            {
+              "id": "sex",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "id": "sex-answer",
+                      "mandatory": true,
+                      "options": [
+                        {
+                          "label": "Male",
+                          "value": "Male"
+                        },
+                        {
+                          "label": "Female",
+                          "value": "Female"
+                        }
+                      ],
+                      "type": "Radio"
+                    }
+                  ],
+                  "id": "sex-question",
+                  "title": "What is <em>{{[answers['first-name'][group_instance], answers['last-name'][group_instance]] | format_household_name_possessive }}</em> sex?",
+                  "type": "General"
+                }
+              ],
+              "routing_rules": [
+                {
+                  "goto": {
+                    "block": "marital-status",
+                    "when": [
+                      {
+                        "condition": "less than",
+                        "date_comparison": {
+                          "offset_by": {
+                            "years": -16
+                          },
+                          "value": "now"
+                        },
+                        "id": "date-of-birth-answer"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "marital-status",
+                    "when": [
+                      {
+                        "condition": "not set",
+                        "id": "date-of-birth-answer"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "nationality"
+                  }
+                }
+              ],
+              "type": "Question"
+            },
+            {
+              "id": "marital-status",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "id": "marital-status-answer",
+                      "mandatory": false,
+                      "options": [
+                        {
+                          "label": "Never married",
+                          "value": "Never married"
+                        },
+                        {
+                          "label": "Married",
+                          "value": "Married"
+                        },
+                        {
+                          "label": "In a registered same-sex civil partnership",
+                          "value": "In a registered same-sex civil partnership"
+                        },
+                        {
+                          "label": "Separated, but still legally married",
+                          "value": "Separated, but still legally married"
+                        },
+                        {
+                          "label": "Separated, but still legally in a same-sex civil partnership",
+                          "value": "Separated, but still legally in a same-sex civil partnership"
+                        },
+                        {
+                          "label": "Divorced",
+                          "value": "Divorced"
+                        },
+                        {
+                          "label": "Formerly in a same-sex civil partnership which is now legally dissolved",
+                          "value": "Formerly in a same-sex civil partnership which is now legally dissolved"
+                        },
+                        {
+                          "label": "Widowed",
+                          "value": "Widowed"
+                        },
+                        {
+                          "label": "Surviving member of a same-sex civil partnership",
+                          "value": "Surviving member of a same-sex civil partnership"
+                        }
+                      ],
+                      "type": "Radio"
+                    }
+                  ],
+                  "id": "marital-status-question",
+                  "title": "What is <em>{{[answers['first-name'][group_instance], answers['last-name'][group_instance]] | format_household_name_possessive }}</em> legal marital status?",
+                  "type": "General"
+                }
+              ],
+              "type": "Question"
+            },
+            {
+              "id": "nationality",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "id": "nationality-answer",
+                      "mandatory": false,
+                      "options": [
+                        {
+                          "label": "British",
+                          "value": "British"
+                        },
+                        {
+                          "label": "Irish",
+                          "value": "Irish"
+                        },
+                        {
+                          "label": "Indian",
+                          "value": "Indian"
+                        },
+                        {
+                          "label": "Pakistani",
+                          "value": "Pakistani"
+                        },
+                        {
+                          "label": "Polish",
+                          "value": "Polish"
+                        },
+                        {
+                          "child_answer_id": "nationality-answer-other",
+                          "label": "Other",
+                          "value": "Other"
+                        }
+                      ],
+                      "type": "Radio"
+                    },
+                    {
+                      "id": "nationality-answer-other",
+                      "label": "Please enter nationality",
+                      "mandatory": false,
+                      "parent_answer_id": "nationality-answer",
+                      "type": "TextField"
+                    }
+                  ],
+                  "id": "nationality-question",
+                  "title": "What is <em>{{[answers['first-name'][group_instance], answers['last-name'][group_instance]] | format_household_name_possessive}}</em> nationality?",
+                  "type": "General"
+                }
+              ],
+              "type": "Question"
+            },
+            {
+              "id": "country-of-birth",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "id": "country-of-birth-answer",
+                      "mandatory": false,
+                      "options": [
+                        {
+                          "label": "England",
+                          "value": "England"
+                        },
+                        {
+                          "label": "Wales",
+                          "value": "Wales"
+                        },
+                        {
+                          "label": "Scotland",
+                          "value": "Scotland"
+                        },
+                        {
+                          "label": "Northern Ireland",
+                          "value": "Northern Ireland"
+                        },
+                        {
+                          "label": "Republic of Ireland",
+                          "value": "Republic of Ireland"
+                        },
+                        {
+                          "label": "Isle of Man or Channel Islands",
+                          "value": "Isle of Man or Channel Islands"
+                        },
+                        {
+                          "label": "India",
+                          "value": "India"
+                        },
+                        {
+                          "label": "Pakistan",
+                          "value": "Pakistan"
+                        },
+                        {
+                          "label": "Poland",
+                          "value": "Poland"
+                        },
+                        {
+                          "child_answer_id": "country-of-birth-answer-other",
+                          "label": "Other",
+                          "value": "Other"
+                        }
+                      ],
+                      "type": "Radio"
+                    },
+                    {
+                      "id": "country-of-birth-answer-other",
+                      "label": "Please enter country of birth",
+                      "mandatory": false,
+                      "parent_answer_id": "country-of-birth-answer",
+                      "type": "TextField"
+                    }
+                  ],
+                  "id": "country-of-birth-question",
+                  "title": "In which country was <em>{{[answers['first-name'][group_instance], answers['last-name'][group_instance]]|format_household_name}}</em> born?",
+                  "type": "General"
+                }
+              ],
+              "routing_rules": [
+                {
+                  "goto": {
+                    "block": "national-identity",
+                    "when": [
+                      {
+                        "condition": "equals",
+                        "id": "country-of-birth-answer",
+                        "value": "England"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "national-identity",
+                    "when": [
+                      {
+                        "condition": "equals",
+                        "id": "country-of-birth-answer",
+                        "value": "Wales"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "national-identity",
+                    "when": [
+                      {
+                        "condition": "equals",
+                        "id": "country-of-birth-answer",
+                        "value": "Scotland"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "national-identity",
+                    "when": [
+                      {
+                        "condition": "equals",
+                        "id": "country-of-birth-answer",
+                        "value": "Northern Ireland"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "national-identity",
+                    "when": [
+                      {
+                        "condition": "not set",
+                        "id": "country-of-birth-answer"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "arrive-in-uk"
+                  }
+                }
+              ],
+              "type": "Question"
+            },
+            {
+              "id": "arrive-in-uk",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "id": "arrive-in-uk-answer",
+                      "mandatory": false,
+                      "maximum": {
+                        "value": "now"
+                      },
+                      "type": "MonthYearDate"
+                    }
+                  ],
+                  "id": "arrive-in-uk-question",
+                  "title": "When did <em>{{[answers['first-name'][group_instance], answers['last-name'][group_instance]] | format_household_name}}</em> first arrive to live in the UK?",
+                  "type": "General"
+                }
+              ],
+              "routing_rules": [
+                {
+                  "goto": {
+                    "block": "arrive-date-in-uk-invalid",
+                    "when": [
+                      {
+                        "condition": "greater than",
+                        "date_comparison": {
+                          "value": "now"
+                        },
+                        "id": "arrive-in-uk-answer"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "arrive-date-in-uk-invalid",
+                    "when": [
+                      {
+                        "condition": "less than",
+                        "date_comparison": {
+                          "id": "date-of-birth-answer"
+                        },
+                        "id": "arrive-in-uk-answer"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "national-identity",
+                    "when": [
+                      {
+                        "condition": "not set",
+                        "id": "arrive-in-uk-answer"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "continuous-in-uk"
+                  }
+                }
+              ],
+              "type": "Question"
+            },
+            {
+              "id": "arrive-date-in-uk-invalid",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "id": "arrive-date-in-uk-invalid-answer",
+                      "mandatory": true,
+                      "options": [
+                        {
+                          "label": "I&apos;d like to correct their date of birth",
+                          "value": "change dob"
+                        },
+                        {
+                          "label": "I&apos;d like to correct their date of arrival in the UK",
+                          "value": "change arrival"
+                        }
+                      ],
+                      "type": "Radio"
+                    }
+                  ],
+                  "description": "The date <em>{{[answers['first-name'][group_instance], answers['last-name'][group_instance]] | format_household_name}}</em> first arrived in the UK must be after their date of birth and not in the future.",
+                  "guidance": {
+                    "content": [
+                      {
+                        "description": "Correct either their date of birth or the date they arrived in the UK."
+                      }
+                    ]
+                  },
+                  "id": "arrive-date-in-uk-invalid-question",
+                  "title": "Invalid date entered",
+                  "type": "General"
+                }
+              ],
+              "routing_rules": [
+                {
+                  "goto": {
+                    "block": "date-of-birth",
+                    "when": [
+                      {
+                        "condition": "equals",
+                        "id": "arrive-date-in-uk-invalid-answer",
+                        "value": "change dob"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "arrive-in-uk",
+                    "when": [
+                      {
+                        "condition": "equals",
+                        "id": "arrive-date-in-uk-invalid-answer",
+                        "value": "change arrival"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "type": "Question"
+            },
+            {
+              "id": "continuous-in-uk",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "id": "continuous-in-uk-answer",
+                      "mandatory": false,
+                      "options": [
+                        {
+                          "label": "Yes",
+                          "value": "Yes"
+                        },
+                        {
+                          "label": "No",
+                          "value": "No"
+                        }
+                      ],
+                      "type": "Radio"
+                    }
+                  ],
+                  "id": "continuous-in-uk-question",
+                  "title": "Apart from holidays and short visits abroad, has <em>{{[answers['first-name'][group_instance], answers['last-name'][group_instance]] | format_household_name}}</em> lived in the UK continuously since {{ answers['arrive-in-uk-answer'][group_instance]|format_date }}?",
+                  "type": "General"
+                }
+              ],
+              "routing_rules": [
+                {
+                  "goto": {
+                    "block": "national-identity",
+                    "when": [
+                      {
+                        "condition": "equals",
+                        "id": "continuous-in-uk-answer",
+                        "value": "Yes"
+                      },
+                      {
+                        "condition": "greater than",
+                        "date_comparison": {
+                          "offset_by": {
+                            "years": -16
+                          },
+                          "value": "now"
+                        },
+                        "id": "date-of-birth-answer"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "why-uk-continuous",
+                    "when": [
+                      {
+                        "condition": "equals",
+                        "id": "continuous-in-uk-answer",
+                        "value": "Yes"
+                      },
+                      {
+                        "condition": "less than",
+                        "date_comparison": {
+                          "offset_by": {
+                            "years": -16
+                          },
+                          "value": "now"
+                        },
+                        "id": "date-of-birth-answer"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "why-uk-continuous",
+                    "when": [
+                      {
+                        "condition": "equals",
+                        "id": "continuous-in-uk-answer",
+                        "value": "Yes"
+                      },
+                      {
+                        "condition": "not set",
+                        "id": "date-of-birth-answer"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "camyr2-block",
+                    "when": [
+                      {
+                        "condition": "equals",
+                        "id": "continuous-in-uk-answer",
+                        "value": "No"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "national-identity"
+                  }
+                }
+              ],
+              "type": "Question"
+            },
+            {
+              "id": "camyr2-block",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "id": "first-arrive-in-uk-answer",
+                      "mandatory": false,
+                      "maximum": {
+                        "value": "now"
+                      },
+                      "type": "MonthYearDate"
+                    }
+                  ],
+                  "id": "camyr2-question",
+                  "title": "When did <em>{{[answers['first-name'][group_instance], answers['last-name'][group_instance]] | format_household_name}}</em> most recently arrive in the United Kingdom?",
+                  "type": "General"
+                }
+              ],
+              "routing_rules": [
+                {
+                  "goto": {
+                    "block": "first-arrive-date-in-uk-invalid",
+                    "when": [
+                      {
+                        "condition": "less than",
+                        "date_comparison": {
+                          "id": "date-of-birth-answer"
+                        },
+                        "id": "first-arrive-in-uk-answer"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "national-identity",
+                    "when": [
+                      {
+                        "condition": "not set",
+                        "id": "first-arrive-in-uk-answer"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "why-uk",
+                    "when": [
+                      {
+                        "condition": "less than",
+                        "date_comparison": {
+                          "offset_by": {
+                            "years": -16
+                          },
+                          "value": "now"
+                        },
+                        "id": "date-of-birth-answer"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "why-uk",
+                    "when": [
+                      {
+                        "condition": "not set",
+                        "id": "date-of-birth-answer"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "national-identity"
+                  }
+                }
+              ],
+              "type": "Question"
+            },
+            {
+              "id": "first-arrive-date-in-uk-invalid",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "id": "first-arrive-date-in-uk-invalid-answer",
+                      "mandatory": true,
+                      "options": [
+                        {
+                          "label": "I&apos;d like to correct their date of birth",
+                          "value": "change dob"
+                        },
+                        {
+                          "label": "I&apos;d like to correct the date they most recently arrived in the UK",
+                          "value": "change first arrival"
+                        }
+                      ],
+                      "type": "Radio"
+                    }
+                  ],
+                  "description": "The date <em>{{[answers['first-name'][group_instance], answers['last-name'][group_instance]] | format_household_name}}</em> most recently arrived in the UK must be after their date of birth.",
+                  "guidance": {
+                    "content": [
+                      {
+                        "description": "Correct either their date of birth or the date they most recently arrived in the UK."
+                      }
+                    ]
+                  },
+                  "id": "first-arrive-date-in-uk-invalid-question",
+                  "title": "Invalid date entered",
+                  "type": "General"
+                }
+              ],
+              "routing_rules": [
+                {
+                  "goto": {
+                    "block": "date-of-birth",
+                    "when": [
+                      {
+                        "condition": "equals",
+                        "id": "first-arrive-date-in-uk-invalid-answer",
+                        "value": "change dob"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "camyr2-block",
+                    "when": [
+                      {
+                        "condition": "equals",
+                        "id": "first-arrive-date-in-uk-invalid-answer",
+                        "value": "change first arrival"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "type": "Question"
+            },
+            {
+              "id": "why-uk",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "id": "why-uk-answer",
+                      "mandatory": false,
+                      "options": [
+                        {
+                          "label": "For employment",
+                          "value": "For employment"
+                        },
+                        {
+                          "label": "For study",
+                          "value": "For study"
+                        },
+                        {
+                          "label": "As a spouse or dependent of a UK citizen or settled person",
+                          "value": "As a spouse or dependent of a UK citizen or settled person"
+                        },
+                        {
+                          "label": "As a spouse or dependent of someone who is coming to or is already in the UK for work or study reasons",
+                          "value": "As a spouse or dependent of someone who is coming to or is already in the UK for work or study reasons"
+                        },
+                        {
+                          "label": "To get married or form a civil partnership in the UK with a non-UK citizen",
+                          "value": "To get married or form a civil partnership in the UK with a non-UK citizen"
+                        },
+                        {
+                          "label": "Seeking asylum",
+                          "value": "Seeking asylum"
+                        },
+                        {
+                          "label": "As a visitor",
+                          "value": "As a visitor"
+                        },
+                        {
+                          "label": "Another reason",
+                          "value": "Another reason"
+                        }
+                      ],
+                      "type": "Radio"
+                    }
+                  ],
+                  "id": "why-uk-question",
+                  "title": "What was <em>{{[answers['first-name'][group_instance], answers['last-name'][group_instance]] | format_household_name_possessive}}</em> main reason for coming to the UK in {{ max_value(answers['arrive-in-uk-answer'][group_instance], answers['first-arrive-in-uk-answer'][group_instance])|format_date }}?",
+                  "type": "General"
+                }
+              ],
+              "routing_rules": [
+                {
+                  "goto": {
+                    "block": "national-identity"
+                  }
+                }
+              ],
+              "type": "Question"
+            },
+            {
+              "id": "why-uk-continuous",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "id": "why-uk-continuous-answer",
+                      "mandatory": false,
+                      "options": [
+                        {
+                          "label": "For employment",
+                          "value": "For employment"
+                        },
+                        {
+                          "label": "For study",
+                          "value": "For study"
+                        },
+                        {
+                          "label": "As a spouse or dependent of a UK citizen or settled person",
+                          "value": "As a spouse or dependent of a UK citizen or settled person"
+                        },
+                        {
+                          "label": "As a spouse or dependent of someone who is coming to or is already in the UK for work or study reasons",
+                          "value": "As a spouse or dependent of someone who is coming to or is already in the UK for work or study reasons"
+                        },
+                        {
+                          "label": "To get married or form a civil partnership in the UK with a non-UK citizen",
+                          "value": "To get married or form a civil partnership in the UK with a non-UK citizen"
+                        },
+                        {
+                          "label": "Seeking asylum",
+                          "value": "Seeking asylum"
+                        },
+                        {
+                          "label": "As a visitor",
+                          "value": "As a visitor"
+                        },
+                        {
+                          "label": "Another reason",
+                          "value": "Another reason"
+                        }
+                      ],
+                      "type": "Radio"
+                    }
+                  ],
+                  "id": "why-uk-continuous-question",
+                  "title": "What was <em>{{[answers['first-name'][group_instance], answers['last-name'][group_instance]] | format_household_name_possessive}}</em> main reason for coming to the UK in {{ answers['arrive-in-uk-answer'][group_instance]|format_date }}?",
+                  "type": "General"
+                }
+              ],
+              "routing_rules": [
+                {
+                  "goto": {
+                    "block": "national-identity"
+                  }
+                }
+              ],
+              "type": "Question"
+            },
+            {
+              "id": "national-identity",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "id": "national-identity-england-answer",
+                      "mandatory": false,
+                      "options": [
+                        {
+                          "label": "English",
+                          "value": "English"
+                        },
+                        {
+                          "label": "Welsh",
+                          "value": "Welsh"
+                        },
+                        {
+                          "label": "Scottish",
+                          "value": "Scottish"
+                        },
+                        {
+                          "label": "Northern Irish",
+                          "value": "Northern Irish"
+                        },
+                        {
+                          "label": "British",
+                          "value": "British"
+                        },
+                        {
+                          "child_answer_id": "national-identity-england-answer-other",
+                          "label": "Other",
+                          "value": "Other"
+                        }
+                      ],
+                      "type": "Checkbox"
+                    },
+                    {
+                      "id": "national-identity-england-answer-other",
+                      "label": "Please enter national identity",
+                      "mandatory": false,
+                      "parent_answer_id": "national-identity-england-answer",
+                      "type": "TextField"
+                    }
+                  ],
+                  "id": "national-identity-england-question",
+                  "skip_conditions": [
+                    {
+                      "when": [
+                        {
+                          "condition": "equals",
+                          "meta": "region_code",
+                          "value": "GB-WLS"
+                        }
+                      ]
+                    }
+                  ],
+                  "title": "What does <em>{{[answers['first-name'][group_instance], answers['last-name'][group_instance]]|format_household_name}}</em> consider their national identity to be?",
+                  "type": "General"
+                },
+                {
+                  "answers": [
+                    {
+                      "id": "national-identity-wales-answer",
+                      "mandatory": false,
+                      "options": [
+                        {
+                          "label": "Welsh",
+                          "value": "Welsh"
+                        },
+                        {
+                          "label": "English",
+                          "value": "English"
+                        },
+                        {
+                          "label": "Scottish",
+                          "value": "Scottish"
+                        },
+                        {
+                          "label": "Northern Irish",
+                          "value": "Northern Irish"
+                        },
+                        {
+                          "label": "British",
+                          "value": "British"
+                        },
+                        {
+                          "child_answer_id": "national-identity-wales-answer-other",
+                          "label": "Other",
+                          "value": "Other"
+                        }
+                      ],
+                      "type": "Checkbox"
+                    },
+                    {
+                      "id": "national-identity-wales-answer-other",
+                      "label": "Please enter national identity",
+                      "mandatory": false,
+                      "parent_answer_id": "national-identity-wales-answer",
+                      "type": "TextField"
+                    }
+                  ],
+                  "id": "national-identity-wales-question",
+                  "skip_conditions": [
+                    {
+                      "when": [
+                        {
+                          "condition": "not equals",
+                          "meta": "region_code",
+                          "value": "GB-WLS"
+                        }
+                      ]
+                    }
+                  ],
+                  "title": "What does <em>{{[answers['first-name'][group_instance], answers['last-name'][group_instance]]|format_household_name}}</em> consider their national identity to be?",
+                  "type": "General"
+                }
+              ],
+              "routing_rules": [
+                {
+                  "goto": {
+                    "block": "understand-welsh",
+                    "when": [
+                      {
+                        "condition": "equals",
+                        "meta": "region_code",
+                        "value": "GB-WLS"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "ethnic-group"
+                  }
+                }
+              ],
+              "type": "Question"
+            },
+            {
+              "id": "understand-welsh",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "id": "understand-welsh-answer",
+                      "mandatory": false,
+                      "options": [
+                        {
+                          "label": "Understand spoken Welsh",
+                          "value": "Understand spoken Welsh"
+                        },
+                        {
+                          "label": "Read Welsh",
+                          "value": "Read Welsh"
+                        },
+                        {
+                          "label": "Write in Welsh",
+                          "value": "Write in Welsh"
+                        },
+                        {
+                          "label": "Speak Welsh",
+                          "value": "Speak Welsh"
+                        },
+                        {
+                          "label": "None of the above",
+                          "value": "None of the above"
+                        }
+                      ],
+                      "type": "Checkbox"
+                    }
+                  ],
+                  "id": "understand-welsh-question",
+                  "title": "Can <em>{{[answers['first-name'][group_instance], answers['last-name'][group_instance]] | format_household_name}}</em>...",
+                  "type": "General"
+                }
+              ],
+              "routing_rules": [
+                {
+                  "goto": {
+                    "block": "welsh-frequency",
+                    "when": [
+                      {
+                        "condition": "contains",
+                        "id": "understand-welsh-answer",
+                        "value": "Speak Welsh"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "ethnic-group"
+                  }
+                }
+              ],
+              "type": "Question"
+            },
+            {
+              "id": "welsh-frequency",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "id": "welsh-frequency-answer",
+                      "mandatory": false,
+                      "options": [
+                        {
+                          "label": "Daily",
+                          "value": "Daily"
+                        },
+                        {
+                          "label": "Weekly",
+                          "value": "Weekly"
+                        },
+                        {
+                          "label": "Less often",
+                          "value": "Less often"
+                        },
+                        {
+                          "label": "Never",
+                          "value": "Never"
+                        }
+                      ],
+                      "type": "Radio"
+                    }
+                  ],
+                  "id": "welsh-frequency-question",
+                  "title": "How often does <em>{{[answers['first-name'][group_instance], answers['last-name'][group_instance]] | format_household_name}}</em> speak Welsh?",
+                  "type": "General"
+                }
+              ],
+              "type": "Question"
+            },
+            {
+              "id": "ethnic-group",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "id": "ethnic-group-answer",
+                      "mandatory": false,
+                      "options": [
+                        {
+                          "description": "Includes any White background",
+                          "label": "White",
+                          "value": "White"
+                        },
+                        {
+                          "description": "Includes White and Black Caribbean, White and Black African, White and Asian or any other Mixed ethnic group",
+                          "label": "Mixed or multiple ethnic groups",
+                          "value": "Mixed or multiple ethnic groups"
+                        },
+                        {
+                          "description": "Includes Indian, Pakistani, Bangladeshi, Chinese or any other Asian background",
+                          "label": "Asian or Asian British",
+                          "value": "Asian or Asian British"
+                        },
+                        {
+                          "description": "Includes African, Caribbean or any other Black background",
+                          "label": "Black, African, Caribbean or Black British",
+                          "value": "Black, African, Caribbean or Black British"
+                        },
+                        {
+                          "description": "For example Arab or any other background",
+                          "label": "Other",
+                          "value": "Other"
+                        }
+                      ],
+                      "type": "Radio"
+                    }
+                  ],
+                  "id": "ethnic-group-question",
+                  "title": "What is <em>{{[answers['first-name'][group_instance], answers['last-name'][group_instance]] | format_household_name_possessive}}</em> ethnic group?",
+                  "type": "General"
+                }
+              ],
+              "routing_rules": [
+                {
+                  "goto": {
+                    "block": "white-ethnic-group",
+                    "when": [
+                      {
+                        "condition": "equals",
+                        "id": "ethnic-group-answer",
+                        "value": "White"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "mixed-ethnic-group",
+                    "when": [
+                      {
+                        "condition": "equals",
+                        "id": "ethnic-group-answer",
+                        "value": "Mixed or multiple ethnic groups"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "asian-ethnic-group",
+                    "when": [
+                      {
+                        "condition": "equals",
+                        "id": "ethnic-group-answer",
+                        "value": "Asian or Asian British"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "black-ethnic-group",
+                    "when": [
+                      {
+                        "condition": "equals",
+                        "id": "ethnic-group-answer",
+                        "value": "Black, African, Caribbean or Black British"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "other-ethnic-group",
+                    "when": [
+                      {
+                        "condition": "equals",
+                        "id": "ethnic-group-answer",
+                        "value": "Other"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "religion"
+                  }
+                }
+              ],
+              "type": "Question"
+            },
+            {
+              "id": "white-ethnic-group",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "id": "white-ethnic-group-answer",
+                      "mandatory": false,
+                      "options": [
+                        {
+                          "label": "English, Welsh, Scottish, Northern Irish or British",
+                          "value": "English, Welsh, Scottish, Northern Irish or British"
+                        },
+                        {
+                          "label": "Irish",
+                          "value": "Irish"
+                        },
+                        {
+                          "label": "Gypsy or Irish Traveller",
+                          "value": "Gypsy or Irish Traveller"
+                        },
+                        {
+                          "child_answer_id": "white-ethnic-group-answer-other",
+                          "label": "Any other White background",
+                          "value": "Other"
+                        }
+                      ],
+                      "type": "Radio"
+                    },
+                    {
+                      "id": "white-ethnic-group-answer-other",
+                      "label": "Please enter ethnic background",
+                      "mandatory": false,
+                      "parent_answer_id": "white-ethnic-group-answer",
+                      "type": "TextField"
+                    }
+                  ],
+                  "id": "white-ethnic-group-question",
+                  "title": "Which one best describes <em>{{[answers['first-name'][group_instance], answers['last-name'][group_instance]] | format_household_name_possessive}}</em> White ethnic group or background?",
+                  "type": "General"
+                }
+              ],
+              "routing_rules": [
+                {
+                  "goto": {
+                    "block": "household-member-completed",
+                    "when": [
+                      {
+                        "condition": "greater than",
+                        "date_comparison": {
+                          "offset_by": {
+                            "years": -16
+                          },
+                          "value": "now"
+                        },
+                        "id": "date-of-birth-answer"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "religion"
+                  }
+                }
+              ],
+              "type": "Question"
+            },
+            {
+              "id": "mixed-ethnic-group",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "id": "mixed-ethnic-group-answer",
+                      "mandatory": false,
+                      "options": [
+                        {
+                          "label": "White and Black Caribbean",
+                          "value": "White and Black Caribbean"
+                        },
+                        {
+                          "label": "White and Black African",
+                          "value": "White and Black African"
+                        },
+                        {
+                          "label": "White and Asian",
+                          "value": "White and Asian"
+                        },
+                        {
+                          "child_answer_id": "mixed-ethnic-group-answer-other",
+                          "label": "Any other Mixed or multiple ethnic background",
+                          "value": "Other"
+                        }
+                      ],
+                      "type": "Radio"
+                    },
+                    {
+                      "id": "mixed-ethnic-group-answer-other",
+                      "label": "Please enter ethnic background",
+                      "mandatory": false,
+                      "parent_answer_id": "mixed-ethnic-group-answer",
+                      "type": "TextField"
+                    }
+                  ],
+                  "id": "mixed-ethnic-group-question",
+                  "title": "Which one best describes <em>{{[answers['first-name'][group_instance], answers['last-name'][group_instance]] | format_household_name_possessive}}</em> Mixed, multiple ethnic group or background?",
+                  "type": "General"
+                }
+              ],
+              "routing_rules": [
+                {
+                  "goto": {
+                    "block": "household-member-completed",
+                    "when": [
+                      {
+                        "condition": "greater than",
+                        "date_comparison": {
+                          "offset_by": {
+                            "years": -16
+                          },
+                          "value": "now"
+                        },
+                        "id": "date-of-birth-answer"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "religion"
+                  }
+                }
+              ],
+              "type": "Question"
+            },
+            {
+              "id": "asian-ethnic-group",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "id": "asian-ethnic-group-answer",
+                      "mandatory": false,
+                      "options": [
+                        {
+                          "label": "Indian",
+                          "value": "Indian"
+                        },
+                        {
+                          "label": "Pakistani",
+                          "value": "Pakistani"
+                        },
+                        {
+                          "label": "Bangladeshi",
+                          "value": "Bangladeshi"
+                        },
+                        {
+                          "label": "Chinese",
+                          "value": "Chinese"
+                        },
+                        {
+                          "child_answer_id": "asian-ethnic-group-answer-other",
+                          "label": "Any other Asian background",
+                          "value": "Other"
+                        }
+                      ],
+                      "type": "Radio"
+                    },
+                    {
+                      "id": "asian-ethnic-group-answer-other",
+                      "label": "Please enter ethnic background",
+                      "mandatory": false,
+                      "parent_answer_id": "asian-ethnic-group-answer",
+                      "type": "TextField"
+                    }
+                  ],
+                  "id": "asian-ethnic-group-question",
+                  "title": "Which one best describes <em>{{[answers['first-name'][group_instance], answers['last-name'][group_instance]] | format_household_name_possessive}}</em> Asian, Asian British ethnic group or background?",
+                  "type": "General"
+                }
+              ],
+              "routing_rules": [
+                {
+                  "goto": {
+                    "block": "household-member-completed",
+                    "when": [
+                      {
+                        "condition": "greater than",
+                        "date_comparison": {
+                          "offset_by": {
+                            "years": -16
+                          },
+                          "value": "now"
+                        },
+                        "id": "date-of-birth-answer"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "religion"
+                  }
+                }
+              ],
+              "type": "Question"
+            },
+            {
+              "id": "black-ethnic-group",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "id": "black-ethnic-group-answer",
+                      "mandatory": false,
+                      "options": [
+                        {
+                          "label": "African",
+                          "value": "African"
+                        },
+                        {
+                          "label": "Caribbean",
+                          "value": "Caribbean"
+                        },
+                        {
+                          "child_answer_id": "black-ethnic-group-answer-other",
+                          "label": "Any other Black, African or Caribbean background",
+                          "value": "Other"
+                        }
+                      ],
+                      "type": "Radio"
+                    },
+                    {
+                      "id": "black-ethnic-group-answer-other",
+                      "label": "Please enter ethnic background",
+                      "mandatory": false,
+                      "parent_answer_id": "black-ethnic-group-answer",
+                      "type": "TextField"
+                    }
+                  ],
+                  "id": "black-ethnic-group-question",
+                  "title": "Which one best describes <em>{{[answers['first-name'][group_instance], answers['last-name'][group_instance]] | format_household_name_possessive}}</em> Black, African, Caribbean, Black British ethnic group or background?",
+                  "type": "General"
+                }
+              ],
+              "routing_rules": [
+                {
+                  "goto": {
+                    "block": "household-member-completed",
+                    "when": [
+                      {
+                        "condition": "greater than",
+                        "date_comparison": {
+                          "offset_by": {
+                            "years": -16
+                          },
+                          "value": "now"
+                        },
+                        "id": "date-of-birth-answer"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "religion"
+                  }
+                }
+              ],
+              "type": "Question"
+            },
+            {
+              "id": "other-ethnic-group",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "id": "other-ethnic-group-answer",
+                      "mandatory": false,
+                      "options": [
+                        {
+                          "label": "Arab",
+                          "value": "Arab"
+                        },
+                        {
+                          "child_answer_id": "other-ethnic-group-answer-other",
+                          "label": "Any other ethnic group",
+                          "value": "Other"
+                        }
+                      ],
+                      "type": "Radio"
+                    },
+                    {
+                      "id": "other-ethnic-group-answer-other",
+                      "label": "Please enter ethnic background",
+                      "mandatory": false,
+                      "parent_answer_id": "other-ethnic-group-answer",
+                      "type": "TextField"
+                    }
+                  ],
+                  "id": "other-ethnic-group-question",
+                  "title": "Which one best describes <em>{{[answers['first-name'][group_instance], answers['last-name'][group_instance]] | format_household_name_possessive}}</em> Other ethnic group or background?",
+                  "type": "General"
+                }
+              ],
+              "routing_rules": [
+                {
+                  "goto": {
+                    "block": "household-member-completed",
+                    "when": [
+                      {
+                        "condition": "greater than",
+                        "date_comparison": {
+                          "offset_by": {
+                            "years": -16
+                          },
+                          "value": "now"
+                        },
+                        "id": "date-of-birth-answer"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "religion"
+                  }
+                }
+              ],
+              "type": "Question"
+            },
+            {
+              "id": "religion",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "id": "religion-answer",
+                      "mandatory": false,
+                      "options": [
+                        {
+                          "label": "No religion",
+                          "value": "No religion"
+                        },
+                        {
+                          "description": "Including Church of England, Catholic, Protestant and other Christian denominations",
+                          "label": "Christian",
+                          "value": "Christian"
+                        },
+                        {
+                          "label": "Buddhist",
+                          "value": "Buddhist"
+                        },
+                        {
+                          "label": "Hindu",
+                          "value": "Hindu"
+                        },
+                        {
+                          "label": "Jewish",
+                          "value": "Jewish"
+                        },
+                        {
+                          "label": "Muslim",
+                          "value": "Muslim"
+                        },
+                        {
+                          "label": "Sikh",
+                          "value": "Sikh"
+                        },
+                        {
+                          "child_answer_id": "religion-answer-other",
+                          "label": "Other religion",
+                          "value": "Other"
+                        }
+                      ],
+                      "type": "Radio"
+                    },
+                    {
+                      "id": "religion-answer-other",
+                      "label": "Please enter religion",
+                      "mandatory": false,
+                      "parent_answer_id": "religion-answer",
+                      "type": "TextField"
+                    }
+                  ],
+                  "description": "",
+                  "id": "religion-question",
+                  "title": "What is <em>{{[answers['first-name'][group_instance], answers['last-name'][group_instance]] | format_household_name_possessive}}</em> religion?",
+                  "type": "General"
+                }
+              ],
+              "routing_rules": [
+                {
+                  "goto": {
+                    "block": "household-member-completed"
+                  }
+                }
+              ],
+              "type": "Question"
+            },
+            {
+              "id": "date-of-birth-no-proxy",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "id": "date-of-birth-answer-np",
+                      "mandatory": false,
+                      "maximum": {
+                        "value": "now"
+                      },
+                      "type": "Date"
+                    }
+                  ],
+                  "id": "date-of-birth-question-np",
+                  "title": "What is your date of birth?",
+                  "type": "General"
+                }
+              ],
+              "routing_rules": [
+                {
+                  "goto": {
+                    "block": "date-of-birth-check-np",
+                    "when": [
+                      {
+                        "condition": "not set",
+                        "id": "date-of-birth-answer-np"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "sex-np"
+                  }
+                }
+              ],
+              "type": "Question"
+            },
+            {
+              "id": "date-of-birth-check-np",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "id": "dob-check-answer-np",
+                      "mandatory": false,
+                      "options": [
+                        {
+                          "label": "Yes",
+                          "value": "Yes"
+                        },
+                        {
+                          "label": "No",
+                          "value": "No"
+                        }
+                      ],
+                      "type": "Radio"
+                    }
+                  ],
+                  "id": "dob-check-question-np",
+                  "title": "Are you aged 16 or over?",
+                  "type": "General"
+                }
+              ],
+              "routing_rules": [
+                {
+                  "goto": {
+                    "block": "household-member-completed",
+                    "when": [
+                      {
+                        "condition": "equals",
+                        "id": "dob-check-answer-np",
+                        "value": "No"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "household-member-completed",
+                    "when": [
+                      {
+                        "condition": "not set",
+                        "id": "dob-check-answer-np"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "sex-np"
+                  }
+                }
+              ],
+              "type": "ConfirmationQuestion"
+            },
+            {
+              "id": "sex-np",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "id": "sex-answer-np",
+                      "mandatory": true,
+                      "options": [
+                        {
+                          "label": "Male",
+                          "value": "Male"
+                        },
+                        {
+                          "label": "Female",
+                          "value": "Female"
+                        }
+                      ],
+                      "type": "Radio"
+                    }
+                  ],
+                  "id": "sex-question-np",
+                  "title": "What is your sex?",
+                  "type": "General"
+                }
+              ],
+              "routing_rules": [
+                {
+                  "goto": {
+                    "block": "marital-status-no-proxy",
+                    "when": [
+                      {
+                        "condition": "less than",
+                        "date_comparison": {
+                          "offset_by": {
+                            "years": -16
+                          },
+                          "value": "now"
+                        },
+                        "id": "date-of-birth-answer-np"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "marital-status-no-proxy",
+                    "when": [
+                      {
+                        "condition": "not set",
+                        "id": "date-of-birth-answer-np"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "nationality-no-proxy"
+                  }
+                }
+              ],
+              "type": "Question"
+            },
+            {
+              "id": "marital-status-no-proxy",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "id": "marital-status-answer-np",
+                      "mandatory": false,
+                      "options": [
+                        {
+                          "label": "Never married",
+                          "value": "Never married"
+                        },
+                        {
+                          "label": "Married",
+                          "value": "Married"
+                        },
+                        {
+                          "label": "In a registered same-sex civil partnership",
+                          "value": "In a registered same-sex civil partnership"
+                        },
+                        {
+                          "label": "Separated, but still legally married",
+                          "value": "Separated, but still legally married"
+                        },
+                        {
+                          "label": "Separated, but still legally in a same-sex civil partnership",
+                          "value": "Separated, but still legally in a same-sex civil partnership"
+                        },
+                        {
+                          "label": "Divorced",
+                          "value": "Divorced"
+                        },
+                        {
+                          "label": "Formerly in a same-sex civil partnership which is now legally dissolved",
+                          "value": "Formerly in a same-sex civil partnership which is now legally dissolved"
+                        },
+                        {
+                          "label": "Widowed",
+                          "value": "Widowed"
+                        },
+                        {
+                          "label": "Surviving member of a same-sex civil partnership",
+                          "value": "Surviving member of a same-sex civil partnership"
+                        }
+                      ],
+                      "type": "Radio"
+                    }
+                  ],
+                  "id": "marital-status-question-np",
+                  "title": "What is your legal marital status?",
+                  "type": "General"
+                }
+              ],
+              "type": "Question"
+            },
+            {
+              "id": "nationality-no-proxy",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "id": "nationality-answer-np",
+                      "mandatory": false,
+                      "options": [
+                        {
+                          "label": "British",
+                          "value": "British"
+                        },
+                        {
+                          "label": "Irish",
+                          "value": "Irish"
+                        },
+                        {
+                          "label": "Indian",
+                          "value": "Indian"
+                        },
+                        {
+                          "label": "Pakistani",
+                          "value": "Pakistani"
+                        },
+                        {
+                          "label": "Polish",
+                          "value": "Polish"
+                        },
+                        {
+                          "child_answer_id": "nationality-answer-other-np",
+                          "label": "Other",
+                          "value": "Other"
+                        }
+                      ],
+                      "type": "Radio"
+                    },
+                    {
+                      "id": "nationality-answer-other-np",
+                      "label": "Please enter nationality",
+                      "mandatory": false,
+                      "parent_answer_id": "nationality-answer-np",
+                      "type": "TextField"
+                    }
+                  ],
+                  "id": "nationality-question-np",
+                  "title": "What is your nationality?",
+                  "type": "General"
+                }
+              ],
+              "type": "Question"
+            },
+            {
+              "id": "country-of-birth-no-proxy",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "id": "country-of-birth-answer-np",
+                      "mandatory": false,
+                      "options": [
+                        {
+                          "label": "England",
+                          "value": "England"
+                        },
+                        {
+                          "label": "Wales",
+                          "value": "Wales"
+                        },
+                        {
+                          "label": "Scotland",
+                          "value": "Scotland"
+                        },
+                        {
+                          "label": "Northern Ireland",
+                          "value": "Northern Ireland"
+                        },
+                        {
+                          "label": "Republic of Ireland",
+                          "value": "Republic of Ireland"
+                        },
+                        {
+                          "label": "Isle of Man or Channel Islands",
+                          "value": "Isle of Man or Channel Islands"
+                        },
+                        {
+                          "label": "India",
+                          "value": "India"
+                        },
+                        {
+                          "label": "Pakistan",
+                          "value": "Pakistan"
+                        },
+                        {
+                          "label": "Poland",
+                          "value": "Poland"
+                        },
+                        {
+                          "child_answer_id": "country-of-birth-answer-other-np",
+                          "label": "Other",
+                          "value": "Other"
+                        }
+                      ],
+                      "type": "Radio"
+                    },
+                    {
+                      "id": "country-of-birth-answer-other-np",
+                      "label": "Please enter your country of birth",
+                      "mandatory": false,
+                      "parent_answer_id": "country-of-birth-answer-np",
+                      "type": "TextField"
+                    }
+                  ],
+                  "id": "country-of-birth-question-np",
+                  "title": "In which country were you born?",
+                  "type": "General"
+                }
+              ],
+              "routing_rules": [
+                {
+                  "goto": {
+                    "block": "national-identity-no-proxy",
+                    "when": [
+                      {
+                        "condition": "equals",
+                        "id": "country-of-birth-answer-np",
+                        "value": "England"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "national-identity-no-proxy",
+                    "when": [
+                      {
+                        "condition": "equals",
+                        "id": "country-of-birth-answer-np",
+                        "value": "Wales"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "national-identity-no-proxy",
+                    "when": [
+                      {
+                        "condition": "equals",
+                        "id": "country-of-birth-answer-np",
+                        "value": "Scotland"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "national-identity-no-proxy",
+                    "when": [
+                      {
+                        "condition": "equals",
+                        "id": "country-of-birth-answer-np",
+                        "value": "Northern Ireland"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "national-identity-no-proxy",
+                    "when": [
+                      {
+                        "condition": "not set",
+                        "id": "country-of-birth-answer-np"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "arrive-in-uk-no-proxy"
+                  }
+                }
+              ],
+              "type": "Question"
+            },
+            {
+              "id": "arrive-in-uk-no-proxy",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "id": "arrive-in-uk-answer-np",
+                      "mandatory": false,
+                      "maximum": {
+                        "value": "now"
+                      },
+                      "type": "MonthYearDate"
+                    }
+                  ],
+                  "id": "arrive-in-uk-question-np",
+                  "title": "When did you first arrive to live in the UK?",
+                  "type": "General"
+                }
+              ],
+              "routing_rules": [
+                {
+                  "goto": {
+                    "block": "arrive-date-in-uk-invalid-no-proxy",
+                    "when": [
+                      {
+                        "condition": "greater than",
+                        "date_comparison": {
+                          "value": "now"
+                        },
+                        "id": "arrive-in-uk-answer-np"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "arrive-date-in-uk-invalid-no-proxy",
+                    "when": [
+                      {
+                        "condition": "less than",
+                        "date_comparison": {
+                          "id": "date-of-birth-answer-np"
+                        },
+                        "id": "arrive-in-uk-answer-np"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "national-identity-no-proxy",
+                    "when": [
+                      {
+                        "condition": "not set",
+                        "id": "arrive-in-uk-answer-np"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "continuous-in-uk-no-proxy"
+                  }
+                }
+              ],
+              "type": "Question"
+            },
+            {
+              "id": "arrive-date-in-uk-invalid-no-proxy",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "id": "arrive-date-in-uk-invalid-answer-np",
+                      "mandatory": true,
+                      "options": [
+                        {
+                          "label": "I&apos;d like to correct my date of birth",
+                          "value": "change dob"
+                        },
+                        {
+                          "label": "I&apos;d like to correct my date of arrival in the UK",
+                          "value": "change arrival"
+                        }
+                      ],
+                      "type": "Radio"
+                    }
+                  ],
+                  "description": "The date you first arrived in the UK must be after your date of birth and not in the future.",
+                  "guidance": {
+                    "content": [
+                      {
+                        "description": "Correct either your date of birth or the date you arrived in the UK."
+                      }
+                    ]
+                  },
+                  "id": "arrive-date-in-uk-invalid-question-np",
+                  "title": "Invalid date entered",
+                  "type": "General"
+                }
+              ],
+              "routing_rules": [
+                {
+                  "goto": {
+                    "block": "date-of-birth-no-proxy",
+                    "when": [
+                      {
+                        "condition": "equals",
+                        "id": "arrive-date-in-uk-invalid-answer-np",
+                        "value": "change dob"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "arrive-in-uk-no-proxy",
+                    "when": [
+                      {
+                        "condition": "equals",
+                        "id": "arrive-date-in-uk-invalid-answer-np",
+                        "value": "change arrival"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "type": "Question"
+            },
+            {
+              "id": "continuous-in-uk-no-proxy",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "id": "continuous-in-uk-answer-np",
+                      "mandatory": false,
+                      "options": [
+                        {
+                          "label": "Yes",
+                          "value": "Yes"
+                        },
+                        {
+                          "label": "No",
+                          "value": "No"
+                        }
+                      ],
+                      "type": "Radio"
+                    }
+                  ],
+                  "id": "continuous-in-uk-question-np",
+                  "title": "Apart from holidays and short visits abroad, have you lived in the UK continuously since {{answers['arrive-in-uk-answer-np'][group_instance]|format_date}}?",
+                  "type": "General"
+                }
+              ],
+              "routing_rules": [
+                {
+                  "goto": {
+                    "block": "national-identity-no-proxy",
+                    "when": [
+                      {
+                        "condition": "equals",
+                        "id": "continuous-in-uk-answer-np",
+                        "value": "Yes"
+                      },
+                      {
+                        "condition": "greater than",
+                        "date_comparison": {
+                          "offset_by": {
+                            "years": -16
+                          },
+                          "value": "now"
+                        },
+                        "id": "date-of-birth-answer-np"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "why-uk-continuous-no-proxy",
+                    "when": [
+                      {
+                        "condition": "equals",
+                        "id": "continuous-in-uk-answer-np",
+                        "value": "Yes"
+                      },
+                      {
+                        "condition": "less than",
+                        "date_comparison": {
+                          "offset_by": {
+                            "years": -16
+                          },
+                          "value": "now"
+                        },
+                        "id": "date-of-birth-answer-np"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "why-uk-continuous-no-proxy",
+                    "when": [
+                      {
+                        "condition": "equals",
+                        "id": "continuous-in-uk-answer-np",
+                        "value": "Yes"
+                      },
+                      {
+                        "condition": "not set",
+                        "id": "date-of-birth-answer-np"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "camyr2-block-no-proxy",
+                    "when": [
+                      {
+                        "condition": "equals",
+                        "id": "continuous-in-uk-answer-np",
+                        "value": "No"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "national-identity-no-proxy"
+                  }
+                }
+              ],
+              "type": "Question"
+            },
+            {
+              "id": "camyr2-block-no-proxy",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "id": "first-arrive-in-uk-answer-np",
+                      "mandatory": false,
+                      "maximum": {
+                        "value": "now"
+                      },
+                      "type": "MonthYearDate"
+                    }
+                  ],
+                  "id": "camyr2-question-np",
+                  "title": "When did you most recently arrive in the United Kingdom?",
+                  "type": "General"
+                }
+              ],
+              "routing_rules": [
+                {
+                  "goto": {
+                    "block": "first-arrive-date-in-uk-invalid-no-proxy",
+                    "when": [
+                      {
+                        "condition": "less than",
+                        "date_comparison": {
+                          "id": "date-of-birth-answer-np"
+                        },
+                        "id": "first-arrive-in-uk-answer-np"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "national-identity-no-proxy",
+                    "when": [
+                      {
+                        "condition": "not set",
+                        "id": "first-arrive-in-uk-answer-np"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "why-uk-no-proxy",
+                    "when": [
+                      {
+                        "condition": "less than",
+                        "date_comparison": {
+                          "offset_by": {
+                            "years": -16
+                          },
+                          "value": "now"
+                        },
+                        "id": "date-of-birth-answer-np"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "why-uk-no-proxy",
+                    "when": [
+                      {
+                        "condition": "not set",
+                        "id": "date-of-birth-answer-np"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "national-identity-no-proxy"
+                  }
+                }
+              ],
+              "type": "Question"
+            },
+            {
+              "id": "first-arrive-date-in-uk-invalid-no-proxy",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "id": "first-arrive-date-in-uk-invalid-answer-np",
+                      "mandatory": true,
+                      "options": [
+                        {
+                          "label": "I&apos;d like to correct my date of birth",
+                          "value": "change dob"
+                        },
+                        {
+                          "label": "I&apos;d like to correct the date of my most recent arrival in the UK",
+                          "value": "change arrival"
+                        }
+                      ],
+                      "type": "Radio"
+                    }
+                  ],
+                  "description": "The date you most recently arrived in the UK must be after your date of birth.",
+                  "guidance": {
+                    "content": [
+                      {
+                        "description": "Correct either your date of birth or the date you most recently arrived in the UK."
+                      }
+                    ]
+                  },
+                  "id": "first-arrive-date-in-uk-invalid-question-np",
+                  "title": "Invalid date entered",
+                  "type": "General"
+                }
+              ],
+              "routing_rules": [
+                {
+                  "goto": {
+                    "block": "date-of-birth-no-proxy",
+                    "when": [
+                      {
+                        "condition": "equals",
+                        "id": "first-arrive-date-in-uk-invalid-answer-np",
+                        "value": "change dob"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "camyr2-block-no-proxy",
+                    "when": [
+                      {
+                        "condition": "equals",
+                        "id": "first-arrive-date-in-uk-invalid-answer-np",
+                        "value": "change arrival"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "type": "Question"
+            },
+            {
+              "id": "why-uk-no-proxy",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "id": "why-uk-answer-np",
+                      "mandatory": false,
+                      "options": [
+                        {
+                          "label": "For employment",
+                          "value": "For employment"
+                        },
+                        {
+                          "label": "For study",
+                          "value": "For study"
+                        },
+                        {
+                          "label": "As a spouse or dependent of a UK citizen or settled person",
+                          "value": "As a spouse or dependent of a UK citizen or settled person"
+                        },
+                        {
+                          "label": "As a spouse or dependent of someone who is coming to or is already in the UK for work or study reasons",
+                          "value": "As a spouse or dependent of someone who is coming to or is already in the UK for work or study reasons"
+                        },
+                        {
+                          "label": "To get married or form a civil partnership in the UK with a non-UK citizen",
+                          "value": "To get married or form a civil partnership in the UK with a non-UK citizen"
+                        },
+                        {
+                          "label": "Seeking asylum",
+                          "value": "Seeking asylum"
+                        },
+                        {
+                          "label": "As a visitor",
+                          "value": "As a visitor"
+                        },
+                        {
+                          "label": "Another reason",
+                          "value": "Another reason"
+                        }
+                      ],
+                      "type": "Radio"
+                    }
+                  ],
+                  "id": "why-uk-question-np",
+                  "title": "What was the main reason for you coming to the UK in {{ max_value(answers['arrive-in-uk-answer-np'][group_instance], answers['first-arrive-in-uk-answer-np'][group_instance])|format_date }}?",
+                  "type": "General"
+                }
+              ],
+              "routing_rules": [
+                {
+                  "goto": {
+                    "block": "national-identity-no-proxy"
+                  }
+                }
+              ],
+              "type": "Question"
+            },
+            {
+              "id": "why-uk-continuous-no-proxy",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "id": "why-uk-continuous-answer-np",
+                      "mandatory": false,
+                      "options": [
+                        {
+                          "label": "For employment",
+                          "value": "For employment"
+                        },
+                        {
+                          "label": "For study",
+                          "value": "For study"
+                        },
+                        {
+                          "label": "As a spouse or dependent of a UK citizen or settled person",
+                          "value": "As a spouse or dependent of a UK citizen or settled person"
+                        },
+                        {
+                          "label": "As a spouse or dependent of someone who is coming to or is already in the UK for work or study reasons",
+                          "value": "As a spouse or dependent of someone who is coming to or is already in the UK for work or study reasons"
+                        },
+                        {
+                          "label": "To get married or form a civil partnership in the UK with a non-UK citizen",
+                          "value": "To get married or form a civil partnership in the UK with a non-UK citizen"
+                        },
+                        {
+                          "label": "Seeking asylum",
+                          "value": "Seeking asylum"
+                        },
+                        {
+                          "label": "As a visitor",
+                          "value": "As a visitor"
+                        },
+                        {
+                          "label": "Another reason",
+                          "value": "Another reason"
+                        }
+                      ],
+                      "type": "Radio"
+                    }
+                  ],
+                  "id": "why-uk-continuous-question-np",
+                  "title": "What was the main reason for you coming to the UK in {{ answers['arrive-in-uk-answer-np'][group_instance]|format_date }}?",
+                  "type": "General"
+                }
+              ],
+              "routing_rules": [
+                {
+                  "goto": {
+                    "block": "national-identity"
+                  }
+                }
+              ],
+              "type": "Question"
+            },
+            {
+              "id": "national-identity-no-proxy",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "id": "national-identity-england-answer-np",
+                      "mandatory": false,
+                      "options": [
+                        {
+                          "label": "English",
+                          "value": "English"
+                        },
+                        {
+                          "label": "Welsh",
+                          "value": "Welsh"
+                        },
+                        {
+                          "label": "Scottish",
+                          "value": "Scottish"
+                        },
+                        {
+                          "label": "Northern Irish",
+                          "value": "Northern Irish"
+                        },
+                        {
+                          "label": "British",
+                          "value": "British"
+                        },
+                        {
+                          "child_answer_id": "national-identity-england-answer-other-np",
+                          "label": "Other",
+                          "value": "Other"
+                        }
+                      ],
+                      "type": "Checkbox"
+                    },
+                    {
+                      "id": "national-identity-england-answer-other-np",
+                      "label": "Please enter your national identity",
+                      "mandatory": false,
+                      "parent_answer_id": "national-identity-england-answer-np",
+                      "type": "TextField"
+                    }
+                  ],
+                  "id": "national-identity-england-question-np",
+                  "skip_conditions": [
+                    {
+                      "when": [
+                        {
+                          "condition": "equals",
+                          "meta": "region_code",
+                          "value": "GB-WLS"
+                        }
+                      ]
+                    }
+                  ],
+                  "title": "What do you consider your national identity to be?",
+                  "type": "General"
+                },
+                {
+                  "answers": [
+                    {
+                      "id": "national-identity-wales-answer-np",
+                      "mandatory": false,
+                      "options": [
+                        {
+                          "label": "Welsh",
+                          "value": "Welsh"
+                        },
+                        {
+                          "label": "English",
+                          "value": "English"
+                        },
+                        {
+                          "label": "Scottish",
+                          "value": "Scottish"
+                        },
+                        {
+                          "label": "Northern Irish",
+                          "value": "Northern Irish"
+                        },
+                        {
+                          "label": "British",
+                          "value": "British"
+                        },
+                        {
+                          "child_answer_id": "national-identity-wales-answer-other-np",
+                          "label": "Other",
+                          "value": "Other"
+                        }
+                      ],
+                      "type": "Checkbox"
+                    },
+                    {
+                      "id": "national-identity-wales-answer-other-np",
+                      "label": "Please enter your national identity",
+                      "mandatory": false,
+                      "parent_answer_id": "national-identity-wales-answer-np",
+                      "type": "TextField"
+                    }
+                  ],
+                  "id": "national-identity-wales-question-no-proxy",
+                  "skip_conditions": [
+                    {
+                      "when": [
+                        {
+                          "condition": "not equals",
+                          "meta": "region_code",
+                          "value": "GB-WLS"
+                        }
+                      ]
+                    }
+                  ],
+                  "title": "What do you consider your national identity to be?",
+                  "type": "General"
+                }
+              ],
+              "routing_rules": [
+                {
+                  "goto": {
+                    "block": "understand-welsh-no-proxy",
+                    "when": [
+                      {
+                        "condition": "equals",
+                        "meta": "region_code",
+                        "value": "GB-WLS"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "ethnic-group-no-proxy"
+                  }
+                }
+              ],
+              "type": "Question"
+            },
+            {
+              "id": "understand-welsh-no-proxy",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "id": "understand-welsh-answer-np",
+                      "mandatory": false,
+                      "options": [
+                        {
+                          "label": "Understand spoken Welsh",
+                          "value": "Understand spoken Welsh"
+                        },
+                        {
+                          "label": "Read Welsh",
+                          "value": "Read Welsh"
+                        },
+                        {
+                          "label": "Write in Welsh",
+                          "value": "Write in Welsh"
+                        },
+                        {
+                          "label": "Speak Welsh",
+                          "value": "Speak Welsh"
+                        },
+                        {
+                          "label": "None of the above",
+                          "value": "None of the above"
+                        }
+                      ],
+                      "type": "Checkbox"
+                    }
+                  ],
+                  "id": "understand-welsh-question-np",
+                  "title": "Can you...",
+                  "type": "General"
+                }
+              ],
+              "routing_rules": [
+                {
+                  "goto": {
+                    "block": "welsh-frequency-no-proxy",
+                    "when": [
+                      {
+                        "condition": "contains",
+                        "id": "understand-welsh-answer-np",
+                        "value": "Speak Welsh"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "ethnic-group-no-proxy"
+                  }
+                }
+              ],
+              "type": "Question"
+            },
+            {
+              "id": "welsh-frequency-no-proxy",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "id": "welsh-frequency-answer-np",
+                      "mandatory": false,
+                      "options": [
+                        {
+                          "label": "Daily",
+                          "value": "Daily"
+                        },
+                        {
+                          "label": "Weekly",
+                          "value": "Weekly"
+                        },
+                        {
+                          "label": "Less often",
+                          "value": "Less often"
+                        },
+                        {
+                          "label": "Never",
+                          "value": "Never"
+                        }
+                      ],
+                      "type": "Radio"
+                    }
+                  ],
+                  "id": "welsh-frequency-question-np",
+                  "title": "How often do you speak Welsh?",
+                  "type": "General"
+                }
+              ],
+              "type": "Question"
+            },
+            {
+              "id": "ethnic-group-no-proxy",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "id": "ethnic-group-answer-np",
+                      "mandatory": false,
+                      "options": [
+                        {
+                          "description": "Includes any White background",
+                          "label": "White",
+                          "value": "White"
+                        },
+                        {
+                          "description": "Includes White and Black Caribbean, White and Black African, White and Asian or any other Mixed ethnic group",
+                          "label": "Mixed or multiple ethnic groups",
+                          "value": "Mixed or multiple ethnic groups"
+                        },
+                        {
+                          "description": "Includes Indian, Pakistani, Bangladeshi, Chinese or any other Asian background",
+                          "label": "Asian or Asian British",
+                          "value": "Asian or Asian British"
+                        },
+                        {
+                          "description": "Includes African, Caribbean or any other Black background",
+                          "label": "Black, African, Caribbean or Black British",
+                          "value": "Black, African, Caribbean or Black British"
+                        },
+                        {
+                          "description": "For example Arab or any other background",
+                          "label": "Other",
+                          "value": "Other"
+                        }
+                      ],
+                      "type": "Radio"
+                    }
+                  ],
+                  "id": "ethnic-group-question-np",
+                  "title": "What is your ethnic group?",
+                  "type": "General"
+                }
+              ],
+              "routing_rules": [
+                {
+                  "goto": {
+                    "block": "white-ethnic-group-no-proxy",
+                    "when": [
+                      {
+                        "condition": "equals",
+                        "id": "ethnic-group-answer-np",
+                        "value": "White"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "mixed-ethnic-group-no-proxy",
+                    "when": [
+                      {
+                        "condition": "equals",
+                        "id": "ethnic-group-answer-np",
+                        "value": "Mixed or multiple ethnic groups"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "asian-ethnic-group-no-proxy",
+                    "when": [
+                      {
+                        "condition": "equals",
+                        "id": "ethnic-group-answer-np",
+                        "value": "Asian or Asian British"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "black-ethnic-group-no-proxy",
+                    "when": [
+                      {
+                        "condition": "equals",
+                        "id": "ethnic-group-answer-np",
+                        "value": "Black, African, Caribbean or Black British"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "other-ethnic-group-no-proxy",
+                    "when": [
+                      {
+                        "condition": "equals",
+                        "id": "ethnic-group-answer-np",
+                        "value": "Other"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "household-member-completed",
+                    "when": [
+                      {
+                        "condition": "greater than",
+                        "date_comparison": {
+                          "offset_by": {
+                            "years": -16
+                          },
+                          "value": "now"
+                        },
+                        "id": "date-of-birth-answer-np"
+                      },
+                      {
+                        "condition": "not set",
+                        "id": "ethnic-group-answer-np"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "religion-no-proxy"
+                  }
+                }
+              ],
+              "type": "Question"
+            },
+            {
+              "id": "white-ethnic-group-no-proxy",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "id": "white-ethnic-group-answer-np",
+                      "mandatory": false,
+                      "options": [
+                        {
+                          "label": "English, Welsh, Scottish, Northern Irish or British",
+                          "value": "English, Welsh, Scottish, Northern Irish or British"
+                        },
+                        {
+                          "label": "Irish",
+                          "value": "Irish"
+                        },
+                        {
+                          "label": "Gypsy or Irish Traveller",
+                          "value": "Gypsy or Irish Traveller"
+                        },
+                        {
+                          "child_answer_id": "white-ethnic-group-answer-other-np",
+                          "label": "Any other White background",
+                          "value": "Other"
+                        }
+                      ],
+                      "type": "Radio"
+                    },
+                    {
+                      "id": "white-ethnic-group-answer-other-np",
+                      "label": "Please enter ethnic background",
+                      "mandatory": false,
+                      "parent_answer_id": "white-ethnic-group-answer-np",
+                      "type": "TextField"
+                    }
+                  ],
+                  "id": "white-ethnic-group-question-np",
+                  "title": "Which one best describes your White ethnic group or background?",
+                  "type": "General"
+                }
+              ],
+              "routing_rules": [
+                {
+                  "goto": {
+                    "block": "household-member-completed",
+                    "when": [
+                      {
+                        "condition": "greater than",
+                        "date_comparison": {
+                          "offset_by": {
+                            "years": -16
+                          },
+                          "value": "now"
+                        },
+                        "id": "date-of-birth-answer-np"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "religion-no-proxy"
+                  }
+                }
+              ],
+              "type": "Question"
+            },
+            {
+              "id": "mixed-ethnic-group-no-proxy",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "id": "mixed-ethnic-group-answer-np",
+                      "mandatory": false,
+                      "options": [
+                        {
+                          "label": "White and Black Caribbean",
+                          "value": "White and Black Caribbean"
+                        },
+                        {
+                          "label": "White and Black African",
+                          "value": "White and Black African"
+                        },
+                        {
+                          "label": "White and Asian",
+                          "value": "White and Asian"
+                        },
+                        {
+                          "child_answer_id": "mixed-ethnic-group-answer-other-np",
+                          "label": "Any other Mixed or multiple ethnic background",
+                          "value": "Other"
+                        }
+                      ],
+                      "type": "Radio"
+                    },
+                    {
+                      "id": "mixed-ethnic-group-answer-other-np",
+                      "label": "Please enter ethnic background",
+                      "mandatory": false,
+                      "parent_answer_id": "mixed-ethnic-group-answer-np",
+                      "type": "TextField"
+                    }
+                  ],
+                  "id": "mixed-ethnic-group-question-np",
+                  "title": "Which one best describes your Mixed, multiple ethnic group or background?",
+                  "type": "General"
+                }
+              ],
+              "routing_rules": [
+                {
+                  "goto": {
+                    "block": "household-member-completed",
+                    "when": [
+                      {
+                        "condition": "greater than",
+                        "date_comparison": {
+                          "offset_by": {
+                            "years": -16
+                          },
+                          "value": "now"
+                        },
+                        "id": "date-of-birth-answer-np"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "religion-no-proxy"
+                  }
+                }
+              ],
+              "type": "Question"
+            },
+            {
+              "id": "asian-ethnic-group-no-proxy",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "id": "asian-ethnic-group-answer-np",
+                      "mandatory": false,
+                      "options": [
+                        {
+                          "label": "Indian",
+                          "value": "Indian"
+                        },
+                        {
+                          "label": "Pakistani",
+                          "value": "Pakistani"
+                        },
+                        {
+                          "label": "Bangladeshi",
+                          "value": "Bangladeshi"
+                        },
+                        {
+                          "label": "Chinese",
+                          "value": "Chinese"
+                        },
+                        {
+                          "child_answer_id": "asian-ethnic-group-answer-other-np",
+                          "label": "Any other Asian background",
+                          "value": "Other"
+                        }
+                      ],
+                      "type": "Radio"
+                    },
+                    {
+                      "id": "asian-ethnic-group-answer-other-np",
+                      "label": "Please enter ethnic background",
+                      "mandatory": false,
+                      "parent_answer_id": "asian-ethnic-group-answer-np",
+                      "type": "TextField"
+                    }
+                  ],
+                  "id": "asian-ethnic-group-question-np",
+                  "title": "Which one best describes your Asian, Asian British ethnic group or background?",
+                  "type": "General"
+                }
+              ],
+              "routing_rules": [
+                {
+                  "goto": {
+                    "block": "household-member-completed",
+                    "when": [
+                      {
+                        "condition": "greater than",
+                        "date_comparison": {
+                          "offset_by": {
+                            "years": -16
+                          },
+                          "value": "now"
+                        },
+                        "id": "date-of-birth-answer-np"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "religion-no-proxy"
+                  }
+                }
+              ],
+              "type": "Question"
+            },
+            {
+              "id": "black-ethnic-group-no-proxy",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "id": "black-ethnic-group-answer-np",
+                      "mandatory": false,
+                      "options": [
+                        {
+                          "label": "African",
+                          "value": "African"
+                        },
+                        {
+                          "label": "Caribbean",
+                          "value": "Caribbean"
+                        },
+                        {
+                          "child_answer_id": "black-ethnic-group-answer-other-np",
+                          "label": "Any other Black, African or Caribbean background",
+                          "value": "Other"
+                        }
+                      ],
+                      "type": "Radio"
+                    },
+                    {
+                      "id": "black-ethnic-group-answer-other-np",
+                      "label": "Please enter ethnic background",
+                      "mandatory": false,
+                      "parent_answer_id": "black-ethnic-group-answer-np",
+                      "type": "TextField"
+                    }
+                  ],
+                  "id": "black-ethnic-group-question-np",
+                  "title": "Which one best describes your Black, African, Caribbean, Black British ethnic group or background?",
+                  "type": "General"
+                }
+              ],
+              "routing_rules": [
+                {
+                  "goto": {
+                    "block": "household-member-completed",
+                    "when": [
+                      {
+                        "condition": "greater than",
+                        "date_comparison": {
+                          "offset_by": {
+                            "years": -16
+                          },
+                          "value": "now"
+                        },
+                        "id": "date-of-birth-answer-np"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "religion-no-proxy"
+                  }
+                }
+              ],
+              "type": "Question"
+            },
+            {
+              "id": "other-ethnic-group-no-proxy",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "id": "other-ethnic-group-answer-np",
+                      "mandatory": false,
+                      "options": [
+                        {
+                          "label": "Arab",
+                          "value": "Arab"
+                        },
+                        {
+                          "child_answer_id": "other-ethnic-group-answer-other-np",
+                          "label": "Any other ethnic group",
+                          "value": "Other"
+                        }
+                      ],
+                      "type": "Radio"
+                    },
+                    {
+                      "id": "other-ethnic-group-answer-other-np",
+                      "label": "Please enter ethnic background",
+                      "mandatory": false,
+                      "parent_answer_id": "other-ethnic-group-answer-np",
+                      "type": "TextField"
+                    }
+                  ],
+                  "id": "other-ethnic-group-question-np",
+                  "title": "Which one best describes your ethnic group or background?",
+                  "type": "General"
+                }
+              ],
+              "routing_rules": [
+                {
+                  "goto": {
+                    "block": "household-member-completed",
+                    "when": [
+                      {
+                        "condition": "greater than",
+                        "date_comparison": {
+                          "offset_by": {
+                            "years": -16
+                          },
+                          "value": "now"
+                        },
+                        "id": "date-of-birth-answer-np"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "religion-no-proxy"
+                  }
+                }
+              ],
+              "type": "Question"
+            },
+            {
+              "id": "religion-no-proxy",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "id": "religion-answer-np",
+                      "mandatory": false,
+                      "options": [
+                        {
+                          "label": "No religion",
+                          "value": "No religion"
+                        },
+                        {
+                          "description": "Including Church of England, Catholic, Protestant and other Christian denominations",
+                          "label": "Christian",
+                          "value": "Christian"
+                        },
+                        {
+                          "label": "Buddhist",
+                          "value": "Buddhist"
+                        },
+                        {
+                          "label": "Hindu",
+                          "value": "Hindu"
+                        },
+                        {
+                          "label": "Jewish",
+                          "value": "Jewish"
+                        },
+                        {
+                          "label": "Muslim",
+                          "value": "Muslim"
+                        },
+                        {
+                          "label": "Sikh",
+                          "value": "Sikh"
+                        },
+                        {
+                          "child_answer_id": "religion-answer-other-np",
+                          "label": "Other religion",
+                          "value": "Other religion"
+                        }
+                      ],
+                      "type": "Radio"
+                    },
+                    {
+                      "id": "religion-answer-other-np",
+                      "label": "Please enter religion",
+                      "mandatory": false,
+                      "parent_answer_id": "religion-answer-np",
+                      "type": "TextField"
+                    }
+                  ],
+                  "id": "religion-question-np",
+                  "title": "What is your religion?",
+                  "type": "General"
+                }
+              ],
+              "routing_rules": [
+                {
+                  "goto": {
+                    "block": "household-member-completed"
+                  }
+                }
+              ],
+              "type": "Question"
+            },
+            {
+              "description": "",
+              "id": "household-member-completed",
+              "title": "There are no more questions for {{[answers['first-name'][group_instance], answers['last-name'][group_instance]] | format_household_name}}",
+              "type": "Interstitial"
+            }
+          ],
+          "id": "household-member-group",
+          "routing_rules": [
+            {
+              "repeat": {
+                "answer_id": "first-name",
+                "type": "answer_count"
+              }
+            }
+          ],
+          "title": "Household Member Details"
+        }
+      ],
+      "id": "household-members-section",
+      "title_from_answers": [
+        "first-name",
+        "last-name"
+      ]
+    },
+    {
+      "groups": [
+        {
+          "blocks": [
+            {
+              "id": "thank-you-block",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "id": "phone-number",
+                      "label": "Phone number",
+                      "mandatory": false,
+                      "type": "TextField"
+                    },
+                    {
+                      "id": "email",
+                      "label": "Email address",
+                      "mandatory": false,
+                      "type": "TextField"
+                    },
+                    {
+                      "id": "confirm-email",
+                      "label": "Confirm email address",
+                      "mandatory": false,
+                      "type": "TextField"
+                    }
+                  ],
+                  "description": "Your contribution so far has been invaluable. Before you submit your answers, please provide an email address and/or a phone number - you may be re-contacted to take part in future research to help us to improve this service.",
+                  "id": "thank-you-question",
+                  "title": "Thank you, you're almost done.",
+                  "type": "General"
+                }
+              ],
+              "type": "Question"
+            },
+            {
+              "id": "confirmation",
+              "questions": [
+                {
+                  "answers": [],
+                  "description": "<p>Thank you for taking the time to provide your answers to these questions. The information you have provided will be held securely and treated as confidential as directed by the Code of Practice for Official Statistics.</p><p>Please submit your responses by using the <em>Submit answers</em> button below. This will lock your questionnaire so that it will not be possible to re-enter the survey.</p>",
+                  "id": "questionnaire-completed-question",
+                  "title": "Thank you, please submit your answers.",
+                  "type": "General"
+                }
+              ],
+              "title": "",
+              "type": "Confirmation"
+            }
+          ],
+          "id": "questionnaire-completed",
+          "title": "Submit answers"
+        }
+      ],
+      "id": "submit-answers",
+      "title": "Submit answers"
+    }
+  ],
+  "survey_id": "lms ",
+  "theme": "default",
+  "title": "Labour Market Survey (Alpha)"
 }

--- a/tests/schemas/test_invalid_yyyy_date_range_period.json
+++ b/tests/schemas/test_invalid_yyyy_date_range_period.json
@@ -1,83 +1,95 @@
 {
-    "mime_type": "application/json/ons/eq",
-    "schema_version": "0.0.1",
-    "data_version": "0.0.2",
-    "survey_id": "023",
-    "title": "Date formats",
-    "description": "A test schema for different date formats",
-    "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
-    "metadata": {
-        "user_id": {
-            "validator": "string"
-        },
-        "period_id": {
-            "validator": "string"
-        },
-        "ru_name": {
-            "validator": "string"
-        },
-        "ref_p_start_date": {
-            "validator": "date"
-        },
-        "ref_p_end_date": {
-            "validator": "date"
-        }
+  "data_version": "0.0.2",
+  "description": "A test schema for different date formats",
+  "legal_basis": "StatisticsOfTradeAct",
+  "metadata": [
+    {
+      "name": "user_id",
+      "validator": "string"
     },
-    "sections": [{
-        "id": "default-section",
-        "groups": [{
-            "id": "dates",
-            "title": "Date Range Validation",
-            "blocks": [
+    {
+      "name": "ref_p_end_date",
+      "validator": "date"
+    },
+    {
+      "name": "ref_p_start_date",
+      "validator": "date"
+    },
+    {
+      "name": "ru_name",
+      "validator": "string"
+    },
+    {
+      "name": "period_id",
+      "validator": "string"
+    }
+  ],
+  "mime_type": "application/json/ons/eq",
+  "schema_version": "0.0.1",
+  "sections": [
+    {
+      "groups": [
+        {
+          "blocks": [
+            {
+              "id": "date-range-block",
+              "questions": [
                 {
-                    "type": "Question",
-                    "id": "date-range-block",
-                    "title": "Date Range",
-                    "questions": [{
-                        "id": "date-range-question",
-                        "title": "Enter Date Range",
-                        "type": "DateRange",
-                        "period_limits": {
-                            "minimum": {
-                                "days": 1
-                            },
-                            "maximum": {
-                                "months": 2
-                            }
-                        },
-                        "answers": [{
-                                "id": "date-range-from",
-                                "label": "Period from",
-                                "mandatory": true,
-                                "type": "YearDate",
-                                "minimum": {
-                                    "meta": "ref_p_start_date",
-                                    "offset_by": {
-                                        "years": -1
-                                    }
-                                }
-                            },
-                            {
-                                "id": "date-range-to",
-                                "label": "Period to",
-                                "mandatory": true,
-                                "type": "YearDate",
-                                "maximum": {
-                                    "meta": "ref_p_end_date",
-                                    "offset_by": {
-                                        "years": 2
-                                    }
-                                }
-                            }
-                        ]
-                    }]
-                },
-                {
-                    "type": "Summary",
-                    "id": "summary"
+                  "answers": [
+                    {
+                      "id": "date-range-from",
+                      "label": "Period from",
+                      "mandatory": true,
+                      "minimum": {
+                        "meta": "ref_p_start_date",
+                        "offset_by": {
+                          "years": -1
+                        }
+                      },
+                      "type": "YearDate"
+                    },
+                    {
+                      "id": "date-range-to",
+                      "label": "Period to",
+                      "mandatory": true,
+                      "maximum": {
+                        "meta": "ref_p_end_date",
+                        "offset_by": {
+                          "years": 2
+                        }
+                      },
+                      "type": "YearDate"
+                    }
+                  ],
+                  "id": "date-range-question",
+                  "period_limits": {
+                    "maximum": {
+                      "months": 2
+                    },
+                    "minimum": {
+                      "days": 1
+                    }
+                  },
+                  "title": "Enter Date Range",
+                  "type": "DateRange"
                 }
-            ]
-        }]
-    }]
+              ],
+              "title": "Date Range",
+              "type": "Question"
+            },
+            {
+              "id": "summary",
+              "type": "Summary"
+            }
+          ],
+          "id": "dates",
+          "title": "Date Range Validation"
+        }
+      ],
+      "id": "default-section"
+    }
+  ],
+  "survey_id": "023",
+  "theme": "default",
+  "title": "Date formats"
 }

--- a/tests/schemas/test_numeric_default_with_routing.json
+++ b/tests/schemas/test_numeric_default_with_routing.json
@@ -1,102 +1,122 @@
 {
-    "mime_type": "application/json/ons/eq",
-    "schema_version": "0.0.1",
-    "data_version": "0.0.1",
-    "survey_id": "0",
-    "title": "Minimum and maximum exclusivity",
-    "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
-    "description": "A questionnaire to test currency input type",
-    "metadata": {
-        "user_id": {
-            "validator": "string"
-        },
-        "period_id": {
-            "validator": "string"
-        },
-        "ru_name": {
-            "validator": "string"
-        }
+  "data_version": "0.0.1",
+  "description": "A questionnaire to test currency input type",
+  "legal_basis": "StatisticsOfTradeAct",
+  "metadata": [
+    {
+      "name": "user_id",
+      "validator": "string"
     },
-    "sections": [{
-        "id": "section-1",
-        "groups": [{
-            "id": "group",
-            "title": "Testing range of linked answers, with min/max_values",
-            "blocks": [{
-                    "type": "Question",
-                    "id": "block-1",
-                    "questions": [{
-                        "id": "question-1",
-                        "title": "Enter a value 1",
-                        "type": "General",
-                        "answers": [{
-                                "id": "answer-1",
-                                "type": "Number",
-                                "mandatory": false,
-                                "default": 0
-                            }
-                        ]
-                    }],
-                    "routing_rules": [{
-                                "goto": {
-                                    "when": [{
-                                        "value": "0",
-                                        "id": "answer-1",
-                                        "condition": "equals"
-                                    }],
-                                    "block": "block-3"
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "block-2"
-                                }
-                            }
-                        ]
-                },
+    {
+      "name": "ru_name",
+      "validator": "string"
+    },
+    {
+      "name": "period_id",
+      "validator": "string"
+    }
+  ],
+  "mime_type": "application/json/ons/eq",
+  "schema_version": "0.0.1",
+  "sections": [
+    {
+      "groups": [
+        {
+          "blocks": [
+            {
+              "id": "block-1",
+              "questions": [
                 {
-                    "type": "Question",
-                    "id": "block-2",
-                    "questions": [{
-                        "type": "General",
-                        "id": "question-2",
-                        "title": "Enter a value 2",
-                        "answers": [{
-                                "id": "answer-2",
-                                "label": "Invalid Range",
-                                "type": "Currency",
-                                "mandatory": false,
-                                "currency": "GBP",
-                                "max_value": {
-                                    "answer_id": "answer-1",
-                                    "exclusive": true
-                                }
-                            }
-                        ]
-                    }]
-                },
-                {
-                    "type": "Question",
-                    "id": "block-3",
-                    "questions": [{
-                        "type": "General",
-                        "id": "question-3",
-                        "title": "Enter a value 3",
-                        "answers": [{
-                                "id": "answer-3",
-                                "label": "Invalid References",
-                                "type": "Percentage",
-                                "mandatory": false
-                            }
-                        ]
-                    }]
-                },
-                {
-                    "type": "Summary",
-                    "id": "summary"
+                  "answers": [
+                    {
+                      "default": 0,
+                      "id": "answer-1",
+                      "mandatory": false,
+                      "type": "Number"
+                    }
+                  ],
+                  "id": "question-1",
+                  "title": "Enter a value 1",
+                  "type": "General"
                 }
-            ]
-        }]
-    }]
+              ],
+              "routing_rules": [
+                {
+                  "goto": {
+                    "block": "block-3",
+                    "when": [
+                      {
+                        "condition": "equals",
+                        "id": "answer-1",
+                        "value": "0"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "block-2"
+                  }
+                }
+              ],
+              "type": "Question"
+            },
+            {
+              "id": "block-2",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "currency": "GBP",
+                      "id": "answer-2",
+                      "label": "Invalid Range",
+                      "mandatory": false,
+                      "max_value": {
+                        "answer_id": "answer-1",
+                        "exclusive": true
+                      },
+                      "type": "Currency"
+                    }
+                  ],
+                  "id": "question-2",
+                  "title": "Enter a value 2",
+                  "type": "General"
+                }
+              ],
+              "type": "Question"
+            },
+            {
+              "id": "block-3",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "id": "answer-3",
+                      "label": "Invalid References",
+                      "mandatory": false,
+                      "type": "Percentage"
+                    }
+                  ],
+                  "id": "question-3",
+                  "title": "Enter a value 3",
+                  "type": "General"
+                }
+              ],
+              "type": "Question"
+            },
+            {
+              "id": "summary",
+              "type": "Summary"
+            }
+          ],
+          "id": "group",
+          "title": "Testing range of linked answers, with min/max_values"
+        }
+      ],
+      "id": "section-1"
+    }
+  ],
+  "survey_id": "0",
+  "theme": "default",
+  "title": "Minimum and maximum exclusivity"
 }

--- a/tests/schemas/test_schema_id_regex.json
+++ b/tests/schemas/test_schema_id_regex.json
@@ -1,58 +1,72 @@
 {
-    "mime_type": "application/json/ons/eq",
-    "schema_version": "0.0.1",
-    "data_version": "0.0.1",
-    "survey_id": "0",
-    "title": "Test Schema ID",
-    "theme": "default",
-    "legal_basis": "StatisticsOfTradeAct",
-    "description": "A questionnaire to test schema id regex",
-    "metadata": {
-        "user_id": {
-            "validator": "string"
-        },
-        "period_id": {
-            "validator": "string"
-        },
-        "ru_name": {
-            "validator": "string"
-        }
+  "data_version": "0.0.1",
+  "description": "A questionnaire to test schema id regex",
+  "legal_basis": "StatisticsOfTradeAct",
+  "metadata": [
+    {
+      "name": "user_id",
+      "validator": "string"
     },
-    "sections": [{
-        "id": "section1",
-        "groups": [{
-            "blocks": [{
-                "type": "Question",
-                "id": "block",
-                "questions": [{
-                    "answers": [{
-                        "description": "Enter percentage of growth",
-                        "id": "answer",
-                        "label": "New to the market 2012-2014",
-                        "mandatory": false,
-                        "q_code": "0",
-                        "type": "Percentage",
-                        "max_value": {
-                            "value": 100
-                        }
-                    }],
-                    "id": "question",
-                    "title": "Test Question",
-                    "type": "General"
-                }],
-                "title": "Percentage Input Test"
-            }],
-                "id": "group",
-                "title": "Test Group"
-            },
+    {
+      "name": "ru_name",
+      "validator": "string"
+    },
+    {
+      "name": "period_id",
+      "validator": "string"
+    }
+  ],
+  "mime_type": "application/json/ons/eq",
+  "schema_version": "0.0.1",
+  "sections": [
+    {
+      "groups": [
+        {
+          "blocks": [
             {
-                "blocks": [{
-                    "type": "Summary",
-                    "id": "summary"
-                }],
-                "id": "summary-group",
-                "title": "Summary"
+              "id": "block",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "description": "Enter percentage of growth",
+                      "id": "answer",
+                      "label": "New to the market 2012-2014",
+                      "mandatory": false,
+                      "max_value": {
+                        "value": 100
+                      },
+                      "q_code": "0",
+                      "type": "Percentage"
+                    }
+                  ],
+                  "id": "question",
+                  "title": "Test Question",
+                  "type": "General"
+                }
+              ],
+              "title": "Percentage Input Test",
+              "type": "Question"
             }
-        ]
-    }]
+          ],
+          "id": "group",
+          "title": "Test Group"
+        },
+        {
+          "blocks": [
+            {
+              "id": "summary",
+              "type": "Summary"
+            }
+          ],
+          "id": "summary-group",
+          "title": "Summary"
+        }
+      ],
+      "id": "section1"
+    }
+  ],
+  "survey_id": "0",
+  "theme": "default",
+  "title": "Test Schema ID"
 }

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -255,9 +255,7 @@ class TestSchemaValidation(unittest.TestCase):
         self.assertEqual(errors[3]['message'], 'Schema Integrity Error. '
                                                "Invalid answer id 'seventh-number-answer' in block "
                                                "total-playback-answer-error's answers_to_calculate")
-        self.assertEqual(errors[4]['message'], 'Schema Integrity Error. '
-                                               "Duplicate answers: {'sixth-number-answer', 'fourth-number-answer'} "
-                                               "in block total-playback-duplicate-error's answers_to_calculate")
+        self.assertIn('Duplicate answers: ', errors[4]['message'])
 
     @staticmethod
     def open_and_load_schema_file(file):


### PR DESCRIPTION
Changes the allowed structure of metadata to 
```
"metadata": [
    {
        "name": "period_id",
        "validator": "string"
    },
```
from
```
"metadata": {
    "period_id": {
        "validator": "string"
    },
```

Json reformat is a pain, do we have any suggestions for a consistent formatter for JSON that we can automate?