### PR TITLE
Ensure that answer option values do not contain piping

### DIFF
--- a/app/validation/validator.py
+++ b/app/validation/validator.py
@@ -111,6 +111,7 @@ class Validator:    # pylint: disable=too-many-public-methods
             for answer in question.get('answers', []):
                 errors.extend(self.validate_routing_on_answer_options(block, answer))
                 errors.extend(self.validate_duplicate_options(answer))
+                errors.extend(self.validate_option_values(answer))
                 errors.extend(self.validate_totaliser_defines_decimal_places(answer))
 
                 if answer['type'] == 'Date':
@@ -588,6 +589,20 @@ class Validator:    # pylint: disable=too-many-public-methods
 
             labels.add(option['label'])
             values.add(option['value'])
+
+        return errors
+
+    def validate_option_values(self, answer):
+        errors = []
+
+        for option in answer.get('options', []):
+
+            if re.match('^.*{{.*}}.*$', option['value']):
+                error_message = 'Option "value" cannot contain piping. Found in option with label - "{}" from answer_id - "{}"'.format(
+                    option['label'],
+                    answer['id']
+                )
+                errors.append(self._error_message(error_message))
 
         return errors
 

--- a/tests/schemas/test_invalid_option_value.json
+++ b/tests/schemas/test_invalid_option_value.json
@@ -1,0 +1,123 @@
+{
+  "eq_id": "3",
+  "form_type": "3",
+  "mime_type": "application/json/ons/eq",
+  "schema_version": "0.0.1",
+  "data_version": "0.0.2",
+  "survey_id": "3",
+  "title": "Piping Option Values",
+  "sections": [
+    {
+      "id": "section3",
+      "title": "",
+      "groups": [
+        {
+          "id": "group3",
+          "title": "",
+          "blocks": [
+            {
+              "id": "block4",
+              "title": "",
+              "type": "Question",
+              "questions": [
+                {
+                  "id": "question4",
+                  "title": "",
+                  "description": "",
+                  "type": "General",
+                  "answers": [
+                    {
+                      "id": "checkboxanswer",
+                      "mandatory": false,
+                      "type": "Checkbox",
+                      "label": "Checkbox",
+                      "description": "",
+                      "options": [
+                        {
+                          "q_code": "0410",
+                          "label": "option1",
+                          "value": "{{ metadata['test_metadata'] }}"
+                        }
+                      ]
+                    },
+                    {
+                      "id": "radioanswer",
+                      "mandatory": false,
+                      "type": "Radio",
+                      "label": "Radio",
+                      "description": "",
+                      "options": [
+                        {
+                          "q_code": "0411",
+                          "label": "option2",
+                          "value": "{{ metadata['test_metadata'] }}"
+                        },
+                        {
+                          "q_code": "0412",
+                          "label": "option3",
+                          "value": "option3"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "confirmation-group",
+          "title": "confirmation",
+          "blocks": [
+            {
+              "title": "You are now ready to submit this survey",
+              "type": "Confirmation",
+              "id": "confirmation",
+              "description": "",
+              "questions": [
+                {
+                  "id": "ready-to-submit-completed-question",
+                  "title": "Submission",
+                  "type": "Content",
+                  "guidance": {
+                    "content": [
+                      {
+                        "list": [
+                          "You will not be able to access or change your answers on submitting the questionnaire",
+                          "If you wish to review your answers please select the relevant completed sections"
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "theme": "default",
+  "legal_basis": "StatisticsOfTradeAct",
+  "navigation": {
+    "visible": false
+  },
+  "metadata": [
+    {
+      "name": "user_id",
+      "validator": "string"
+    },
+    {
+      "name": "period_id",
+      "validator": "string"
+    },
+    {
+      "name": "ru_name",
+      "validator": "string"
+    },
+    {
+      "name": "test_metadata",
+      "validator": "string"
+    }
+  ]
+}

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -13,7 +13,7 @@ logger = getLogger()
 configure(logger_factory=LoggerFactory())
 
 
-class TestSchemaValidation(unittest.TestCase):
+class TestSchemaValidation(unittest.TestCase):  # pylint: disable=too-many-public-methods
 
     def setUp(self):
         self.validator = Validator()
@@ -327,6 +327,23 @@ class TestSchemaValidation(unittest.TestCase):
         errors = self.validator.validate_schema(json_to_validate)
 
         self.assertEqual(0, len(errors))
+
+    def test_invalid_piping_in_option_values(self):
+        """ Ensures that there is invalid to use piping in a checkbox value """
+        file = 'schemas/test_invalid_option_value.json'
+        json_to_validate = self._open_and_load_schema_file(file)
+
+        errors = self.validator.validate_schema(json_to_validate)
+
+        print(errors)
+
+        self.assertEqual(len(errors), 2)
+        self.assertEqual(errors[0]['message'],
+                         'Schema Integrity Error. Option "value" cannot contain piping. '
+                         'Found in option with label - "option1" from answer_id - "checkboxanswer"')
+        self.assertEqual(errors[1]['message'],
+                         'Schema Integrity Error. Option "value" cannot contain piping. '
+                         'Found in option with label - "option2" from answer_id - "radioanswer"')
 
     @staticmethod
     def _open_and_load_schema_file(file):


### PR DESCRIPTION
Validation to enforce that option values cannot contain piping.

I contemplated creating a whitelist of allowed characters but everything seems to accept string so I presume that would be restrictive. Instead I have done a very simple regex test that checks to see if anything looks like a piping value. However this might not be optimal. Suggestions welcome.

## Testing
1. You can apply a piping value to an option label and publisher will send it as the value so I tested this against publisher using that but you have to change the publisher validator URL to `docker.for.mac.localhost:5001` once you have schema-validator running locally.
2. The unit tests should pass.
