### PR TITLE
Remove references to session prompts

### DIFF
--- a/schemas/questionnaire_v1.json
+++ b/schemas/questionnaire_v1.json
@@ -41,10 +41,6 @@
       "description": "The amount of time in seconds before timing out a users session.",
       "type": "integer"
     },
-    "session_prompt_in_seconds": {
-      "description": "The amount of time in seconds before showing the prompt informing a user of the time to session timeout.",
-      "type": "integer"
-    },
     "title": {
       "type": "string"
     },


### PR DESCRIPTION
### What is the context of this PR?
Removes references to session prompts which have been removed from `eq-survey-runner` as per https://github.com/ONSdigital/eq-survey-runner/pull/1964

### How to review 
- Ensure tests pass
