### PR TITLE
Allow metadata to be defined but not used

### DIFF
--- a/app/validation/validator.py
+++ b/app/validation/validator.py
@@ -145,11 +145,6 @@ class Validator:
             if metadata not in schema_metadata:
                 errors.append(self._error_message('Metadata - {} not specified in metadata field'.format(metadata)))
 
-        # Checks if unused metadata is defined
-        for metadata in schema_metadata:
-            if metadata not in all_metadata and metadata not in default_metadata:
-                errors.append(self._error_message('Unused metadata defined in metadata field - {}'.format(metadata)))
-
         return errors
 
     def validate_calculated_ids_in_answers_to_calculate_exists(self, question):

--- a/tests/schemas/test_valid_metadata.json
+++ b/tests/schemas/test_valid_metadata.json
@@ -1,0 +1,81 @@
+{
+  "eq_id": "3",
+  "form_type": "3",
+  "mime_type": "application/json/ons/eq",
+  "schema_version": "0.0.1",
+  "data_version": "0.0.2",
+  "survey_id": "3",
+  "title": "Metadata",
+  "sections": [{
+    "id": "section3",
+    "title": "",
+    "groups": [{
+        "id": "group3",
+        "title": "",
+        "blocks": [{
+          "id": "block4",
+          "title": "",
+          "type": "Question",
+          "questions": [{
+            "id": "question4",
+            "title": "",
+            "description": "",
+            "type": "General",
+            "answers": [{
+              "id": "answer6",
+              "mandatory": false,
+              "type": "TextField",
+              "label": "Text",
+              "description": ""
+            }]
+          }]
+        }]
+      },
+      {
+        "id": "confirmation-group",
+        "title": "confirmation",
+        "blocks": [{
+          "title": "You are now ready to submit this survey",
+          "type": "Confirmation",
+          "id": "confirmation",
+          "description": "",
+          "questions": [{
+            "id": "ready-to-submit-completed-question",
+            "title": "Submission",
+            "type": "Content",
+            "guidance": {
+              "content": [{
+                "list": [
+                  "You will not be able to access or change your answers on submitting the questionnaire",
+                  "If you wish to review your answers please select the relevant completed sections"
+                ]
+              }]
+            }
+          }]
+        }]
+      }
+    ]
+  }],
+  "theme": "default",
+  "legal_basis": "StatisticsOfTradeAct",
+  "navigation": {
+    "visible": false
+  },
+  "metadata": [{
+      "name": "user_id",
+      "validator": "string"
+    },
+    {
+      "name": "period_id",
+      "validator": "string"
+    },
+    {
+      "name": "ru_name",
+      "validator": "string"
+    },
+    {
+      "name": "test_metadata",
+      "validator": "string"
+    }
+  ]
+}

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -169,13 +169,11 @@ class TestSchemaValidation(unittest.TestCase):
 
         errors = self.validator.validate_schema(json_to_validate)
 
-        self.assertEqual(len(errors), 3)
+        self.assertEqual(len(errors), 2)
         self.assertEqual(errors[0]['message'], 'Schema Integrity Error. Metadata - ru_name not specified in metadata '
                                                'field')
         self.assertEqual(errors[1]['message'], 'Schema Integrity Error. Metadata - invalid not specified in metadata '
                                                'field')
-        self.assertEqual(errors[2]['message'], 'Schema Integrity Error. Unused metadata defined in metadata field - '
-                                               'invalid_metadata')
 
     def test_invalid_question_titles_object(self):
 
@@ -279,6 +277,16 @@ class TestSchemaValidation(unittest.TestCase):
 
         for i, error in enumerate(errors):
             self.assertEqual(error['message'], error_messages[i])
+
+    def test_metadata_defined_but_not_used_is_valid(self):
+        """ Ensures that there are no errors when metadata is defined in the schema but not used """
+        file_name = 'schemas/test_valid_metadata.json'
+        json_to_validate = self.open_and_load_schema_file(file_name)
+
+        errors = self.validator.validate_schema(json_to_validate)
+
+        self.assertEqual(0, len(errors))
+
 
     @staticmethod
     def open_and_load_schema_file(file):


### PR DESCRIPTION
### Description
Fixes #87 
This change ensures that metadata defined in the schema does not cause a validation error if it is not used within that schema. A change to the logic in this validation is required in order to support a new feature within author to add and remove metadata for a questionnaire.

The reverse logic should still work as expected. i.e. metadata that is being used without first being defined should still cause an error during validation.

### How to review
Changes should look sensible.
All tests and code quality checks should pass.