### PR TITLE
Validate that section title exists when navigation is enabled

### DIFF
--- a/app/validation/validator.py
+++ b/app/validation/validator.py
@@ -43,6 +43,7 @@ class Validator:    # pylint: disable=too-many-public-methods
             all_groups.extend(section.get('groups'))
 
         for section in json_to_validate['sections']:
+            errors.extend(self._validate_navigation(json_to_validate, section))
             for group in section['groups']:
 
                 errors.extend(self._validate_routing_rules(group, all_groups, answers_with_parent_ids))
@@ -51,6 +52,26 @@ class Validator:    # pylint: disable=too-many-public-methods
                     errors.extend(self.validate_skip_condition(skip_condition, answers_with_parent_ids, group))
 
                 errors.extend(self._validate_blocks(json_to_validate, section, group, all_groups, answers_with_parent_ids, numeric_answer_ranges))
+
+        return errors
+
+    def _validate_navigation(self, json_to_validate, section):
+        errors = []
+
+        navigation = json_to_validate.get('navigation')
+        if not navigation:
+            return errors
+
+        nav_is_visible = navigation.get('visible')
+        if not nav_is_visible:
+            return errors
+
+        title = section.get('title', '')
+        title_from_answers = len(section.get('title_from_answers', []))
+
+        if not re.match('\\w+', title) and title_from_answers == 0:
+            error_message = 'Section ({}) is missing a title and navigation is enabled'.format(section['id'])
+            errors.append(self._error_message(error_message))
 
         return errors
 

--- a/tests/schemas/test_invalid_navigation.json
+++ b/tests/schemas/test_invalid_navigation.json
@@ -1,0 +1,175 @@
+{
+  "data_version": "0.0.1",
+  "description": "A questionnaire to test currency input type",
+  "legal_basis": "StatisticsOfTradeAct",
+  "metadata": [
+    {
+      "name": "user_id",
+      "validator": "string"
+    },
+    {
+      "name": "ru_name",
+      "validator": "string"
+    },
+    {
+      "name": "period_id",
+      "validator": "string"
+    }
+  ],
+  "navigation": {
+    "visible": true
+  },
+  "mime_type": "application/json/ons/eq",
+  "schema_version": "0.0.1",
+  "sections": [
+    {
+      "title": "",
+      "groups": [
+        {
+          "blocks": [
+            {
+              "id": "block-1",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "decimal_places": 2,
+                      "id": "answer-1",
+                      "label": "Answer 1",
+                      "mandatory": false,
+                      "type": "Number"
+                    }
+                  ],
+                  "id": "question-1",
+                  "title": "Enter a value 1",
+                  "type": "General"
+                }
+              ],
+              "type": "Question"
+            },
+            {
+              "id": "summary-1",
+              "type": "Summary"
+            }
+          ],
+          "id": "group-1",
+          "title": "Ensure navigation has section titles"
+        }
+      ],
+      "id": "section-1"
+    },
+    {
+      "groups": [
+        {
+          "blocks": [
+            {
+              "id": "block-2",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "decimal_places": 2,
+                      "id": "answer-2",
+                      "label": "Answer 1",
+                      "mandatory": false,
+                      "type": "Number"
+                    }
+                  ],
+                  "id": "question-2",
+                  "title": "Enter a value 1",
+                  "type": "General"
+                }
+              ],
+              "type": "Question"
+            },
+            {
+              "id": "summary-2",
+              "type": "Summary"
+            }
+          ],
+          "id": "group-2",
+          "title": "Ensure navigation has section titles"
+        }
+      ],
+      "id": "section-2"
+    },
+    {
+      "groups": [
+        {
+          "blocks": [
+            {
+              "id": "block-3",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "decimal_places": 2,
+                      "id": "answer-3",
+                      "label": "Answer 1",
+                      "mandatory": false,
+                      "type": "Number"
+                    }
+                  ],
+                  "id": "question-3",
+                  "title": "Enter a value 1",
+                  "type": "General"
+                }
+              ],
+              "type": "Question"
+            },
+            {
+              "id": "summary-3",
+              "type": "Summary"
+            }
+          ],
+          "id": "group-3",
+          "title": "Ensure navigation has section titles"
+        }
+      ],
+      "title": "Section 3 title",
+      "id": "section-3"
+    },
+    {
+      "groups": [
+        {
+          "blocks": [
+            {
+              "id": "block-4",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "decimal_places": 2,
+                      "id": "answer-4",
+                      "label": "Answer 1",
+                      "mandatory": false,
+                      "type": "Number"
+                    }
+                  ],
+                  "id": "question-4",
+                  "title": "Enter a value 1",
+                  "type": "General"
+                }
+              ],
+              "type": "Question"
+            },
+            {
+              "id": "summary-4",
+              "type": "Summary"
+            }
+          ],
+          "id": "group-4",
+          "title": "Ensure navigation has section titles"
+        }
+      ],
+      "title_from_answers": [
+        "answer-1",
+        "answer-2"
+      ],
+      "id": "section-4"
+    }
+  ],
+  "survey_id": "0",
+  "theme": "default",
+  "title": "Minimum and maximum exclusivity"
+}

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -335,8 +335,6 @@ class TestSchemaValidation(unittest.TestCase):  # pylint: disable=too-many-publi
 
         errors = self.validator.validate_schema(json_to_validate)
 
-        print(errors)
-
         self.assertEqual(len(errors), 2)
         self.assertEqual(errors[0]['message'],
                          'Schema Integrity Error. Option "value" cannot contain piping. '
@@ -344,6 +342,18 @@ class TestSchemaValidation(unittest.TestCase):  # pylint: disable=too-many-publi
         self.assertEqual(errors[1]['message'],
                          'Schema Integrity Error. Option "value" cannot contain piping. '
                          'Found in option with label - "option2" from answer_id - "radioanswer"')
+
+    def test_invalid_navigation(self):
+        """ Ensure that when navigation is enabled sections have title """
+        file = 'schemas/test_invalid_navigation.json'
+        json_to_validate = self._open_and_load_schema_file(file)
+
+        errors = self.validator.validate_schema(json_to_validate)
+        self.assertEqual(len(errors), 2)
+        self.assertEqual(errors[0]['message'],
+                         'Schema Integrity Error. Section (section-1) is missing a title and navigation is enabled')
+        self.assertEqual(errors[1]['message'],
+                         'Schema Integrity Error. Section (section-2) is missing a title and navigation is enabled')
 
     @staticmethod
     def _open_and_load_schema_file(file):


### PR DESCRIPTION
This ensures that when navigation is visible that section title must be populated. Without this change when no section title is provided and navigation is visible this results in runner looking broken.