### PR TITLE
Add 'optional_string' and remove 'optional' type

### DIFF
--- a/schemas/questionnaire_v1.json
+++ b/schemas/questionnaire_v1.json
@@ -72,11 +72,9 @@
               "boolean",
               "date",
               "string",
+              "optional_string",
               "uuid"
             ]
-          },
-          "optional": {
-            "type": "boolean"
           }
         },
         "additionalProperties": false,


### PR DESCRIPTION
Reverting a previous change, to add an 'optional_string'
- [Related PR for address playback](https://github.com/ONSdigital/eq-survey-runner/pull/1804)
- [Previous schema-validator PR for optional](https://github.com/ONSdigital/eq-schema-validator/pull/92)