### PR TITLE
Make optional fields in metadata possible

### DIFF
--- a/schemas/questionnaire_v1.json
+++ b/schemas/questionnaire_v1.json
@@ -74,9 +74,27 @@
               "string",
               "uuid"
             ]
+          },
+          "address_line1": {
+            "type": "string"
+          },
+          "address_line2": {
+            "type": "string"
+          },
+          "locality": {
+            "type": "string"
+          },
+          "town_name": {
+            "type": "string"
+          },
+          "postcode": {
+            "type": "string"
+          },
+          "optional": {
+            "type": "boolean"
           }
         },
-        "additionalProperties": true,
+        "additionalProperties": false,
         "required": [
           "name",
           "validator"

--- a/schemas/questionnaire_v1.json
+++ b/schemas/questionnaire_v1.json
@@ -76,7 +76,7 @@
             ]
           }
         },
-        "additionalProperties": false,
+        "additionalProperties": true,
         "required": [
           "name",
           "validator"

--- a/schemas/questionnaire_v1.json
+++ b/schemas/questionnaire_v1.json
@@ -75,21 +75,6 @@
               "uuid"
             ]
           },
-          "address_line1": {
-            "type": "string"
-          },
-          "address_line2": {
-            "type": "string"
-          },
-          "locality": {
-            "type": "string"
-          },
-          "town_name": {
-            "type": "string"
-          },
-          "postcode": {
-            "type": "string"
-          },
           "optional": {
             "type": "boolean"
           }


### PR DESCRIPTION
The lms schema has optional metadata fields for address playback (address_line1, address_line2, etc), which means we need to be able to have extra fields which are optional.

- Test with [this branch in survey-runner](https://github.com/ONSdigital/eq-survey-runner/pull/1804)

- Also running off [the go launcher pr](https://github.com/ONSdigital/go-launch-a-survey/pull/118)