### PR TITLE
Remove RoutingRules from required in ConfirmationQuestion

### DIFF
--- a/schemas/blocks/confirmation_question.json
+++ b/schemas/blocks/confirmation_question.json
@@ -39,8 +39,7 @@
     "required": [
       "id",
       "type",
-      "questions",
-      "routing_rules"
+      "questions"
     ]
   }
 }


### PR DESCRIPTION
In a repeat until pattern the `Do you need to add any thinf else` type question should be a ConfirmationQuestion as it is not needed on a summary page. This type of question however does not have routing rules and so validator should not enforce this.