### PR TITLE
Add boolean metadata value type, remove object

### DIFF
--- a/schemas/questionnaire_v1.json
+++ b/schemas/questionnaire_v1.json
@@ -72,9 +72,10 @@
           "validator": {
             "type": "string",
             "enum": [
+              "boolean",
               "date",
               "string",
-              "object"
+              "uuid"
             ]
           }
         },

--- a/tests/schemas/test_invalid_metadata.json
+++ b/tests/schemas/test_invalid_metadata.json
@@ -44,12 +44,16 @@
       "validator": "date"
     },
     {
-      "name": "variant_flags",
-      "validator": "object"
+      "name": "flag",
+      "validator": "boolean"
     },
     {
       "name": "period_str",
       "validator": "string"
+    },
+    {
+      "name": "case_id",
+      "validator": "uuid"
     }
   ],
   "mime_type": "application/json/ons/eq",
@@ -89,7 +93,10 @@
                       "title": "region_code: {{ metadata['region_code'] }}"
                     },
                     {
-                      "title": "variant_flags: {{ metadata['variant_flags'] }}"
+                      "title": "flag: {{ metadata['flag'] }}"
+                    },
+                    {
+                      "title": "case_id: {{ metadata['case_id'] }}"
                     },
                     {
                       "title": "Invalid: {{ metadata['invalid'] }}"


### PR DESCRIPTION
In aid of flattening out `variant_flags` in to the top level claims object of the JWT, it became apparent that a boolean validator type was needed.

Tested against the updated schemas in https://github.com/ONSdigital/eq-survey-runner/pull/1715