### PR TITLE
Use non global named args

### DIFF
--- a/schemas/string_interpolation/definitions.json
+++ b/schemas/string_interpolation/definitions.json
@@ -56,6 +56,9 @@
               "$ref": "transforms/format_number.json#/format_number"
             },
             {
+              "$ref": "transforms/format_currency.json#/format_currency"
+            },
+            {
               "$ref": "transforms/format_date.json#/format_date"
             },
             {

--- a/schemas/string_interpolation/transforms/concatenate_list.json
+++ b/schemas/string_interpolation/transforms/concatenate_list.json
@@ -11,7 +11,7 @@
       "arguments": {
         "type": "object",
         "properties": {
-          "list": {
+          "list_to_concatenate": {
             "description": "This should be set to something that produces a list e.g. an answer that repeats, or provide multiple answer ids.",
             "$ref": "../definitions.json#/value_sources" 
           },
@@ -22,7 +22,7 @@
         },
         "additionalProperties": false,
         "required": [
-          "list",
+          "list_to_concatenate",
           "delimiter"
         ]    
       }

--- a/schemas/string_interpolation/transforms/format_currency.json
+++ b/schemas/string_interpolation/transforms/format_currency.json
@@ -1,25 +1,23 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema",
-  "format_list": {
-    "description": "A transform for outputting a list",
+  "format_currency": {
     "type": "object",
     "properties": {
       "transform": {
         "type": "string",
-        "enum": ["format_list"]
+        "enum": ["format_currency"]
       },
       "arguments": {
         "type": "object",
         "properties": {
-          "list_to_format": {
-            "description": "This should be set to something that produces a list e.g. an answer that repeats, or provide multiple answer ids.",
-            "$ref": "../definitions.json#/value_sources" 
+          "number": {
+            "$ref": "../definitions.json#/value_sources"
           }
         },
         "additionalProperties": false,
         "required": [
-          "list_to_format"
-        ]    
+          "number"
+        ]
       }
     },
     "additionalProperties": false,

--- a/schemas/string_interpolation/transforms/format_date.json
+++ b/schemas/string_interpolation/transforms/format_date.json
@@ -10,10 +10,10 @@
       "arguments": {
         "type": "object",
         "properties": {
-          "date": {
+          "date_to_format": {
             "$ref": "../definitions.json#/value_sources" 
           },
-          "format": {
+          "date_format": {
             "type": "string",
             "description": "See https://unicode.org/reports/tr35/tr35-dates.html#Date_Format_Patterns",
             "enum": [
@@ -24,7 +24,7 @@
         },
         "additionalProperties": false,
         "required": [
-          "date"
+          "date_to_format"
         ]
       }
     },

--- a/schemas/string_interpolation/transforms/format_possessive.json
+++ b/schemas/string_interpolation/transforms/format_possessive.json
@@ -10,13 +10,13 @@
       "arguments": {
         "type": "object",
         "properties": {
-          "string": {
+          "string_to_format": {
             "$ref": "../definitions.json#/value_sources" 
           }
         },
         "additionalProperties": false,
         "required": [
-          "string"
+          "string_to_format"
         ]    
       }
     },

--- a/tests/schemas/test_string_transforms.json
+++ b/tests/schemas/test_string_transforms.json
@@ -134,11 +134,11 @@
                                 {
                                     "transform": "format_date",
                                     "arguments": {
-                                        "date": {
+                                        "date_to_format": {
                                             "source": "answers",
                                             "identifier": "answer5"
                                         },
-                                        "format": "EEEE d MMMM"
+                                        "date_format": "EEEE d MMMM"
                                     }
                                 }
                             ]
@@ -278,7 +278,7 @@
                                     {
                                         "transform": "concatenate_list",
                                         "arguments": {
-                                            "list": {
+                                            "list_to_concatenate": {
                                                 "source": "answers",
                                                 "identifier": "q2-answer-1"
                                             },
@@ -302,7 +302,7 @@
                                     {
                                         "transform": "concatenate_list",
                                         "arguments": {
-                                            "list": {
+                                            "list_to_concatenate": {
                                                 "source": "answers",
                                                 "identifier": ["q2-answer-1","q2-answer-2"]
                                             },
@@ -334,7 +334,7 @@
                                     {
                                         "transform": "format_possessive",
                                         "arguments": {
-                                            "string": {
+                                            "string_to_format": {
                                                 "source": "answers",
                                                 "identifier": "q3-answer-1"
                                             }
@@ -357,7 +357,7 @@
                                     {
                                         "transform": "concatenate_list",
                                         "arguments": {
-                                            "list": {
+                                            "list_to_concatenate": {
                                                 "source": "answers",
                                                 "identifier": ["q2-answer-1","q2-answer-2"]
                                             },
@@ -367,7 +367,7 @@
                                     {
                                         "transform": "format_possessive",
                                         "arguments": {
-                                            "string": {
+                                            "string_to_format": {
                                                 "source": "previous_transform"
                                             }
                                         }
@@ -397,7 +397,7 @@
                                     {
                                         "transform": "format_list",
                                         "arguments": {
-                                            "list": {
+                                            "list_to_format": {
                                                 "source": "answers",
                                                 "identifier": ["q2-answer-1","q2-answer-2"]
                                             }


### PR DESCRIPTION
### What is the context of this PR?

Updates the arguments to placeholder transforms to be less generic and non conflicting with python globals. This allows transformations to meet our coding standards in runner.

Additionally add format_currency as a transform, as defined in the docs here: https://github.com/ONSdigital/eq-schema-validator/blob/v3/doc/decisions/0001-define-piping-in-a-structured-way.md#previous-answers-or-metadata-transformed-in-some-way

Once this is merged, https://github.com/ONSdigital/eq-survey-runner/pull/2010 will pass validation tests.