### PR TITLE
Ensure that required fields are actually populated

### DIFF
--- a/schemas/answers/currency.json
+++ b/schemas/answers/currency.json
@@ -10,7 +10,7 @@
         "$ref": "../common_definitions.json#/q_code"
       },
       "label": {
-        "type": "string"
+        "$ref": "../common_definitions.json#/populated_string"
       },
       "guidance": {
         "$ref": "../common_definitions.json#/guidance"

--- a/schemas/answers/definitions.json
+++ b/schemas/answers/definitions.json
@@ -11,7 +11,7 @@
       "type": "object",
       "properties": {
         "label": {
-          "type": "string"
+          "$ref": "../common_definitions.json#/populated_string"
         },
         "value": {
           "type": "string"

--- a/schemas/answers/number.json
+++ b/schemas/answers/number.json
@@ -10,7 +10,7 @@
         "$ref": "../common_definitions.json#/q_code"
       },
       "label": {
-        "type": "string"
+        "$ref": "../common_definitions.json#/populated_string"
       },
       "guidance": {
         "$ref": "../common_definitions.json#/guidance"

--- a/schemas/answers/text_field.json
+++ b/schemas/answers/text_field.json
@@ -10,7 +10,7 @@
         "$ref": "../common_definitions.json#/q_code"
       },
       "label": {
-        "type": "string"
+        "$ref": "../common_definitions.json#/populated_string"
       },
       "guidance": {
         "$ref": "../common_definitions.json#/guidance"

--- a/schemas/answers/unit.json
+++ b/schemas/answers/unit.json
@@ -10,7 +10,7 @@
         "$ref": "../common_definitions.json#/q_code"
       },
       "label": {
-        "type": "string"
+        "$ref": "../common_definitions.json#/populated_string"
       },
       "guidance": {
         "$ref": "../common_definitions.json#/guidance"

--- a/schemas/common_definitions.json
+++ b/schemas/common_definitions.json
@@ -10,6 +10,10 @@
     "description": "A question code used by downstream systems to identify answers.",
     "pattern": "^[0-9a-z]+$"
   },
+  "populated_string": {
+    "type": "string",
+    "pattern": "\\w+"
+  },
   "definitions": {
     "description": "Allows customisation of question definition title and description.",
     "type": "array",


### PR DESCRIPTION
Required fields such as labels on options and some answer types only had to be a string - their contents was never validated. This meant that empty strings were viewed as being valid. This meant that runner could be made to look broken.

This is a breaking change for some of the test schemas in runner and here is the PR to resolve this https://github.com/ONSdigital/eq-survey-runner/pull/1984