### PR TITLE
Add detail_answer to Options

### DIFF
--- a/schemas/answers/currency.json
+++ b/schemas/answers/currency.json
@@ -87,7 +87,8 @@
       "id",
       "type",
       "mandatory",
-      "currency"
+      "currency",
+      "label"
     ]
   }
 }

--- a/schemas/answers/definitions.json
+++ b/schemas/answers/definitions.json
@@ -19,16 +19,15 @@
         "q_code": {
           "$ref": "../common_definitions.json#/q_code"
         },
-        "child_answer_id": {
-          "type": "string",
-          "description": "The id of an answer that should be treated as a child of this one, for example a text field answer can be the child of a radio option. The id must be of an answer in this list of answers.",
-          "minLength": 1
+        "detail_answer": {
+            "$ref": "./text_field.json#/answer"
         },
         "description": {
           "type": "string",
           "description": "Descriptive text that appears below the option label"
         }
       },
+      "additionalProperties": false,
       "required": [
         "label",
         "value"

--- a/schemas/answers/number.json
+++ b/schemas/answers/number.json
@@ -83,7 +83,8 @@
     "required": [
       "id",
       "type",
-      "mandatory"
+      "mandatory",
+      "label"
     ]
   }
 }

--- a/schemas/answers/percentage.json
+++ b/schemas/answers/percentage.json
@@ -81,7 +81,8 @@
     "required": [
       "id",
       "type",
-      "mandatory"
+      "mandatory",
+      "label"
     ]
   }
 }

--- a/schemas/answers/text_field.json
+++ b/schemas/answers/text_field.json
@@ -6,10 +6,6 @@
       "id": {
         "$ref": "../common_definitions.json#/id"
       },
-      "parent_answer_id": {
-        "type": "string",
-        "description": "The id of an answer which is the parent of this child answer, for example a radio option leading to a text field answer."
-      },
       "q_code": {
         "$ref": "../common_definitions.json#/q_code"
       },
@@ -49,6 +45,7 @@
     "required": [
       "id",
       "type",
+      "label",
       "mandatory"
     ]
   }

--- a/schemas/answers/unit.json
+++ b/schemas/answers/unit.json
@@ -90,7 +90,8 @@
       "type",
       "mandatory",
       "unit",
-      "unit_length"
+      "unit_length",
+      "label"
     ]
   }
 }

--- a/schemas/questions/mutually_exclusive.json
+++ b/schemas/questions/mutually_exclusive.json
@@ -45,7 +45,7 @@
       "answers": {
         "type": "array",
         "minItems": 2,
-        "maxItems": 3,
+        "maxItems": 2,
         "items": {
           "oneOf": [
             {

--- a/tests/schemas/test_invalid_multiple_question_titles.json
+++ b/tests/schemas/test_invalid_multiple_question_titles.json
@@ -176,6 +176,7 @@
                   "answers": [
                     {
                       "id": "age-answer",
+                      "label": "Age",
                       "mandatory": true,
                       "type": "Number"
                     }

--- a/tests/schemas/test_invalid_mutually_exclusive_conditions.json
+++ b/tests/schemas/test_invalid_mutually_exclusive_conditions.json
@@ -57,16 +57,14 @@
                           "label": "Other",
                           "description": "Choose any other topping",
                           "value": "Other",
-                          "child_answer_id": "checkbox-child-other-answer"
+                          "detail_answer": {
+                            "mandatory": false,
+                            "id": "checkbox-child-other-answer",
+                            "label": "Please specify other",
+                            "type": "TextField"
+                          }
                         }
                       ]
-                    },
-                    {
-                      "parent_answer_id": "checkbox-answer",
-                      "mandatory": false,
-                      "id": "checkbox-child-other-answer",
-                      "label": "Please specify other",
-                      "type": "TextField"
                     },
                     {
                       "id": "checkbox-exclusive-answer",
@@ -102,11 +100,6 @@
                     },
                     {
                       "id": "mutually-exclusive-date-answer-2",
-                      "mandatory": false,
-                      "type": "Date"
-                    },
-                    {
-                      "id": "mutually-exclusive-date-answer-3",
                       "mandatory": false,
                       "type": "Date"
                     }

--- a/tests/schemas/test_invalid_numeric_answers.json
+++ b/tests/schemas/test_invalid_numeric_answers.json
@@ -31,6 +31,7 @@
                     {
                       "decimal_places": 2,
                       "id": "answer-1",
+                      "label": "Answer 1",
                       "mandatory": false,
                       "type": "Number"
                     }

--- a/tests/schemas/test_invalid_survey_id_whitespace.json
+++ b/tests/schemas/test_invalid_survey_id_whitespace.json
@@ -141,19 +141,17 @@
                           "value": "The address above is not on your letter"
                         },
                         {
-                          "child_answer_id": "address-type-check-answer-other",
                           "label": "Other",
-                          "value": "Other"
+                          "value": "Other",
+                          "detail_answer": {
+                            "id": "address-type-check-answer-other",
+                            "label": "Please describe",
+                            "mandatory": false,
+                            "type": "TextField"
+                          }
                         }
                       ],
                       "type": "Radio"
-                    },
-                    {
-                      "id": "address-type-check-answer-other",
-                      "label": "Please describe",
-                      "mandatory": false,
-                      "parent_answer_id": "address-type-check-answer",
-                      "type": "TextField"
                     }
                   ],
                   "id": "address-type-check-question",
@@ -702,19 +700,17 @@
                           "value": "Polish"
                         },
                         {
-                          "child_answer_id": "nationality-answer-other",
+                          "detail_answer": {
+                            "id": "nationality-answer-other",
+                            "label": "Please enter nationality",
+                            "mandatory": false,
+                            "type": "TextField"
+                          },
                           "label": "Other",
                           "value": "Other"
                         }
                       ],
                       "type": "Radio"
-                    },
-                    {
-                      "id": "nationality-answer-other",
-                      "label": "Please enter nationality",
-                      "mandatory": false,
-                      "parent_answer_id": "nationality-answer",
-                      "type": "TextField"
                     }
                   ],
                   "id": "nationality-question",
@@ -770,19 +766,17 @@
                           "value": "Poland"
                         },
                         {
-                          "child_answer_id": "country-of-birth-answer-other",
+                          "detail_answer":  {
+                            "id": "country-of-birth-answer-other",
+                            "label": "Please enter country of birth",
+                            "mandatory": false,
+                            "type": "TextField"
+                          },
                           "label": "Other",
                           "value": "Other"
                         }
                       ],
                       "type": "Radio"
-                    },
-                    {
-                      "id": "country-of-birth-answer-other",
-                      "label": "Please enter country of birth",
-                      "mandatory": false,
-                      "parent_answer_id": "country-of-birth-answer",
-                      "type": "TextField"
                     }
                   ],
                   "id": "country-of-birth-question",
@@ -1385,19 +1379,17 @@
                           "value": "British"
                         },
                         {
-                          "child_answer_id": "national-identity-england-answer-other",
+                          "detail_answer": {
+                            "id": "national-identity-england-answer-other",
+                            "label": "Please enter national identity",
+                            "mandatory": false,
+                            "type": "TextField"
+                          },
                           "label": "Other",
                           "value": "Other"
                         }
                       ],
                       "type": "Checkbox"
-                    },
-                    {
-                      "id": "national-identity-england-answer-other",
-                      "label": "Please enter national identity",
-                      "mandatory": false,
-                      "parent_answer_id": "national-identity-england-answer",
-                      "type": "TextField"
                     }
                   ],
                   "id": "national-identity-england-question",
@@ -1442,19 +1434,17 @@
                           "value": "British"
                         },
                         {
-                          "child_answer_id": "national-identity-wales-answer-other",
+                          "detail_answer":  {
+                            "id": "national-identity-wales-answer-other",
+                            "label": "Please enter national identity",
+                            "mandatory": false,
+                            "type": "TextField"
+                          },
                           "label": "Other",
                           "value": "Other"
                         }
                       ],
                       "type": "Checkbox"
-                    },
-                    {
-                      "id": "national-identity-wales-answer-other",
-                      "label": "Please enter national identity",
-                      "mandatory": false,
-                      "parent_answer_id": "national-identity-wales-answer",
-                      "type": "TextField"
                     }
                   ],
                   "id": "national-identity-wales-question",
@@ -1723,19 +1713,17 @@
                           "value": "Gypsy or Irish Traveller"
                         },
                         {
-                          "child_answer_id": "white-ethnic-group-answer-other",
+                          "detail_answer": {
+                            "id": "white-ethnic-group-answer-other",
+                            "label": "Please enter ethnic background",
+                            "mandatory": false,
+                            "type": "TextField"
+                          },
                           "label": "Any other White background",
                           "value": "Other"
                         }
                       ],
                       "type": "Radio"
-                    },
-                    {
-                      "id": "white-ethnic-group-answer-other",
-                      "label": "Please enter ethnic background",
-                      "mandatory": false,
-                      "parent_answer_id": "white-ethnic-group-answer",
-                      "type": "TextField"
                     }
                   ],
                   "id": "white-ethnic-group-question",
@@ -1791,19 +1779,17 @@
                           "value": "White and Asian"
                         },
                         {
-                          "child_answer_id": "mixed-ethnic-group-answer-other",
+                          "detail_answer": {
+                            "id": "mixed-ethnic-group-answer-other",
+                            "label": "Please enter ethnic background",
+                            "mandatory": false,
+                            "type": "TextField"
+                          },
                           "label": "Any other Mixed or multiple ethnic background",
                           "value": "Other"
                         }
                       ],
                       "type": "Radio"
-                    },
-                    {
-                      "id": "mixed-ethnic-group-answer-other",
-                      "label": "Please enter ethnic background",
-                      "mandatory": false,
-                      "parent_answer_id": "mixed-ethnic-group-answer",
-                      "type": "TextField"
                     }
                   ],
                   "id": "mixed-ethnic-group-question",
@@ -1863,19 +1849,17 @@
                           "value": "Chinese"
                         },
                         {
-                          "child_answer_id": "asian-ethnic-group-answer-other",
+                          "detail_answer":  {
+                            "id": "asian-ethnic-group-answer-other",
+                            "label": "Please enter ethnic background",
+                            "mandatory": false,
+                            "type": "TextField"
+                          },
                           "label": "Any other Asian background",
                           "value": "Other"
                         }
                       ],
                       "type": "Radio"
-                    },
-                    {
-                      "id": "asian-ethnic-group-answer-other",
-                      "label": "Please enter ethnic background",
-                      "mandatory": false,
-                      "parent_answer_id": "asian-ethnic-group-answer",
-                      "type": "TextField"
                     }
                   ],
                   "id": "asian-ethnic-group-question",
@@ -1927,19 +1911,17 @@
                           "value": "Caribbean"
                         },
                         {
-                          "child_answer_id": "black-ethnic-group-answer-other",
+                          "detail_answer": {
+                            "id": "black-ethnic-group-answer-other",
+                            "label": "Please enter ethnic background",
+                            "mandatory": false,
+                            "type": "TextField"
+                          },
                           "label": "Any other Black, African or Caribbean background",
                           "value": "Other"
                         }
                       ],
                       "type": "Radio"
-                    },
-                    {
-                      "id": "black-ethnic-group-answer-other",
-                      "label": "Please enter ethnic background",
-                      "mandatory": false,
-                      "parent_answer_id": "black-ethnic-group-answer",
-                      "type": "TextField"
                     }
                   ],
                   "id": "black-ethnic-group-question",
@@ -1987,19 +1969,17 @@
                           "value": "Arab"
                         },
                         {
-                          "child_answer_id": "other-ethnic-group-answer-other",
+                          "detail_answer": {
+                            "id": "other-ethnic-group-answer-other",
+                            "label": "Please enter ethnic background",
+                            "mandatory": false,
+                            "type": "TextField"
+                          },
                           "label": "Any other ethnic group",
                           "value": "Other"
                         }
                       ],
                       "type": "Radio"
-                    },
-                    {
-                      "id": "other-ethnic-group-answer-other",
-                      "label": "Please enter ethnic background",
-                      "mandatory": false,
-                      "parent_answer_id": "other-ethnic-group-answer",
-                      "type": "TextField"
                     }
                   ],
                   "id": "other-ethnic-group-question",
@@ -2072,19 +2052,17 @@
                           "value": "Sikh"
                         },
                         {
-                          "child_answer_id": "religion-answer-other",
+                          "detail_answer": {
+                            "id": "religion-answer-other",
+                            "label": "Please enter religion",
+                            "mandatory": false,
+                            "type": "TextField"
+                          },
                           "label": "Other religion",
                           "value": "Other"
                         }
                       ],
                       "type": "Radio"
-                    },
-                    {
-                      "id": "religion-answer-other",
-                      "label": "Please enter religion",
-                      "mandatory": false,
-                      "parent_answer_id": "religion-answer",
-                      "type": "TextField"
                     }
                   ],
                   "description": "",
@@ -2348,19 +2326,17 @@
                           "value": "Polish"
                         },
                         {
-                          "child_answer_id": "nationality-answer-other-np",
+                          "detail_answer": {
+                            "id": "nationality-answer-other-np",
+                            "label": "Please enter nationality",
+                            "mandatory": false,
+                            "type": "TextField"
+                          },
                           "label": "Other",
                           "value": "Other"
                         }
                       ],
                       "type": "Radio"
-                    },
-                    {
-                      "id": "nationality-answer-other-np",
-                      "label": "Please enter nationality",
-                      "mandatory": false,
-                      "parent_answer_id": "nationality-answer-np",
-                      "type": "TextField"
                     }
                   ],
                   "id": "nationality-question-np",
@@ -2416,19 +2392,17 @@
                           "value": "Poland"
                         },
                         {
-                          "child_answer_id": "country-of-birth-answer-other-np",
+                          "detail_answer": {
+                            "id": "country-of-birth-answer-other-np",
+                            "label": "Please enter your country of birth",
+                            "mandatory": false,
+                            "type": "TextField"
+                          },
                           "label": "Other",
                           "value": "Other"
                         }
                       ],
                       "type": "Radio"
-                    },
-                    {
-                      "id": "country-of-birth-answer-other-np",
-                      "label": "Please enter your country of birth",
-                      "mandatory": false,
-                      "parent_answer_id": "country-of-birth-answer-np",
-                      "type": "TextField"
                     }
                   ],
                   "id": "country-of-birth-question-np",
@@ -3031,19 +3005,17 @@
                           "value": "British"
                         },
                         {
-                          "child_answer_id": "national-identity-england-answer-other-np",
+                          "detail_answer": {
+                            "id": "national-identity-england-answer-other-np",
+                            "label": "Please enter your national identity",
+                            "mandatory": false,
+                            "type": "TextField"
+                          },
                           "label": "Other",
                           "value": "Other"
                         }
                       ],
                       "type": "Checkbox"
-                    },
-                    {
-                      "id": "national-identity-england-answer-other-np",
-                      "label": "Please enter your national identity",
-                      "mandatory": false,
-                      "parent_answer_id": "national-identity-england-answer-np",
-                      "type": "TextField"
                     }
                   ],
                   "id": "national-identity-england-question-np",
@@ -3088,19 +3060,17 @@
                           "value": "British"
                         },
                         {
-                          "child_answer_id": "national-identity-wales-answer-other-np",
+                          "detail_answer": {
+                            "id": "national-identity-wales-answer-other-np",
+                            "label": "Please enter your national identity",
+                            "mandatory": false,
+                            "type": "TextField"
+                          },
                           "label": "Other",
                           "value": "Other"
                         }
                       ],
                       "type": "Checkbox"
-                    },
-                    {
-                      "id": "national-identity-wales-answer-other-np",
-                      "label": "Please enter your national identity",
-                      "mandatory": false,
-                      "parent_answer_id": "national-identity-wales-answer-np",
-                      "type": "TextField"
                     }
                   ],
                   "id": "national-identity-wales-question-no-proxy",
@@ -3390,19 +3360,17 @@
                           "value": "Gypsy or Irish Traveller"
                         },
                         {
-                          "child_answer_id": "white-ethnic-group-answer-other-np",
+                          "detail_answer": {
+                            "id": "white-ethnic-group-answer-other-np",
+                            "label": "Please enter ethnic background",
+                            "mandatory": false,
+                            "type": "TextField"
+                          },
                           "label": "Any other White background",
                           "value": "Other"
                         }
                       ],
                       "type": "Radio"
-                    },
-                    {
-                      "id": "white-ethnic-group-answer-other-np",
-                      "label": "Please enter ethnic background",
-                      "mandatory": false,
-                      "parent_answer_id": "white-ethnic-group-answer-np",
-                      "type": "TextField"
                     }
                   ],
                   "id": "white-ethnic-group-question-np",
@@ -3458,19 +3426,17 @@
                           "value": "White and Asian"
                         },
                         {
-                          "child_answer_id": "mixed-ethnic-group-answer-other-np",
+                          "detail_answer": {
+                            "id": "mixed-ethnic-group-answer-other-np",
+                            "label": "Please enter ethnic background",
+                            "mandatory": false,
+                            "type": "TextField"
+                          },
                           "label": "Any other Mixed or multiple ethnic background",
                           "value": "Other"
                         }
                       ],
                       "type": "Radio"
-                    },
-                    {
-                      "id": "mixed-ethnic-group-answer-other-np",
-                      "label": "Please enter ethnic background",
-                      "mandatory": false,
-                      "parent_answer_id": "mixed-ethnic-group-answer-np",
-                      "type": "TextField"
                     }
                   ],
                   "id": "mixed-ethnic-group-question-np",
@@ -3530,19 +3496,17 @@
                           "value": "Chinese"
                         },
                         {
-                          "child_answer_id": "asian-ethnic-group-answer-other-np",
+                          "detail_answer": {
+                            "id": "asian-ethnic-group-answer-other-np",
+                            "label": "Please enter ethnic background",
+                            "mandatory": false,
+                            "type": "TextField"
+                          },
                           "label": "Any other Asian background",
                           "value": "Other"
                         }
                       ],
                       "type": "Radio"
-                    },
-                    {
-                      "id": "asian-ethnic-group-answer-other-np",
-                      "label": "Please enter ethnic background",
-                      "mandatory": false,
-                      "parent_answer_id": "asian-ethnic-group-answer-np",
-                      "type": "TextField"
                     }
                   ],
                   "id": "asian-ethnic-group-question-np",
@@ -3594,19 +3558,17 @@
                           "value": "Caribbean"
                         },
                         {
-                          "child_answer_id": "black-ethnic-group-answer-other-np",
+                          "detail_answer": {
+                            "id": "black-ethnic-group-answer-other-np",
+                            "label": "Please enter ethnic background",
+                            "mandatory": false,
+                            "type": "TextField"
+                          },
                           "label": "Any other Black, African or Caribbean background",
                           "value": "Other"
                         }
                       ],
                       "type": "Radio"
-                    },
-                    {
-                      "id": "black-ethnic-group-answer-other-np",
-                      "label": "Please enter ethnic background",
-                      "mandatory": false,
-                      "parent_answer_id": "black-ethnic-group-answer-np",
-                      "type": "TextField"
                     }
                   ],
                   "id": "black-ethnic-group-question-np",
@@ -3654,19 +3616,17 @@
                           "value": "Arab"
                         },
                         {
-                          "child_answer_id": "other-ethnic-group-answer-other-np",
+                          "detail_answer": {
+                            "id": "other-ethnic-group-answer-other-np",
+                            "label": "Please enter ethnic background",
+                            "mandatory": false,
+                            "type": "TextField"
+                          },
                           "label": "Any other ethnic group",
                           "value": "Other"
                         }
                       ],
                       "type": "Radio"
-                    },
-                    {
-                      "id": "other-ethnic-group-answer-other-np",
-                      "label": "Please enter ethnic background",
-                      "mandatory": false,
-                      "parent_answer_id": "other-ethnic-group-answer-np",
-                      "type": "TextField"
                     }
                   ],
                   "id": "other-ethnic-group-question-np",
@@ -3739,19 +3699,17 @@
                           "value": "Sikh"
                         },
                         {
-                          "child_answer_id": "religion-answer-other-np",
+                          "detail_answer": {
+                            "id": "religion-answer-other-np",
+                            "label": "Please enter religion",
+                            "mandatory": false,
+                            "type": "TextField"
+                          },
                           "label": "Other religion",
                           "value": "Other religion"
                         }
                       ],
                       "type": "Radio"
-                    },
-                    {
-                      "id": "religion-answer-other-np",
-                      "label": "Please enter religion",
-                      "mandatory": false,
-                      "parent_answer_id": "religion-answer-np",
-                      "type": "TextField"
                     }
                   ],
                   "id": "religion-question-np",

--- a/tests/schemas/test_numeric_default_with_routing.json
+++ b/tests/schemas/test_numeric_default_with_routing.json
@@ -31,6 +31,7 @@
                     {
                       "default": 0,
                       "id": "answer-1",
+                      "label": "Answer 1",
                       "mandatory": false,
                       "type": "Number"
                     }

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -303,10 +303,9 @@ class TestSchemaValidation(unittest.TestCase):
 
         errors = self.validator.validate_schema(json_to_validate)
 
-        self.assertEqual(len(errors), 3)
+        self.assertEqual(len(errors), 2)
         self.assertEqual(errors[0]['message'], 'Schema Integrity Error. MutuallyExclusive question type cannot contain mandatory answers.')
-        self.assertEqual(errors[1]['message'], 'Schema Integrity Error. Too many answers have been provided.')
-        self.assertEqual(errors[2]['message'], 'Schema Integrity Error. mutually-exclusive-date-answer-3 is not of type Checkbox.')
+        self.assertEqual(errors[1]['message'], 'Schema Integrity Error. mutually-exclusive-date-answer-2 is not of type Checkbox.')
 
     def test_decimal_places_must_be_defined_when_using_totaliser(self):
 
@@ -315,9 +314,10 @@ class TestSchemaValidation(unittest.TestCase):
 
         errors = self.validator.validate_schema(json_to_validate)
         self.assertEqual(len(errors), 2)
-        self.assertEqual(errors[0]['message'], 'Schema Integrity Error. \'decimal_places\' must be defined and set to 2 for the answer_id - total-percentage')
-        self.assertEqual(errors[1]['message'], 'Schema Integrity Error. \'decimal_places\' must be defined and set to 2 for the answer_id - total-percentage-2')
-
+        self.assertEqual(errors[0]['message'],
+                         "Schema Integrity Error. 'decimal_places' must be defined and set to 2 for the answer_id - total-percentage")
+        self.assertEqual(errors[1]['message'],
+                         "Schema Integrity Error. 'decimal_places' must be defined and set to 2 for the answer_id - total-percentage-2")
 
     def test_metadata_defined_but_not_used_is_valid(self):
         """ Ensures that there are no errors when metadata is defined in the schema but not used """


### PR DESCRIPTION
Add detail_answer to options as part of [Runner PR](https://github.com/ONSdigital/eq-survey-runner/pull/1920)

Initially only supports TextField.
Removes references to Child/Parent answer ids
Number of Mutually Exclusive answers can now be checked in schema json