### PR TITLE
Changes for comparison_id in when clauses

### DIFF
--- a/schemas/common_definitions.json
+++ b/schemas/common_definitions.json
@@ -137,6 +137,10 @@
             "integer"
           ]
         },
+        "comparison_id": {
+            "type": "string",
+            "description": "The id of an answer which should be compared to."
+        },
         "date_comparison": {
           "type": "object",
           "properties": {

--- a/schemas/lists/currencies.json
+++ b/schemas/lists/currencies.json
@@ -71,7 +71,6 @@
       "IDR",
       "ILS",
       "INR",
-      "INR",
       "IQD",
       "IRR",
       "ISK",

--- a/tests/schemas/test_invalid_answer_comparison_id.json
+++ b/tests/schemas/test_invalid_answer_comparison_id.json
@@ -1,0 +1,226 @@
+{
+  "mime_type": "application/json/ons/eq",
+  "schema_version": "0.0.1",
+  "data_version": "0.0.2",
+  "survey_id": "001",
+  "title": "Test Routing Answer Comparisons",
+  "theme": "default",
+  "legal_basis": "StatisticsOfTradeAct",
+  "description": "A test survey for routing based comparison with answers",
+  "metadata": [{
+    "name": "user_id",
+    "validator": "string"
+  }, {
+    "name": "period_id",
+    "validator": "string"
+  }, {
+    "name": "ru_name",
+    "validator": "string"
+  }],
+  "sections": [{
+    "id": "default-section",
+    "groups": [{
+      "id": "repeating-comparison",
+      "title": "Repeat until comparison",
+      "routing_rules": [{
+        "repeat": {
+          "type": "until",
+          "when": [{
+            "id": "repeating-comparison-1-answer",
+            "condition": "equals",
+            "comparison_id": "bad-answer-id-1"
+          }]
+        }
+      }],
+      "blocks": [{
+        "type": "Question",
+        "id": "repeating-comparison-1-block",
+        "title": "",
+        "description": "",
+        "questions": [{
+          "description": "",
+          "id": "repeating-comparison-1-question",
+          "title": "Enter a number",
+          "type": "General",
+          "answers": [{
+            "id": "repeating-comparison-1-answer",
+            "description": "",
+            "label": "A number",
+            "mandatory": true,
+            "type": "Number"
+          }]
+        }]
+      },{
+        "type": "Question",
+        "id": "repeating-comparison-2-block",
+        "title": "Enter the same number to stop",
+        "description": "",
+        "questions": [{
+          "description": "",
+          "id": "repeating-comparison-2-question",
+          "title": "Enter another number",
+          "type": "General",
+          "answers": [{
+            "id": "repeating-comparison-2-answer",
+            "description": "",
+            "label": "Another number",
+            "mandatory": true,
+            "type": "Number"
+          }]
+        }]
+      }]
+    }, {
+      "id": "route-group",
+      "title": "",
+      "blocks": [{
+        "type": "Question",
+        "id": "route-comparison-1",
+        "description": "",
+        "questions": [{
+          "answers": [{
+            "id": "route-comparison-1-answer",
+            "label": "1st Number",
+            "mandatory": true,
+            "type": "Number"
+          }],
+          "description": "",
+          "id": "route-comparison-1-question",
+          "title": "Enter your first number",
+          "type": "General"
+        }]
+      }, {
+        "type": "Question",
+        "id": "route-comparison-2",
+        "description": "",
+        "questions": [{
+          "answers": [{
+            "id": "route-comparison-2-answer",
+            "label": "2nd Number",
+            "mandatory": true,
+            "type": "Number"
+          }],
+          "description": "",
+          "id": "route-comparison-2-question",
+          "title": "Enter a higher number to skip the next interstitial",
+          "type": "General"
+        }],
+        "routing_rules": [{
+          "goto": {
+            "block": "route-comparison-4",
+            "when": [{
+              "id": "route-comparison-2-answer",
+              "condition": "greater than",
+              "comparison_id": "bad-answer-id-2"
+            }]
+          }
+        }, {
+          "goto": {
+            "block": "route-comparison-3"
+          }
+        }]
+      }, {
+        "type": "Interstitial",
+        "id": "route-comparison-3",
+        "title": "Your second number was lower or equal",
+        "description": "This page should be skipped if your second answer was higher than your first"
+      },
+        {
+          "type": "Interstitial",
+          "id": "route-comparison-4",
+          "title": "Your second number was higher",
+          "description": "This page should never be skipped"
+        }]
+    }, {
+      "blocks": [{
+        "type": "Question",
+        "id": "comparison-1",
+        "description": "",
+        "questions": [{
+          "answers": [{
+            "id": "comparison-1-answer",
+            "label": "1st Number",
+            "mandatory": true,
+            "type": "Number"
+          }],
+          "description": "",
+          "id": "comparison-1-question",
+          "title": "Enter your first number",
+          "type": "General"
+        }]
+      }, {
+        "type": "Question",
+        "id": "comparison-2",
+        "description": "",
+        "questions": [{
+          "answers": [{
+            "id": "comparison-2-answer",
+            "label": "2nd Number",
+            "mandatory": true,
+            "type": "Number"
+          }],
+          "description": "",
+          "id": "comparison-2-question",
+          "title": "Enter your second number",
+          "type": "General"
+        }]
+      }, {
+        "type": "Interstitial",
+        "id": "equals-answers",
+        "title": "Second equal first",
+        "description": "Your second number was equal to your first number",
+        "skip_conditions": [{
+          "when": [{
+            "id": "comparison-1-answer",
+            "condition": "not equals",
+            "comparison_id": "bad-answer-id-3"
+          }]
+        }]
+      }, {
+        "type": "Interstitial",
+        "id": "less-than-answers",
+        "title": "First less than second",
+        "description": "Your first answer was less than your second number",
+        "skip_conditions": [{
+          "when": [{
+            "id": "comparison-1-answer",
+            "condition": "greater than",
+            "comparison_id": "bad-answer-id-4"
+          }]
+        }, {
+          "when": [{
+            "id": "comparison-1-answer",
+            "condition": "equals",
+            "comparison_id": "bad-answer-id-5"
+          }]
+        }]
+      }, {
+        "type": "Interstitial",
+        "id": "greater-than-answers",
+        "title": "First greater than second",
+        "description": "Your first answer was greater than your second number",
+        "skip_conditions": [{
+          "when": [{
+            "id": "comparison-1-answer",
+            "condition": "less than",
+            "comparison_id": "bad-answer-id-6"
+          }]
+        }, {
+          "when": [{
+            "id": "bad-answer-id-7",
+            "condition": "equals",
+            "comparison_id": "comparison-2-answer"
+          }]
+        }]
+      }],
+      "id": "skip-group",
+      "title": ""
+    }, {
+      "id": "summary-group",
+      "title": "",
+      "blocks": [{
+        "type": "Summary",
+        "id": "summary"
+      }]
+    }]
+  }]
+}

--- a/tests/schemas/test_invalid_answer_comparison_types.json
+++ b/tests/schemas/test_invalid_answer_comparison_types.json
@@ -1,0 +1,260 @@
+{
+    "mime_type": "application/json/ons/eq",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.2",
+    "survey_id": "001",
+    "title": "Test Routing Answer Comparisons",
+    "theme": "default",
+    "legal_basis": "StatisticsOfTradeAct",
+    "description": "A test survey for routing based comparison with answers",
+    "metadata": [{
+        "name": "user_id",
+        "validator": "string"
+    }, {
+        "name": "period_id",
+        "validator": "string"
+    }, {
+        "name": "ru_name",
+        "validator": "string"
+    }],
+    "sections": [{
+        "id": "default-section",
+        "groups": [{
+            "id": "repeating-comparison",
+            "title": "Repeat until comparison",
+            "routing_rules": [{
+                "repeat": {
+                    "type": "until",
+                    "when": [{
+                        "id": "repeating-comparison-1-answer",
+                        "condition": "equals",
+                        "comparison_id": "repeating-comparison-2-answer"
+                    }]
+                }
+            }],
+            "blocks": [{
+                "type": "Question",
+                "id": "repeating-comparison-1-block",
+                "title": "",
+                "description": "",
+                "questions": [{
+                    "description": "",
+                    "id": "repeating-comparison-1-question",
+                    "title": "Enter a number",
+                    "type": "General",
+                    "answers": [{
+                        "id": "repeating-comparison-1-answer",
+                        "description": "",
+                        "label": "A number",
+                        "mandatory": true,
+                        "type": "Number"
+                    }]
+                }]
+            },{
+                "type": "Question",
+                "id": "repeating-comparison-2-block",
+                "title": "Enter the same number to stop",
+                "description": "",
+                "questions": [{
+                    "description": "",
+                    "id": "repeating-comparison-2-question",
+                    "title": "Enter another number",
+                    "type": "General",
+                    "answers": [{
+                        "id": "repeating-comparison-2-answer",
+                        "description": "",
+                        "label": "Another number",
+                        "mandatory": true,
+                        "type": "TextField"
+                    }]
+                }]
+            }]
+        }, {
+            "id": "route-group",
+            "title": "",
+            "blocks": [{
+                "type": "Question",
+                "id": "route-comparison-1",
+                "description": "",
+                "questions": [{
+                    "answers": [{
+                        "id": "route-comparison-1-answer",
+                        "label": "1st Number",
+                        "mandatory": true,
+                        "type": "Number"
+                    }],
+                    "description": "",
+                    "id": "route-comparison-1-question",
+                    "title": "Enter your first number",
+                    "type": "General"
+                }]
+            }, {
+                "type": "Question",
+                "id": "route-comparison-2",
+                "description": "",
+                "questions": [{
+                    "answers": [{
+                        "id": "route-comparison-2-answer",
+                        "label": "2nd Number",
+                        "mandatory": true,
+                        "type": "TextField"
+                    }],
+                    "description": "",
+                    "id": "route-comparison-2-question",
+                    "title": "Enter a higher number to skip the next interstitial",
+                    "type": "General"
+                }],
+                "routing_rules": [{
+                    "goto": {
+                        "block": "route-comparison-4",
+                        "when": [{
+                            "id": "route-comparison-2-answer",
+                            "condition": "greater than",
+                            "comparison_id": "route-comparison-1-answer"
+                        }]
+                    }
+                }, {
+                    "goto": {
+                        "block": "route-comparison-3"
+                    }
+                }]
+            }, {
+                "type": "Interstitial",
+                "id": "route-comparison-3",
+                "title": "Your second number was lower or equal",
+                "description": "This page should be skipped if your second answer was higher than your first"
+            },
+            {
+                "type": "Interstitial",
+                "id": "route-comparison-4",
+                "title": "Your second number was higher",
+                "description": "This page should never be skipped"
+            }]
+        }, {
+            "blocks": [{
+                "type": "Question",
+                "id": "comparison-1",
+                "description": "",
+                "questions": [{
+                    "answers": [{
+                        "id": "comparison-1-answer",
+                        "label": "1st Number",
+                        "mandatory": true,
+                        "type": "Number"
+                    }],
+                    "description": "",
+                    "id": "comparison-1-question",
+                    "title": "Enter your first number",
+                    "type": "General"
+                }]
+            }, {
+                "type": "Question",
+                "id": "comparison-2",
+                "description": "",
+                "questions": [{
+                    "answers": [{
+                        "id": "comparison-2-answer",
+                        "label": "2nd Number",
+                        "mandatory": true,
+                        "type": "TextField"
+                    }],
+                    "description": "",
+                    "id": "comparison-2-question",
+                    "title": "Enter your second number",
+                    "type": "General"
+                }]
+            }, {
+                "type": "Question",
+                "id": "comparison-3",
+                "description": "",
+                "questions": [{
+                    "answers": [{
+                        "id": "comparison-3-answer",
+                        "label": "2nd Number",
+                        "mandatory": true,
+                        "type": "TextField"
+                    }],
+                    "description": "",
+                    "id": "comparison-3-question",
+                    "type": "General",
+                    "titles": [{
+                        "value": "What is your gender?",
+                        "when": [{
+                            "id": "comparison-1-answer",
+                            "condition": "not equals",
+                            "comparison_id": "comparison-1-answer"
+                        }]
+                    }, {
+                        "value": "What is their gender?",
+                        "when": [{
+                            "id": "comparison-1-answer",
+                            "condition": "equals",
+                            "comparison_id": "comparison-1-answer"
+                        }]
+                    },
+                    {
+                        "value": "What is someone's gender"
+                    }]
+                }]
+            }, {
+                "type": "Interstitial",
+                "id": "equals-answers",
+                "title": "Second equal first",
+                "description": "Your second number was equal to your first number",
+                "skip_conditions": [{
+                    "when": [{
+                        "id": "comparison-1-answer",
+                        "condition": "not equals",
+                        "comparison_id": "comparison-2-answer"
+                    }]
+                }]
+            }, {
+                "type": "Interstitial",
+                "id": "less-than-answers",
+                "title": "First less than second",
+                "description": "Your first answer was less than your second number",
+                "skip_conditions": [{
+                    "when": [{
+                        "id": "comparison-1-answer",
+                        "condition": "greater than",
+                        "comparison_id": "comparison-2-answer"
+                    }]
+                }, {
+                    "when": [{
+                        "id": "comparison-1-answer",
+                        "condition": "equals",
+                        "comparison_id": "comparison-2-answer"
+                    }]
+                }]
+            }, {
+                "type": "Interstitial",
+                "id": "greater-than-answers",
+                "title": "First greater than second",
+                "description": "Your first answer was greater than your second number",
+                "skip_conditions": [{
+                    "when": [{
+                        "id": "comparison-1-answer",
+                        "condition": "not set",
+                        "comparison_id": "comparison-1-answer"
+                    }]
+                }, {
+                    "when": [{
+                        "id": "comparison-1-answer",
+                        "condition": "set",
+                        "comparison_id": "comparison-1-answer"
+                    }]
+                }]
+            }],
+            "id": "skip-group",
+            "title": ""
+        }, {
+            "id": "summary-group",
+            "title": "",
+            "blocks": [{
+                "type": "Summary",
+                "id": "summary"
+            }]
+        }]
+    }]
+}
+

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -234,6 +234,52 @@ class TestSchemaValidation(unittest.TestCase):
                                                "total-playback-answer-error's answers_to_calculate")
         self.assertIn('Duplicate answers: ', errors[4]['message'])
 
+    def test_answer_comparisons_different_types(self):
+        """ Ensures that when answer comparison is used, the type of the variables must be the same """
+        file_name = 'schemas/test_invalid_answer_comparison_types.json'
+        json_to_validate = self.open_and_load_schema_file(file_name)
+
+        errors = self.validator.validate_schema(json_to_validate)
+
+        error_messages = [
+            'Schema Integrity Error. The answers used as comparison_id "repeating-comparison-2-answer" and answer_id "repeating-comparison-1-answer" in the "when" clause for repeating-comparison have different types',
+            'Schema Integrity Error. The answers used as comparison_id "route-comparison-1-answer" and answer_id "route-comparison-2-answer" in the "when" clause for route-comparison-2 have different types',
+            'Schema Integrity Error. The "when" clause for comparison-3-question with conditional titles cannot contain a comparison_id',
+            'Schema Integrity Error. The "when" clause for comparison-3-question with conditional titles cannot contain a comparison_id',
+            'Schema Integrity Error. The answers used as comparison_id "comparison-2-answer" and answer_id "comparison-1-answer" in the "when" clause for equals-answers have different types',
+            'Schema Integrity Error. The answers used as comparison_id "comparison-2-answer" and answer_id "comparison-1-answer" in the "when" clause for less-than-answers have different types',
+            'Schema Integrity Error. The answers used as comparison_id "comparison-2-answer" and answer_id "comparison-1-answer" in the "when" clause for less-than-answers have different types',
+            'Schema Integrity Error. The "when" clause for greater-than-answers contains a comparison_id and uses a condition of unset or set',
+            'Schema Integrity Error. The "when" clause for greater-than-answers contains a comparison_id and uses a condition of unset or set',
+        ]
+        
+        self.assertEqual(len(errors), len(error_messages))
+
+        for i, error in enumerate(errors):
+            self.assertEqual(error['message'], error_messages[i])
+
+    def test_answer_comparisons_invalid_comparison_id(self):
+        """ Ensures that when answer comparison is used, the comparison_id is a valid answer id"""
+        file_name = 'schemas/test_invalid_answer_comparison_id.json'
+        json_to_validate = self.open_and_load_schema_file(file_name)
+
+        errors = self.validator.validate_schema(json_to_validate)
+
+        error_messages = [
+            'Schema Integrity Error. The answer id - bad-answer-id-1 in the comparison_id key of the "when" clause for repeating-comparison does not exist',
+            'Schema Integrity Error. The answer id - bad-answer-id-2 in the comparison_id key of the "when" clause for route-comparison-2 does not exist',
+            'Schema Integrity Error. The answer id - bad-answer-id-3 in the comparison_id key of the "when" clause for equals-answers does not exist',
+            'Schema Integrity Error. The answer id - bad-answer-id-4 in the comparison_id key of the "when" clause for less-than-answers does not exist',
+            'Schema Integrity Error. The answer id - bad-answer-id-5 in the comparison_id key of the "when" clause for less-than-answers does not exist',
+            'Schema Integrity Error. The answer id - bad-answer-id-6 in the comparison_id key of the "when" clause for greater-than-answers does not exist',
+            'Schema Integrity Error. The answer id - bad-answer-id-7 in the id key of the "when" clause for greater-than-answers does not exist',
+        ]
+        
+        self.assertEqual(len(errors), len(error_messages))
+
+        for i, error in enumerate(errors):
+            self.assertEqual(error['message'], error_messages[i])
+
     @staticmethod
     def open_and_load_schema_file(file):
         json_file = open(os.path.join(os.path.dirname(os.path.realpath(__file__)), file), encoding='utf8')


### PR DESCRIPTION
Runner is adding a `comparison_id` to the when clause.

This PR updates the json schema to allow for `comparison_id`.

- Since these when conditions can also be used in skip conditions, I have added validation for those too.
- Adding skip condition validation raised an issue with MWS survey in runner.
- Disallow `set` and `unset` with comparison_id
- Disallow comparison_id being used in `when` clauses in titles (since this could cause other issues and isn't needed by a customer)
