### PR TITLE
 Define piping (string interpolation) in a structured way

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,6 @@ secrets.yml
 
 #PyCharm
 .idea
+
+*.bak
+.vscode/

--- a/doc/decisions/0001-define-piping-in-a-structured-way.md
+++ b/doc/decisions/0001-define-piping-in-a-structured-way.md
@@ -1,0 +1,310 @@
+# 1. Define piping (string interpolation) in a structured way
+
+## Context
+
+The current way we define piping (string interpolation) in a schema is to include jinja filters directly in the source strings. This has a number of issues:
+
+- It's hard to read for translators.
+- It's possible that the jinja filters could become corrupted during translation.
+- If the way that we resolve the piped information changes, then the translations would all need to be updated.
+- We can't easily parse the schema to understand what is being piped, for example to find all places where a specific answer is piped.
+
+## Proposal
+
+To define an appropriate schema to resolve placeholders in a source string. When resolving placeholder values we need to cater for:
+
+- Previous answers or metadata
+- Previous answers or metadata transformed in some way e.g. formatting a number with a currency symbol
+- Using multiple answers, metadata or fixed values in a transform e.g. formatting a date answer with a specific format
+- Chaining transforms e.g. concatenate a name and then add a 's
+
+### Previous answers or metadata
+
+Current:
+
+```json
+{
+    "description": "What was the <em>total gross weekly pay</em> paid to employees in the last week of {{metadata['period_str']}}?"
+}
+```
+
+Proposed:
+
+```json
+{
+    "description": {
+        "text": "What was the <em>total gross weekly pay</em> paid to employees in the last week of {period}?",
+        "placeholders": [
+            {
+                "placeholder": "period",
+                "value": {
+                    "source": "metadata",
+                    "identifier": "period_str"
+                }
+            }
+        ]
+    }
+}
+```
+
+## Previous answers or metadata transformed in some way
+
+Current:
+
+```json
+{
+    "description": "Of the <em>{{format_currency(answers['total-retail-turnover-answer'])}}</em> total retail turnover, what was the value of internet sales?"
+}
+```
+
+Proposed:
+
+```json
+{
+    "description": {
+        "text": "Of the <em>{total_turnover}</em> total retail turnover, what was the value of internet sales?",
+        "placeholders": [
+            {
+                "placeholder": "total_turnover",
+                "transforms": [
+                    {
+                        "transform": "format_currency",
+                        "arguments": {
+                            "number": {
+                                "source": "answers",
+                                "identifier": "total-retail-turnover-answer"
+                            }
+                        }
+                    }
+                ]
+            }
+        ]
+    }
+}
+```
+
+## Using multiple answers, metadata or fixed values in a transform
+
+```json
+{
+    "description": "Are you able to report for the period starting on {{format_date_custom(metadata['ref_p_start_date'], 'EEEE d MMMM YYYY')}}?"
+}
+```
+
+Proposed:
+
+```json
+{
+
+    "description": {
+        "text": "Are you able to report for the period starting on {start_date}?",
+        "placeholders": [
+            {
+                "placeholder": "start_date",
+                "transforms": [
+                    {
+                        "transform": "format_date",
+                        "arguments": {
+                            "date": {
+                                "source": "metadata",
+                                "identifier": "ref_p_start_date"
+                            },
+                            "format": "EEEE d MMMM YYYY"
+                        }
+                    }
+                ]
+            }
+        ]
+    }
+}
+```
+
+## Chaining transforms
+
+Current:
+
+```json
+{
+    "description": "What is <em>{{[answers['first-name'][group_instance], answers['last-name'][group_instance]] | format_household_name_possessive }}</em> date of birth?""
+}
+```
+
+Proposed:
+
+```json
+{
+    "description": {
+        "text": "What is <em>{persons_name}</em> date of birth?",
+        "placeholders": [
+            {
+                "placeholder": "persons_name",
+                "transforms": [
+                    {
+                        "transform": "concatenate_list",
+                        "arguments": {
+                            "list": {
+                                "source": "answers",
+                                "identifier": ["first-name","last-name"]
+                            },
+                            "delimiter": " "
+                        }
+                    },
+                    {
+                        "transform": "format_possessive",
+                        "arguments": {
+                            "string": {
+                                "source": "previous_transform"
+                            }
+                        }
+                    }
+                ]
+            }
+        ]
+    }
+}
+```
+
+## Full worked example (with surrounding schema)
+
+Original:
+
+```json
+{
+    "type": "ConfirmationQuestion",
+    "id": "confirm-dob-proxy",
+    "questions": [{
+        "id": "confirm-date-of-birth-proxy",
+        "title": "{{[answers['first-name'][group_instance], answers['last-name'][group_instance]] | format_household_name}} is {{ calculate_years_difference (answers['date-of-birth-answer'][group_instance], 'now') }} old. Is this correct?",
+        "type": "General",
+        "answers": [{
+            "id": "confirm-date-of-birth-answer-proxy",
+            "mandatory": true,
+            "options": [{
+                    "label": "Yes, {{[answers['first-name'][group_instance], answers['last-name'][group_instance]] | format_household_name}} is {{ calculate_years_difference (answers['date-of-birth-answer'][group_instance], 'now') }} old",
+                    "value": "Yes"
+                },
+                {
+                    "label": "No, I need to change their date of birth",
+                    "value": "No"
+                }
+            ],
+            "type": "Radio"
+        }]
+    }]
+}
+```
+
+Proposed:
+
+```json
+{
+    "type": "ConfirmationQuestion",
+    "id": "confirm-dob-proxy",
+    "questions": [{
+        "id": "confirm-date-of-birth-proxy",
+        "title": {
+            "text": "{person_name} is {age_in_years} old. Is this correct?",
+            "placeholders": [
+                {
+                    "placeholder": "person_name",
+                    "transforms": [
+                        {
+                            "transform": "concatenate_list",
+                            "arguments": {
+                                "list": {
+                                    "source": "answers",
+                                    "identifier": ["first-name","last-name"]
+                                },
+                                "delimiter": " "
+                            }
+                        }
+                    ]
+                },
+                {
+                    "placeholder": "age_in_years",
+                    "transforms": [
+                        {
+                            "transform": "calculate_years_difference",
+                            "arguments": {
+                                "first_date": {
+                                    "source": "answers",
+                                    "identifier": "date-of-birth-answer"
+                                },
+                                "second_date": {
+                                    "value": "now"
+                                }
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        "type": "General",
+        "answers": [{
+            "id": "confirm-date-of-birth-answer-proxy",
+            "mandatory": true,
+            "options": [{
+                    "label": {
+                        "text": "{person_name} is {age_in_years} old. Is this correct?",
+                        "placeholders": [
+                            {
+                                "placeholder": "person_name",
+                                "transforms": [
+                                    {
+                                        "transform": "concatenate_list",
+                                        "arguments": {
+                                            "list": {
+                                                "source": "answers",
+                                                "identifier": ["first-name","last-name"]
+                                            },
+                                            "delimiter": " "
+                                        }
+                                    }
+                                ]
+                            },
+                            {
+                                "placeholder": "age_in_years",
+                                "transforms": [
+                                    {
+                                        "transform": "calculate_years_difference",
+                                        "arguments": {
+                                            "first_date": {
+                                                "source": "answers",
+                                                "identifier": "date-of-birth-answer"
+                                            },
+                                            "second_date": {
+                                                "value": "now"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    "value": "Yes"
+                },
+                {
+                    "label": {
+                        "text": "No, I need to change their date of birth"
+                    },
+                    "value": "No"
+                }
+            ],
+            "type": "Radio"
+        }]
+    }]
+}
+```
+
+Note: The repetition of placeholder resolution in the same block is rare
+
+---
+
+
+## Other notes
+
+- No provision has been made in the schema design for group instances. It is assumed that:
+  - When a placeholder is used in a non-repeating group that any reference to answers resolves to all answers that match the answer id.
+  - When a placeholder is used in a repeating group that any reference to answers resolves to the answer that matches within the current repeat.
+- `format_date_range` and `format_datetime` should be done via two separate placeholders rather than a transform, so that the 'to' and 'at' are in the sentence to be translated.
+- Jinja filters are used to resolve values in the variables schema e.g. `period` in 1_0005. This will no longer work and will require some further design outside of the scope of this proposal.

--- a/schemas/answers/checkbox.json
+++ b/schemas/answers/checkbox.json
@@ -16,7 +16,7 @@
         "$ref": "../common_definitions.json#/guidance"
       },
       "description": {
-        "type": "string"
+        "$ref": "../string_interpolation/definitions.json#/string_with_placeholders"
       },
       "type": {
         "type": "string",

--- a/schemas/answers/currency.json
+++ b/schemas/answers/currency.json
@@ -16,7 +16,7 @@
         "$ref": "../common_definitions.json#/guidance"
       },
       "description": {
-        "type": "string"
+        "$ref": "../string_interpolation/definitions.json#/string_with_placeholders"
       },
       "type": {
         "type": "string",

--- a/schemas/answers/date.json
+++ b/schemas/answers/date.json
@@ -16,7 +16,7 @@
         "$ref": "../common_definitions.json#/guidance"
       },
       "description": {
-        "type": "string"
+        "$ref": "../string_interpolation/definitions.json#/string_with_placeholders"
       },
       "type": {
         "type": "string",

--- a/schemas/answers/definitions.json
+++ b/schemas/answers/definitions.json
@@ -11,7 +11,7 @@
       "type": "object",
       "properties": {
         "label": {
-          "type": "string"
+          "$ref": "../string_interpolation/definitions.json#/string_with_placeholders"
         },
         "value": {
           "type": "string"

--- a/schemas/answers/dropdown.json
+++ b/schemas/answers/dropdown.json
@@ -25,7 +25,7 @@
         "type": "string"
       },
       "description": {
-        "type": "string"
+        "$ref": "../string_interpolation/definitions.json#/string_with_placeholders"
       },
       "options": {
         "allOf": [

--- a/schemas/answers/duration.json
+++ b/schemas/answers/duration.json
@@ -16,7 +16,7 @@
         "$ref": "../common_definitions.json#/guidance"
       },
       "description": {
-        "type": "string"
+        "$ref": "../string_interpolation/definitions.json#/string_with_placeholders"
       },
       "type": {
         "type": "string",

--- a/schemas/answers/month_year_date.json
+++ b/schemas/answers/month_year_date.json
@@ -16,7 +16,7 @@
         "$ref": "../common_definitions.json#/guidance"
       },
       "description": {
-        "type": "string"
+        "$ref": "../string_interpolation/definitions.json#/string_with_placeholders"
       },
       "type": {
         "type": "string",

--- a/schemas/answers/number.json
+++ b/schemas/answers/number.json
@@ -16,7 +16,7 @@
         "$ref": "../common_definitions.json#/guidance"
       },
       "description": {
-        "type": "string"
+        "$ref": "../string_interpolation/definitions.json#/string_with_placeholders"
       },
       "type": {
         "type": "string",

--- a/schemas/answers/percentage.json
+++ b/schemas/answers/percentage.json
@@ -16,7 +16,7 @@
         "$ref": "../common_definitions.json#/guidance"
       },
       "description": {
-        "type": "string"
+        "$ref": "../string_interpolation/definitions.json#/string_with_placeholders"
       },
       "type": {
         "type": "string",

--- a/schemas/answers/radio.json
+++ b/schemas/answers/radio.json
@@ -16,7 +16,7 @@
         "$ref": "../common_definitions.json#/guidance"
       },
       "description": {
-        "type": "string"
+        "$ref": "../string_interpolation/definitions.json#/string_with_placeholders"
       },
       "type": {
         "type": "string",

--- a/schemas/answers/relationship.json
+++ b/schemas/answers/relationship.json
@@ -16,7 +16,7 @@
         "$ref": "../common_definitions.json#/guidance"
       },
       "description": {
-        "type": "string"
+        "$ref": "../string_interpolation/definitions.json#/string_with_placeholders"
       },
       "type": {
         "type": "string",

--- a/schemas/answers/text_area.json
+++ b/schemas/answers/text_area.json
@@ -16,7 +16,7 @@
         "$ref": "../common_definitions.json#/guidance"
       },
       "description": {
-        "type": "string"
+        "$ref": "../string_interpolation/definitions.json#/string_with_placeholders"
       },
       "type": {
         "type": "string",

--- a/schemas/answers/text_field.json
+++ b/schemas/answers/text_field.json
@@ -16,7 +16,7 @@
         "$ref": "../common_definitions.json#/guidance"
       },
       "description": {
-        "type": "string"
+        "$ref": "../string_interpolation/definitions.json#/string_with_placeholders"
       },
       "type": {
         "type": "string",

--- a/schemas/answers/unit.json
+++ b/schemas/answers/unit.json
@@ -16,7 +16,7 @@
         "$ref": "../common_definitions.json#/guidance"
       },
       "description": {
-        "type": "string"
+        "$ref": "../string_interpolation/definitions.json#/string_with_placeholders"
       },
       "type": {
         "type": "string",

--- a/schemas/answers/year_date.json
+++ b/schemas/answers/year_date.json
@@ -16,7 +16,7 @@
         "$ref": "../common_definitions.json#/guidance"
       },
       "description": {
-        "type": "string"
+        "$ref": "../string_interpolation/definitions.json#/string_with_placeholders"
       },
       "type": {
         "type": "string",

--- a/schemas/blocks/answer_summary.json
+++ b/schemas/blocks/answer_summary.json
@@ -13,7 +13,7 @@
         ]
       },
       "title": {
-        "type": "string"
+        "$ref": "../string_interpolation/definitions.json#/string_with_placeholders"
       },
       "label": {
         "type": "string"

--- a/schemas/blocks/confirmation.json
+++ b/schemas/blocks/confirmation.json
@@ -7,10 +7,10 @@
         "$ref": "../common_definitions.json#/id"
       },
       "title": {
-        "type": "string"
+        "$ref": "../string_interpolation/definitions.json#/string_with_placeholders"
       },
       "description": {
-        "type": "string"
+        "$ref": "../string_interpolation/definitions.json#/string_with_placeholders"
       },
       "number": {
         "type": "string"

--- a/schemas/blocks/confirmation_question.json
+++ b/schemas/blocks/confirmation_question.json
@@ -13,7 +13,7 @@
         "type": "string"
       },
       "description": {
-        "type": "string"
+        "$ref": "../string_interpolation/definitions.json#/string_with_placeholders"
       },
       "number": {
         "type": "string"

--- a/schemas/blocks/interstitial.json
+++ b/schemas/blocks/interstitial.json
@@ -10,10 +10,10 @@
         "type": "string"
       },
       "title": {
-        "type": "string"
+        "$ref": "../string_interpolation/definitions.json#/string_with_placeholders"
       },
       "description": {
-        "type": "string"
+        "$ref": "../string_interpolation/definitions.json#/string_with_placeholders"
       },
       "number": {
         "type": "string"

--- a/schemas/blocks/introduction.json
+++ b/schemas/blocks/introduction.json
@@ -7,10 +7,10 @@
         "$ref": "../common_definitions.json#/id"
       },
       "title": {
-        "type": "string"
+        "$ref": "../string_interpolation/definitions.json#/string_with_placeholders"
       },
       "description": {
-        "type": "string"
+        "$ref": "../string_interpolation/definitions.json#/string_with_placeholders"
       },
       "type": {
         "type": "string",

--- a/schemas/blocks/question.json
+++ b/schemas/blocks/question.json
@@ -10,10 +10,10 @@
         "type": "string"
       },
       "title": {
-        "type": "string"
+        "$ref": "../string_interpolation/definitions.json#/string_with_placeholders"
       },
       "description": {
-        "type": "string"
+        "$ref": "../string_interpolation/definitions.json#/string_with_placeholders"
       },
       "number": {
         "type": "string"

--- a/schemas/common_definitions.json
+++ b/schemas/common_definitions.json
@@ -462,7 +462,9 @@
     "type": "array",
     "description": "Used to allow a title contents to be set based on conditional values",
     "items": {
-      "value": "string",
+      "value": {
+        "$ref": "../string_interpolation/definitions.json#/string_with_placeholders"
+      },
       "when": {
         "$ref": "common_definitions.json#/when"
       },

--- a/schemas/questions/calculated.json
+++ b/schemas/questions/calculated.json
@@ -10,7 +10,7 @@
         "$ref": "../common_definitions.json#/content"
       },
       "title": {
-        "type": "string"
+        "$ref": "../string_interpolation/definitions.json#/string_with_placeholders"
       },
       "titles": {
         "$ref": "../common_definitions.json#/titles"
@@ -19,7 +19,7 @@
         "type": "string"
       },
       "description": {
-        "type": "string"
+        "$ref": "../string_interpolation/definitions.json#/string_with_placeholders"
       },
       "definitions": {
         "$ref": "../common_definitions.json#/definitions"

--- a/schemas/questions/content.json
+++ b/schemas/questions/content.json
@@ -10,7 +10,7 @@
         "$ref": "../common_definitions.json#/content"
       },
       "title": {
-        "type": "string"
+        "$ref": "../string_interpolation/definitions.json#/string_with_placeholders"
       },
       "titles": {
         "$ref": "../common_definitions.json#/titles"
@@ -19,7 +19,7 @@
         "type": "string"
       },
       "description": {
-        "type": "string"
+        "$ref": "../string_interpolation/definitions.json#/string_with_placeholders"
       },
       "definitions": {
         "$ref": "../common_definitions.json#/definitions"

--- a/schemas/questions/date_range.json
+++ b/schemas/questions/date_range.json
@@ -10,7 +10,7 @@
         "$ref": "../common_definitions.json#/content"
       },
       "title": {
-        "type": "string"
+        "$ref": "../string_interpolation/definitions.json#/string_with_placeholders"
       },
       "titles": {
         "$ref": "../common_definitions.json#/titles"
@@ -22,7 +22,7 @@
         "type": "string"
       },
       "definitions": {
-        "$ref": "../common_definitions.json#/definitions"
+        "$ref": "../string_interpolation/definitions.json#/string_with_placeholders"
       },
       "guidance": {
         "type": "object",

--- a/schemas/questions/general.json
+++ b/schemas/questions/general.json
@@ -10,7 +10,7 @@
         "$ref": "../common_definitions.json#/content"
       },
       "title": {
-        "type": "string"
+        "$ref": "../string_interpolation/definitions.json#/string_with_placeholders"
       },
       "titles": {
         "$ref": "../common_definitions.json#/titles"
@@ -19,7 +19,7 @@
         "type": "string"
       },
       "description": {
-        "type": "string"
+        "$ref": "../string_interpolation/definitions.json#/string_with_placeholders"
       },
       "definitions": {
         "$ref": "../common_definitions.json#/definitions"

--- a/schemas/questions/mutually_exclusive.json
+++ b/schemas/questions/mutually_exclusive.json
@@ -10,7 +10,7 @@
         "$ref": "../common_definitions.json#/content"
       },
       "title": {
-        "type": "string"
+        "$ref": "../string_interpolation/definitions.json#/string_with_placeholders"
       },
       "titles": {
         "$ref": "../common_definitions.json#/titles"
@@ -19,7 +19,7 @@
         "type": "string"
       },
       "description": {
-        "type": "string"
+        "$ref": "../string_interpolation/definitions.json#/string_with_placeholders"
       },
       "definitions": {
         "$ref": "../common_definitions.json#/definitions"

--- a/schemas/questions/relationship.json
+++ b/schemas/questions/relationship.json
@@ -10,7 +10,7 @@
         "$ref": "../common_definitions.json#/content"
       },
       "title": {
-        "type": "string"
+        "$ref": "../string_interpolation/definitions.json#/string_with_placeholders"
       },
       "titles": {
         "$ref": "../common_definitions.json#/titles"
@@ -19,7 +19,7 @@
         "type": "string"
       },
       "description": {
-        "type": "string"
+        "$ref": "../string_interpolation/definitions.json#/string_with_placeholders"
       },
       "member_label": {
         "type": "string"

--- a/schemas/questions/repeating_answer.json
+++ b/schemas/questions/repeating_answer.json
@@ -10,7 +10,7 @@
         "$ref": "../common_definitions.json#/content"
       },
       "title": {
-        "type": "string"
+        "$ref": "../string_interpolation/definitions.json#/string_with_placeholders"
       },
       "titles": {
         "$ref": "../common_definitions.json#/titles"
@@ -19,7 +19,7 @@
         "type": "string"
       },
       "description": {
-        "type": "string"
+        "$ref": "../string_interpolation/definitions.json#/string_with_placeholders"
       },
       "definitions": {
         "$ref": "../common_definitions.json#/definitions"

--- a/schemas/string_interpolation/definitions.json
+++ b/schemas/string_interpolation/definitions.json
@@ -1,0 +1,144 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema",
+  "string_with_placeholders": {
+    "oneOf": [
+      {
+        "description": "String with no placeholders.",
+        "type": "string"
+      },
+      {
+        "description": "An object that represents a string with placeholders.",
+        "type": "object",
+        "properties": {
+          "text": {
+            "type": "string"
+          },
+          "placeholders": {
+            "$ref": "#/placeholders"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "text",
+          "placeholders"
+        ]
+      }
+    ]
+  },
+  "placeholders": {
+    "description": "A mapping of string placeholders to their values.",
+    "type": "array", 
+    "items": {
+      "$ref": "#/placeholder"
+    },
+    "minItems": 1
+  },
+  "placeholder": {
+    "description": "A mapping of a string placeholder to it's value. The value can also be transformed.",
+    "type": "object",
+    "properties": {
+      "placeholder": {
+        "description": "The placeholder in the string that will be replaced e.g. 'test' is the placeholder in 'My {test} string'.",
+        "type": "string",
+        "pattern": "^[0-9a-z_]+$"
+      },
+      "value": {
+        "description": "A direct lookup with no transforms.",
+        "$ref": "#/lookup_source"
+      },
+      "transforms": {
+        "description": "A list of transforms to resolve the placeholder value.",
+        "type": "array",
+        "items": {
+          "type": "object",
+          "anyOf": [
+            {
+              "$ref": "transforms/format_number.json#/format_number"
+            },
+            {
+              "$ref": "transforms/format_date.json#/format_date"
+            },
+            {
+              "$ref": "transforms/format_date_range.json#/format_date_range"
+            },
+            {
+              "$ref": "transforms/calculate_years_difference.json#/calculate_years_difference"
+            },
+            {
+              "$ref": "transforms/concatenate_list.json#/concatenate_list"
+            },
+            {
+              "$ref": "transforms/format_list.json#/format_list"
+            },
+            {
+              "$ref": "transforms/format_possessive.json#/format_possessive"
+            }
+          ]
+        }
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "placeholder"
+    ],
+    "oneOf": [
+      {
+        "required": [ "value" ]
+      },
+      {
+        "required": [ "transforms" ]
+      }
+    ]
+  },
+  "value_sources": {
+    "oneOf": [
+      {
+        "$ref": "#/chained_source"
+      },
+      {
+        "$ref": "#/lookup_source"
+      }
+    ]
+  },
+  "chained_source": {
+    "description": "This will take the value from the previous transform. Can't be used for the first transform.",
+    "type": "object",
+    "properties": {
+      "source": {
+        "type": "string",
+        "enum": [
+          "previous_transform"
+        ]
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "source"
+    ]
+  },
+  "lookup_source": {
+    "description": "Look up the value from a data source.",
+    "type": "object",
+    "properties": {
+      "source": {
+        "description": "The data source.",
+        "type": "string",
+        "enum": [
+          "answers",
+          "metadata",
+          "collection_metadata"
+        ]
+      },
+      "identifier": {
+        "description": "The identifier of the item in the data source. This would be an answer id for answers, and a metadata property name for metadata. The array option allows multiple values to be passed as a list to a transform.",
+        "type": ["string","array"]
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "source",
+      "identifier"
+    ]
+  }
+}
+

--- a/schemas/string_interpolation/transforms/calculate_years_difference.json
+++ b/schemas/string_interpolation/transforms/calculate_years_difference.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema",
+  "calculate_years_difference": {
+    "type": "object",
+    "properties": {
+      "transform": {
+        "type": "string",
+        "enum": ["calculate_years_difference"]
+      },
+      "arguments": {
+        "type": "object",
+        "properties": {
+          "first_date": {
+            "oneOf": [
+              {
+                "$ref": "../definitions.json#/value_sources" 
+              },
+              {
+                "$ref": "#/date_value" 
+              }
+            ]
+          },
+          "second_date": {
+            "oneOf": [
+              {
+                "$ref": "../definitions.json#/value_sources" 
+              },
+              {
+                "$ref": "#/date_value" 
+              }
+            ]
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "first_date",
+          "second_date"
+        ]    
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "transform",
+      "arguments"
+    ]
+  },
+  "date_value": {
+    "type:": "object",
+    "properties": {
+      "value": {
+        "type": "string",
+        "pattern": "^(\\d{4}-\\d{2}-\\d{2}|\\d{4}-\\d{2}|\\d{4}|now)$"
+      }
+    },
+    "additionalProperties": false
+  }
+}

--- a/schemas/string_interpolation/transforms/concatenate_list.json
+++ b/schemas/string_interpolation/transforms/concatenate_list.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema",
+  "concatenate_list": {
+    "description": "A transform for joining lists of strings together with a delimiter e.g. with a list of ['a','b'] and delimeter ' ' the output would be 'a b'.",
+    "type": "object",
+    "properties": {
+      "transform": {
+        "type": "string",
+        "enum": ["concatenate_list"]
+      },
+      "arguments": {
+        "type": "object",
+        "properties": {
+          "list": {
+            "description": "This should be set to something that produces a list e.g. an answer that repeats, or provide multiple answer ids.",
+            "$ref": "../definitions.json#/value_sources" 
+          },
+          "delimiter": {
+            "description": "The delimiter to use, common ones are ' ' for names and ', ' for addresses.",
+            "type": "string"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "list",
+          "delimiter"
+        ]    
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "transform",
+      "arguments"
+    ]
+  }
+}

--- a/schemas/string_interpolation/transforms/format_date.json
+++ b/schemas/string_interpolation/transforms/format_date.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema",
+  "format_date": {
+    "type": "object",
+    "properties": {
+      "transform": {
+        "type": "string",
+        "enum": ["format_date"]
+      },
+      "arguments": {
+        "type": "object",
+        "properties": {
+          "date": {
+            "$ref": "../definitions.json#/value_sources" 
+          },
+          "format": {
+            "type": "string",
+            "description": "See https://unicode.org/reports/tr35/tr35-dates.html#Date_Format_Patterns",
+            "enum": [
+              "EEEE d MMMM",
+              "EEEE d MMMM YYYY"
+            ]
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "date"
+        ]
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "transform",
+      "arguments"
+    ]
+  }
+}

--- a/schemas/string_interpolation/transforms/format_date_range.json
+++ b/schemas/string_interpolation/transforms/format_date_range.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema",
+  "format_date_range": {
+    "type": "object",
+    "properties": {
+      "transform": {
+        "type": "string",
+        "enum": ["format_date_range"]
+      },
+      "arguments": {
+        "type": "object",
+        "properties": {
+          "start_date": {
+            "$ref": "../definitions.json#/value_sources"
+          },
+          "end_date": {
+            "$ref": "../definitions.json#/value_sources"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "start_date"
+        ]    
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "transform",
+      "arguments"
+    ]
+  }
+}

--- a/schemas/string_interpolation/transforms/format_list.json
+++ b/schemas/string_interpolation/transforms/format_list.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema",
+  "format_list": {
+    "description": "A transform for outputting a list",
+    "type": "object",
+    "properties": {
+      "transform": {
+        "type": "string",
+        "enum": ["format_list"]
+      },
+      "arguments": {
+        "type": "object",
+        "properties": {
+          "list": {
+            "description": "This should be set to something that produces a list e.g. an answer that repeats, or provide multiple answer ids.",
+            "$ref": "../definitions.json#/value_sources" 
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "list"
+        ]    
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "transform",
+      "arguments"
+    ]
+  }
+}

--- a/schemas/string_interpolation/transforms/format_number.json
+++ b/schemas/string_interpolation/transforms/format_number.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema",
+  "format_number": {
+    "type": "object",
+    "properties": {
+      "transform": {
+        "type": "string",
+        "enum": ["format_number"]
+      },
+      "arguments": {
+        "type": "object",
+        "properties": {
+          "number": {
+            "$ref": "../definitions.json#/value_sources" 
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "number"
+        ]    
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "transform",
+      "arguments"
+    ]
+  }
+}

--- a/schemas/string_interpolation/transforms/format_possessive.json
+++ b/schemas/string_interpolation/transforms/format_possessive.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema",
+  "format_possessive": {
+    "type": "object",
+    "properties": {
+      "transform": {
+        "type": "string",
+        "enum": ["format_possessive"]
+      },
+      "arguments": {
+        "type": "object",
+        "properties": {
+          "string": {
+            "$ref": "../definitions.json#/value_sources" 
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "string"
+        ]    
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "transform",
+      "arguments"
+    ]
+  }
+}

--- a/tests/schemas/test_invalid_string_transforms.json
+++ b/tests/schemas/test_invalid_string_transforms.json
@@ -1,0 +1,215 @@
+{
+    "eq_id": "3",
+    "form_type": "3",
+    "mime_type": "application/json/ons/eq",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.2",
+    "survey_id": "3",
+    "title": "Invalid String Transforms",
+    "sections": [{
+      "id": "section1",
+      "groups": [{
+          "id": "group1",
+          "title": "",
+          "blocks": [{
+            "id": "block1",
+            "title": "",
+            "type": "Question",
+            "questions": [{
+              "id": "question1",
+              "title": "",
+              "description": "",
+              "type": "General",
+              "answers": [
+                  {
+                    "id": "answer1",
+                    "mandatory": false,
+                    "type": "TextField",
+                    "label": "Placeholder in 'text' doesn't have a definition",
+                    "description": {
+                        "text": "test {answer1}",
+                        "placeholders": [{
+                            "placeholder": "answer2",
+                            "value": {
+                                "source": "answers",
+                                "identifier": "answer1"
+                            }
+                        }]
+                    }
+                  }
+                ]
+            }]
+          },
+          {
+            "id": "block2",
+            "title": "",
+            "type": "Question",
+            "questions": [{
+              "id": "question2",
+              "title": "",
+              "description": "",
+              "type": "General",
+              "answers": [
+                  {
+                    "id": "answer2",
+                    "mandatory": false,
+                    "type": "TextField",
+                    "label": "Number of placeholders in 'text' doesn't match number of definitions",
+                    "description": {
+                        "text": "test {answer1} and {answer2}",
+                        "placeholders": [{
+                            "placeholder": "answer1",
+                            "value": {
+                                "source": "answers",
+                                "identifier": "answer1"
+                            }
+                        }]
+                    }
+                  }
+                ]
+            }]
+          },
+          {
+            "id": "block3",
+            "title": "",
+            "type": "Question",
+            "questions": [{
+              "id": "question3",
+              "title": "",
+              "description": "",
+              "type": "General",
+              "answers": [
+                  {
+                    "id": "answer3",
+                    "mandatory": false,
+                    "type": "TextField",
+                    "label": "Number of placeholders in 'text' doesn't match number of definitions",
+                    "description": {
+                        "text": "test {answer1}",
+                        "placeholders": [{
+                            "placeholder": "answer1",
+                            "value": {
+                                "source": "answers",
+                                "identifier": "answer1"
+                            }
+                        },
+                        {
+                            "placeholder": "answer2",
+                            "value": {
+                                "source": "answers",
+                                "identifier": "answer2"
+                            }
+                        }]
+                    }
+                  }
+                ]
+            }]
+          },
+          {
+            "id": "block4",
+            "title": "",
+            "type": "Question",
+            "questions": [{
+              "id": "question4",
+              "title": "",
+              "description": "",
+              "type": "General",
+              "answers": [
+                  {
+                    "id": "answer4",
+                    "mandatory": false,
+                    "type": "TextField",
+                    "label": "Can't reference 'previous_transform' in first transform",
+                    "description": {
+                        "text": "test {answer1}",
+                        "placeholders": [{
+                            "placeholder": "answer1",
+                            "transforms": [{
+                                "transform": "format_number",
+                                "arguments": {
+                                    "number": {
+                                        "source": "previous_transform"
+                                    }
+                                }
+                            }]
+                        }]
+                    }
+                  }
+                ]
+            }]
+          },
+          {
+            "id": "block5",
+            "title": "",
+            "type": "Question",
+            "questions": [{
+              "id": "question5",
+              "title": "",
+              "description": "",
+              "type": "General",
+              "answers": [
+                  {
+                    "id": "answer5",
+                    "mandatory": false,
+                    "type": "TextField",
+                    "label": "Chained transforms must reference previous_transform",
+                    "description": {
+                        "text": "test {answer1}",
+                        "placeholders": [{
+                            "placeholder": "answer1",
+                            "transforms": [{
+                                "transform": "format_number",
+                                "arguments": {
+                                    "number": {
+                                        "source": "answers",
+                                        "identifier": "answer1"
+                                    }
+                                }
+                            },
+                            {
+                                "transform": "format_number",
+                                "arguments": {
+                                    "number": {
+                                        "source": "answers",
+                                        "identifier": "answer1"
+                                    }
+                                }
+                            }]
+                        }]
+                    }
+                  }
+                ]
+            }]
+          },
+          {
+            "id": "confirmation",
+            "type": "Confirmation",
+            "description": "",
+            "title": ""
+          }]
+        }
+      ]
+    }],
+    "theme": "default",
+    "legal_basis": "StatisticsOfTradeAct",
+    "navigation": {
+      "visible": false
+    },
+    "metadata": [{
+        "name": "user_id",
+        "validator": "string"
+      },
+      {
+        "name": "period_id",
+        "validator": "string"
+      },
+      {
+        "name": "ru_name",
+        "validator": "string"
+      },
+      {
+        "name": "test_metadata",
+        "validator": "string"
+      }
+    ]
+}

--- a/tests/schemas/test_string_transforms.json
+++ b/tests/schemas/test_string_transforms.json
@@ -1,0 +1,516 @@
+{
+    "eq_id": "3",
+    "form_type": "3",
+    "mime_type": "application/json/ons/eq",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.2",
+    "survey_id": "3",
+    "title": "String Transforms",
+    "sections": [{
+      "id": "section1",
+      "groups": [{
+          "id": "group1",
+          "title": "",
+          "blocks": [{
+            "id": "block1",
+            "title": "",
+            "type": "Question",
+            "questions": [{
+              "id": "question1",
+              "title": "",
+              "description": "",
+              "type": "General",
+              "answers": [
+                  {
+                    "id": "answer0",
+                    "mandatory": false,
+                    "type": "TextField",
+                    "label": "Simple value from answer store",
+                    "description": "description with no placeholders"
+                  },
+                  {
+                    "id": "answer1",
+                    "mandatory": false,
+                    "type": "TextField",
+                    "label": "Simple value from answer store",
+                    "description": {
+                        "text": "test {simple_answer}",
+                        "placeholders": [{
+                            "placeholder": "simple_answer",
+                            "value": {
+                                "source": "answers",
+                                "identifier": "answer1"
+                            }
+                        }]
+                    }
+                  },
+                  {
+                    "id": "answer2",
+                    "mandatory": false,
+                    "type": "TextField",
+                    "label": "Simple value from answer store via transform",
+                    "description": {
+                        "text": "test {simple_answer_with_transform}",
+                        "placeholders": [{
+                            "placeholder": "simple_answer_with_transform",
+                            "transforms": [{
+                                "transform": "format_number",
+                                "arguments": {
+                                    "number": {
+                                        "source": "answers",
+                                        "identifier": "answer2"
+                                    }
+                                }
+                            }]
+                        }]
+                    }
+                  },
+                  {
+                    "id": "answer3",
+                    "mandatory": false,
+                    "type": "TextField",
+                    "label": "Two values from answer store via transform",
+                    "description": {
+                        "text": "test {date_range}",
+                        "placeholders": [{
+                            "placeholder": "date_range",
+                            "transforms": [{
+                                "transform": "format_date_range",
+                                "arguments": {
+                                    "start_date": {
+                                        "source": "answers",
+                                        "identifier": "answer3"
+                                    },
+                                    "end_date": {
+                                        "source": "answers",
+                                        "identifier": "answer3"
+                                    }
+                                }
+                            }]
+                        }]
+                    }
+                  },
+                  {
+                    "id": "answer4",
+                    "mandatory": false,
+                    "type": "TextField",
+                    "label": "Two tranforms chained together",
+                    "description": {
+                        "text": "test {multiple_transforms}",
+                        "placeholders": [{
+                            "placeholder": "multiple_transforms",
+                            "transforms": [
+                                {
+                                    "transform": "format_number",
+                                    "arguments": {
+                                        "number": {
+                                            "source": "answers",
+                                            "identifier": "answer4"
+                                        }
+                                    }
+                                },
+                                {
+                                    "transform": "format_number",
+                                    "arguments": {
+                                        "number": {
+                                            "source": "previous_transform"
+                                        }
+                                    }
+                                }
+                            ]
+                        }]
+                    }
+                  },
+                  {
+                    "id": "answer5",
+                    "mandatory": false,
+                    "type": "TextField",
+                    "label": "String value passed to transform",
+                    "description": {
+                        "text": "test {value}",
+                        "placeholders": [{
+                            "placeholder": "value",
+                            "transforms": [
+                                {
+                                    "transform": "format_date",
+                                    "arguments": {
+                                        "date": {
+                                            "source": "answers",
+                                            "identifier": "answer5"
+                                        },
+                                        "format": "EEEE d MMMM"
+                                    }
+                                }
+                            ]
+                        }]
+                    }
+                  }
+                ]
+            },
+            {
+                "id": "question2",
+                "title": "",
+                "description": "Calculate years difference tests",
+                "type": "General",
+                "answers": [
+                    {
+                        "id": "q2-answer-1",
+                        "mandatory": false,
+                        "type": "TextField",
+                        "label": "Simple calculate years difference",
+                        "description": {
+                            "text": "test {simple_difference}",
+                            "placeholders": [{
+                                "placeholder": "simple_difference",
+                                "transforms": [
+                                    {
+                                        "transform": "calculate_years_difference",
+                                        "arguments": {
+                                            "first_date": {
+                                                "value": "2018-01-01"
+                                            },
+                                            "second_date": {
+                                                "value": "2019-01-20"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }]
+                        }
+                    },
+                    {
+                        "id": "q2-answer-2",
+                        "mandatory": false,
+                        "type": "TextField",
+                        "label": "Calculate years difference with one lookup",
+                        "description": {
+                            "text": "test {one_lookup}",
+                            "placeholders": [{
+                                "placeholder": "one_lookup",
+                                "transforms": [
+                                    {
+                                        "transform": "calculate_years_difference",
+                                        "arguments": {
+                                            "first_date": {
+                                                "source": "answers",
+                                                "identifier": "q2-answer-1"
+                                            },
+                                            "second_date": {
+                                                "value": "2019-01-20"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }]
+                        }
+                    },
+                    {
+                        "id": "q2-answer-3",
+                        "mandatory": false,
+                        "type": "TextField",
+                        "label": "Calculate years difference with two lookups",
+                        "description": {
+                            "text": "test {two_lookups}",
+                            "placeholders": [{
+                                "placeholder": "two_lookups",
+                                "transforms": [
+                                    {
+                                        "transform": "calculate_years_difference",
+                                        "arguments": {
+                                            "first_date": {
+                                                "source": "answers",
+                                                "identifier": "q2-answer-1"
+                                            },
+                                            "second_date": {
+                                                "source": "answers",
+                                                "identifier": "q2-answer-2"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }]
+                        }
+                    },
+                    {
+                        "id": "q2-answer-4",
+                        "mandatory": false,
+                        "type": "TextField",
+                        "label": "Calculate years difference to current date",
+                        "description": {
+                            "text": "test {difference_to_current_date}",
+                            "placeholders": [{
+                                "placeholder": "difference_to_current_date",
+                                "transforms": [
+                                    {
+                                        "transform": "calculate_years_difference",
+                                        "arguments": {
+                                            "first_date": {
+                                                "source": "answers",
+                                                "identifier": "q2-answer-1"
+                                            },
+                                            "second_date": {
+                                                "value": "now"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }]
+                        }
+                    }
+                ]
+            },
+            {
+                "id": "question3",
+                "title": "",
+                "description": "Concatenate list tests",
+                "type": "General",
+                "answers": [
+                    {
+                        "id": "q3-answer-1",
+                        "mandatory": false,
+                        "type": "TextField",
+                        "label": "Concatenate list of answer that is a list",
+                        "description": {
+                            "text": "test {concatenated_list}",
+                            "placeholders": [{
+                                "placeholder": "concatenated_list",
+                                "transforms": [
+                                    {
+                                        "transform": "concatenate_list",
+                                        "arguments": {
+                                            "list": {
+                                                "source": "answers",
+                                                "identifier": "q2-answer-1"
+                                            },
+                                            "delimiter": " "
+                                        }
+                                    }
+                                ]
+                            }]
+                        }
+                    },
+                    {
+                        "id": "q3-answer-2",
+                        "mandatory": false,
+                        "type": "TextField",
+                        "label": "Concatenate list of multiple answers",
+                        "description": {
+                            "text": "test {concatenated_list}",
+                            "placeholders": [{
+                                "placeholder": "concatenated_list",
+                                "transforms": [
+                                    {
+                                        "transform": "concatenate_list",
+                                        "arguments": {
+                                            "list": {
+                                                "source": "answers",
+                                                "identifier": ["q2-answer-1","q2-answer-2"]
+                                            },
+                                            "delimiter": ", "
+                                        }
+                                    }
+                                ]
+                            }]
+                        }
+                    }
+                ]
+            },
+            {
+                "id": "question4",
+                "title": "",
+                "description": "Format possessive tests",
+                "type": "General",
+                "answers": [
+                    {
+                        "id": "q4-answer-1",
+                        "mandatory": false,
+                        "type": "TextField",
+                        "label": "Simple format possessive of answer",
+                        "description": {
+                            "text": "test {possessive_string}",
+                            "placeholders": [{
+                                "placeholder": "possessive_string",
+                                "transforms": [
+                                    {
+                                        "transform": "format_possessive",
+                                        "arguments": {
+                                            "string": {
+                                                "source": "answers",
+                                                "identifier": "q3-answer-1"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }]
+                        }
+                    },
+                    {
+                        "id": "q4-answer-2",
+                        "mandatory": false,
+                        "type": "TextField",
+                        "label": "Format possessive of an answer from another transform",
+                        "description": {
+                            "text": "test {possessive_string}",
+                            "placeholders": [{
+                                "placeholder": "possessive_string",
+                                "transforms": [
+                                    {
+                                        "transform": "concatenate_list",
+                                        "arguments": {
+                                            "list": {
+                                                "source": "answers",
+                                                "identifier": ["q2-answer-1","q2-answer-2"]
+                                            },
+                                            "delimiter": " "
+                                        }
+                                    },
+                                    {
+                                        "transform": "format_possessive",
+                                        "arguments": {
+                                            "string": {
+                                                "source": "previous_transform"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }]
+                        }
+                    }
+                ]
+            },
+            {
+                "id": "question5",
+                "title": "",
+                "description": "Format list tests",
+                "type": "General",
+                "answers": [
+                    {
+                        "id": "q5-answer-1",
+                        "mandatory": false,
+                        "type": "TextField",
+                        "label": "Simple format list",
+                        "description": {
+                            "text": "{list}",
+                            "placeholders": [{
+                                "placeholder": "list",
+                                "transforms": [
+                                    {
+                                        "transform": "format_list",
+                                        "arguments": {
+                                            "list": {
+                                                "source": "answers",
+                                                "identifier": ["q2-answer-1","q2-answer-2"]
+                                            }
+                                        }
+                                    }
+                                ]
+                            }]
+                        }
+                    }
+                ]
+            },
+            {
+                "id": "question6",
+                "title": "",
+                "description": "Radio option label tests",
+                "type": "General",
+                "answers": [
+                    {
+                        "id": "q6-answer-1",
+                        "mandatory": false,
+                        "type": "Radio",
+                        "label": "Placeholders in radio option label",
+                        "description": "",
+                        "options": [
+                            {
+                                "label": {
+                                    "text": "test {simple_answer}",
+                                    "placeholders": [
+                                        {
+                                            "placeholder": "simple_answer",
+                                            "value": {
+                                                "source": "answers",
+                                                "identifier": "answer1"
+                                            }
+                                        }
+                                    ]
+                                },
+                                "value": "value"
+                            },
+                            {
+                                "label": "Another value",
+                                "value": "value2"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "id": "question7",
+                "title": "",
+                "description": "Checkbox option label tests",
+                "type": "General",
+                "answers": [
+                    {
+                        "id": "q7-answer-1",
+                        "mandatory": false,
+                        "type": "Checkbox",
+                        "label": "Placeholders in checkbox option label",
+                        "description": "",
+                        "options": [
+                            {
+                                "label": {
+                                    "text": "test {simple_answer}",
+                                    "placeholders": [
+                                        {
+                                            "placeholder": "simple_answer",
+                                            "value": {
+                                                "source": "answers",
+                                                "identifier": "answer1"
+                                            }
+                                        }
+                                    ]
+                                },
+                                "value": "value"
+                            },
+                            {
+                                "label": "Another value",
+                                "value": "value2"
+                            }
+                        ]
+                    }
+                ]
+            }]
+          },
+          {
+            "id": "confirmation",
+            "type": "Confirmation",
+            "description": "",
+            "title": ""
+          }]
+        }
+      ]
+    }],
+    "theme": "default",
+    "legal_basis": "StatisticsOfTradeAct",
+    "navigation": {
+      "visible": false
+    },
+    "metadata": [{
+        "name": "user_id",
+        "validator": "string"
+      },
+      {
+        "name": "period_id",
+        "validator": "string"
+      },
+      {
+        "name": "ru_name",
+        "validator": "string"
+      },
+      {
+        "name": "test_metadata",
+        "validator": "string"
+      }
+    ]
+}

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -13,7 +13,7 @@ logger = getLogger()
 configure(logger_factory=LoggerFactory())
 
 
-class TestSchemaValidation(unittest.TestCase):
+class TestSchemaValidation(unittest.TestCase):  # pylint: disable=too-many-public-methods
 
     def setUp(self):
         self.validator = Validator()
@@ -327,6 +327,38 @@ class TestSchemaValidation(unittest.TestCase):
         errors = self.validator.validate_schema(json_to_validate)
 
         self.assertEqual(0, len(errors))
+
+    def test_string_transforms(self):
+        file_name = 'schemas/test_string_transforms.json'
+        json_to_validate = self._open_and_load_schema_file(file_name)
+
+        errors = self.validator.validate_schema(json_to_validate)
+
+        self.assertEqual(0, len(errors))
+
+    def test_invalid_string_transforms(self):
+        file_name = 'schemas/test_invalid_string_transforms.json'
+        json_to_validate = self._open_and_load_schema_file(file_name)
+
+        errors = self.validator.validate_schema(json_to_validate)
+
+        self.assertEqual(5, len(errors))
+
+        self.assertEqual(
+            errors[0]['message'],
+            "Schema Integrity Error. Placeholders in 'text' doesn't match 'placeholders' definition for block id 'block1'")
+        self.assertEqual(
+            errors[1]['message'],
+            "Schema Integrity Error. Placeholders in 'text' doesn't match 'placeholders' definition for block id 'block2'")
+        self.assertEqual(
+            errors[2]['message'],
+            "Schema Integrity Error. Placeholders in 'text' doesn't match 'placeholders' definition for block id 'block3'")
+        self.assertEqual(
+            errors[3]['message'],
+            "Schema Integrity Error. Can't reference `previous_transform` in a first transform in block id 'block4'")
+        self.assertEqual(
+            errors[4]['message'],
+            "Schema Integrity Error. `previous_transform` not referenced in chained transform in block id 'block5'")
 
     @staticmethod
     def _open_and_load_schema_file(file):


### PR DESCRIPTION
The current way we define piping (string interpolation) in a schema is to include jinja filters directly in the source strings, which has a number of issues. This pull request contains a proposal to move away from this to a defined schema structure.