### PR TITLE
Add lists to schema validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ In the eq-schema-validator directory, ensure you are using a recent version of n
 
 ```
 npm install 
+npm i -g gulp-cli
 ```
 
 Run the following to format all json files in the schemas directory:

--- a/schemas/blocks/list_collector.json
+++ b/schemas/blocks/list_collector.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema",
+  "block": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "$ref": "../common_definitions.json#/id"
+      },
+      "type": {
+        "type": "string",
+        "enum": ["ListCollector"]
+      },
+      "populates_list": {
+        "type": "string"
+      },
+      "add_answer_value": {
+        "type": "string"
+      },
+      "question": {
+        "$ref": "../questions/definitions.json#/question"
+      },
+      "question_variants": {
+        "$ref": "../common_definitions.json#/question_variants"
+      },
+      "add_block": {
+        "$ref": "question.json#/block"
+      },
+      "edit_block": {
+        "$ref": "question.json#/block"
+      },
+      "remove_block": {
+        "$ref": "question.json#/block"
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "id",
+      "type",
+      "populates_list",
+      "add_answer_value",
+      "add_block",
+      "edit_block",
+      "remove_block"
+    ],
+    "oneOf": [
+      {
+        "required": [
+          "question"
+        ]
+      },
+      {
+        "required": [
+          "question_variants"
+        ]
+      }
+    ]
+  }
+}

--- a/schemas/questionnaire_v1.json
+++ b/schemas/questionnaire_v1.json
@@ -177,6 +177,9 @@
                         "$ref": "blocks/introduction.json#/block"
                       },
                       {
+                        "$ref": "blocks/list_collector.json#/block"
+                      },
+                      {
                         "$ref": "blocks/question.json#/block"
                       },
                       {

--- a/tests/schemas/invalid/test_invalid_list_collector_non_radio.json
+++ b/tests/schemas/invalid/test_invalid_list_collector_non_radio.json
@@ -1,0 +1,142 @@
+{
+  "mime_type": "application/json/ons/eq",
+  "schema_version": "0.0.1",
+  "data_version": "0.0.2",
+  "survey_id": "0",
+  "title": "Test ListCollector",
+  "theme": "default",
+  "description": "A questionnaire to test ListCollector",
+  "metadata": [
+    {
+      "name": "user_id",
+      "validator": "string"
+    },
+    {
+      "name": "period_id",
+      "validator": "string"
+    },
+    {
+      "name": "ru_name",
+      "validator": "string"
+    }
+  ],
+  "sections": [
+    {
+      "id": "section",
+      "groups": [
+        {
+          "id": "group",
+          "title": "List",
+          "blocks": [
+            {
+              "id": "list-collector",
+              "type": "ListCollector",
+              "populates_list": "people",
+              "add_answer_value": "Yes",
+              "question": {
+                "id": "confirmation-question",
+                "type": "General",
+                "title": "Does anyone else live here?",
+                "answers": [
+                  {
+                    "id": "anyone-else",
+                    "mandatory": true,
+                    "type": "Checkbox",
+                    "options": [
+                      {
+                        "label": "Yes",
+                        "value": "Yes"
+                      },
+                      {
+                        "label": "No",
+                        "value": "No"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "add_block": {
+                "id": "add-person",
+                "type": "Question",
+                "question": {
+                  "id": "add-question",
+                  "type": "General",
+                  "title": "What is the name of the person?",
+                  "answers": [
+                    {
+                        "id": "first-name",
+                        "label": "First name",
+                        "mandatory": true,
+                        "type": "TextField"
+                    },
+                    {
+                        "id": "last-name",
+                        "label": "Last name",
+                        "mandatory": true,
+                        "type": "TextField"
+                    }
+                  ]
+
+                }
+              },
+              "edit_block": {
+                "id": "edit-person",
+                "type": "Question",
+                "question": {
+                  "id": "edit-question",
+                  "type": "General",
+                  "title": "What is the name of the person?",
+                  "answers": [
+                    {
+                        "id": "first-name",
+                        "label": "First name",
+                        "mandatory": true,
+                        "type": "TextField"
+                    },
+                    {
+                        "id": "last-name",
+                        "label": "Last name",
+                        "mandatory": true,
+                        "type": "TextField"
+                    }
+                  ]
+
+                }
+              },
+              "remove_block": {
+                "id": "remove-person",
+                "type": "Question",
+                "question": {
+                  "id": "remove-question",
+                  "type": "General",
+                  "title": "Are you sure you want to remove this person?",
+                  "answers": [
+                    {
+                      "id": "remove-confirmation",
+                      "mandatory": true,
+                      "type": "Radio",
+                      "options": [
+                        {
+                          "label": "Yes",
+                          "value": "Yes"
+                        },
+                        {
+                          "label": "No",
+                          "value": "No"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "type": "Summary",
+              "id": "summary"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/schemas/invalid/test_invalid_list_collector_with_no_add_option.json
+++ b/tests/schemas/invalid/test_invalid_list_collector_with_no_add_option.json
@@ -1,0 +1,142 @@
+{
+  "mime_type": "application/json/ons/eq",
+  "schema_version": "0.0.1",
+  "data_version": "0.0.2",
+  "survey_id": "0",
+  "title": "Test ListCollector",
+  "theme": "default",
+  "description": "A questionnaire to test ListCollector",
+  "metadata": [
+    {
+      "name": "user_id",
+      "validator": "string"
+    },
+    {
+      "name": "period_id",
+      "validator": "string"
+    },
+    {
+      "name": "ru_name",
+      "validator": "string"
+    }
+  ],
+  "sections": [
+    {
+      "id": "section",
+      "groups": [
+        {
+          "id": "group",
+          "title": "List",
+          "blocks": [
+            {
+              "id": "list-collector",
+              "type": "ListCollector",
+              "populates_list": "people",
+              "add_answer_value": "SomethingElse",
+              "question": {
+                "id": "confirmation-question",
+                "type": "General",
+                "title": "Does anyone else live here?",
+                "answers": [
+                  {
+                    "id": "anyone-else",
+                    "mandatory": true,
+                    "type": "Radio",
+                    "options": [
+                      {
+                        "label": "Yes",
+                        "value": "Yes"
+                      },
+                      {
+                        "label": "No",
+                        "value": "No"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "add_block": {
+                "id": "add-person",
+                "type": "Question",
+                "question": {
+                  "id": "add-question",
+                  "type": "General",
+                  "title": "What is the name of the person?",
+                  "answers": [
+                    {
+                        "id": "first-name",
+                        "label": "First name",
+                        "mandatory": true,
+                        "type": "TextField"
+                    },
+                    {
+                        "id": "last-name",
+                        "label": "Last name",
+                        "mandatory": true,
+                        "type": "TextField"
+                    }
+                  ]
+
+                }
+              },
+              "edit_block": {
+                "id": "edit-person",
+                "type": "Question",
+                "question": {
+                  "id": "edit-question",
+                  "type": "General",
+                  "title": "What is the name of the person?",
+                  "answers": [
+                    {
+                        "id": "first-name",
+                        "label": "First name",
+                        "mandatory": true,
+                        "type": "TextField"
+                    },
+                    {
+                        "id": "last-name",
+                        "label": "Last name",
+                        "mandatory": true,
+                        "type": "TextField"
+                    }
+                  ]
+
+                }
+              },
+              "remove_block": {
+                "id": "remove-person",
+                "type": "Question",
+                "question": {
+                  "id": "remove-question",
+                  "type": "General",
+                  "title": "Are you sure you want to remove this person?",
+                  "answers": [
+                    {
+                      "id": "remove-confirmation",
+                      "mandatory": true,
+                      "type": "Radio",
+                      "options": [
+                        {
+                          "label": "Yes",
+                          "value": "Yes"
+                        },
+                        {
+                          "label": "No",
+                          "value": "No"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "type": "Summary",
+              "id": "summary"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/schemas/invalid/test_invalid_list_collector_with_routing.json
+++ b/tests/schemas/invalid/test_invalid_list_collector_with_routing.json
@@ -1,0 +1,158 @@
+{
+  "mime_type": "application/json/ons/eq",
+  "schema_version": "0.0.1",
+  "data_version": "0.0.2",
+  "survey_id": "0",
+  "title": "Test ListCollector",
+  "theme": "default",
+  "description": "A questionnaire to test ListCollector",
+  "metadata": [
+    {
+      "name": "user_id",
+      "validator": "string"
+    },
+    {
+      "name": "period_id",
+      "validator": "string"
+    },
+    {
+      "name": "ru_name",
+      "validator": "string"
+    }
+  ],
+  "sections": [
+    {
+      "id": "section",
+      "groups": [
+        {
+          "id": "group",
+          "title": "List",
+          "blocks": [
+            {
+              "id": "list-collector",
+              "type": "ListCollector",
+              "populates_list": "people",
+              "add_answer_value": "Yes",
+              "question": {
+                "id": "confirmation-question",
+                "type": "General",
+                "title": "Does anyone else live here?",
+                "answers": [
+                  {
+                    "id": "anyone-else",
+                    "mandatory": true,
+                    "type": "Radio",
+                    "options": [
+                      {
+                        "label": "Yes",
+                        "value": "Yes"
+                      },
+                      {
+                        "label": "No",
+                        "value": "No"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "add_block": {
+                "id": "add-person",
+                "type": "Question",
+                "question": {
+                  "id": "add-question",
+                  "type": "General",
+                  "title": "What is the name of the person?",
+                  "answers": [
+                    {
+                        "id": "first-name",
+                        "label": "First name",
+                        "mandatory": true,
+                        "type": "TextField"
+                    },
+                    {
+                        "id": "last-name",
+                        "label": "Last name",
+                        "mandatory": true,
+                        "type": "TextField"
+                    }
+                  ]
+
+                }
+              },
+              "edit_block": {
+                "id": "edit-person",
+                "type": "Question",
+                "question": {
+                  "id": "edit-question",
+                  "type": "General",
+                  "title": "What is the name of the person?",
+                  "answers": [
+                    {
+                        "id": "first-name",
+                        "label": "First name",
+                        "mandatory": true,
+                        "type": "TextField"
+                    },
+                    {
+                        "id": "last-name",
+                        "label": "Last name",
+                        "mandatory": true,
+                        "type": "TextField"
+                    }
+                  ]
+
+                }
+              },
+              "remove_block": {
+                "id": "remove-person",
+                "type": "Question",
+                "question": {
+                  "id": "remove-question",
+                  "type": "General",
+                  "title": "Are you sure you want to remove this person?",
+                  "answers": [
+                    {
+                      "id": "remove-confirmation",
+                      "mandatory": true,
+                      "type": "Radio",
+                      "options": [
+                        {
+                          "label": "Yes",
+                          "value": "Yes"
+                        },
+                        {
+                          "label": "No",
+                          "value": "No"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                "routing_rules": [{
+                        "goto": {
+                            "block": "summary",
+                            "when": [{
+                                "id": "remove-confirmation",
+                                "condition": "equals",
+                                "value": "Yes"
+                            }]
+                        }
+                    },
+                    {
+                        "goto": {
+                            "block": "summary"
+                        }
+                    }
+                ]
+              }
+            },
+            {
+              "type": "Summary",
+              "id": "summary"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/schemas/valid/test_list_collector.json
+++ b/tests/schemas/valid/test_list_collector.json
@@ -1,0 +1,142 @@
+{
+  "mime_type": "application/json/ons/eq",
+  "schema_version": "0.0.1",
+  "data_version": "0.0.2",
+  "survey_id": "0",
+  "title": "Test ListCollector",
+  "theme": "default",
+  "description": "A questionnaire to test ListCollector",
+  "metadata": [
+    {
+      "name": "user_id",
+      "validator": "string"
+    },
+    {
+      "name": "period_id",
+      "validator": "string"
+    },
+    {
+      "name": "ru_name",
+      "validator": "string"
+    }
+  ],
+  "sections": [
+    {
+      "id": "section",
+      "groups": [
+        {
+          "id": "group",
+          "title": "List",
+          "blocks": [
+            {
+              "id": "list-collector",
+              "type": "ListCollector",
+              "populates_list": "people",
+              "add_answer_value": "Yes",
+              "question": {
+                "id": "confirmation-question",
+                "type": "General",
+                "title": "Does anyone else live here?",
+                "answers": [
+                  {
+                    "id": "anyone-else",
+                    "mandatory": true,
+                    "type": "Radio",
+                    "options": [
+                      {
+                        "label": "Yes",
+                        "value": "Yes"
+                      },
+                      {
+                        "label": "No",
+                        "value": "No"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "add_block": {
+                "id": "add-person",
+                "type": "Question",
+                "question": {
+                  "id": "add-question",
+                  "type": "General",
+                  "title": "What is the name of the person?",
+                  "answers": [
+                    {
+                        "id": "first-name",
+                        "label": "First name",
+                        "mandatory": true,
+                        "type": "TextField"
+                    },
+                    {
+                        "id": "last-name",
+                        "label": "Last name",
+                        "mandatory": true,
+                        "type": "TextField"
+                    }
+                  ]
+
+                }
+              },
+              "edit_block": {
+                "id": "edit-person",
+                "type": "Question",
+                "question": {
+                  "id": "edit-question",
+                  "type": "General",
+                  "title": "What is the name of the person?",
+                  "answers": [
+                    {
+                        "id": "first-name",
+                        "label": "First name",
+                        "mandatory": true,
+                        "type": "TextField"
+                    },
+                    {
+                        "id": "last-name",
+                        "label": "Last name",
+                        "mandatory": true,
+                        "type": "TextField"
+                    }
+                  ]
+
+                }
+              },
+              "remove_block": {
+                "id": "remove-person",
+                "type": "Question",
+                "question": {
+                  "id": "remove-question",
+                  "type": "General",
+                  "title": "Are you sure you want to remove this person?",
+                  "answers": [
+                    {
+                      "id": "remove-confirmation",
+                      "mandatory": true,
+                      "type": "Radio",
+                      "options": [
+                        {
+                          "label": "Yes",
+                          "value": "Yes"
+                        },
+                        {
+                          "label": "No",
+                          "value": "No"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "type": "Summary",
+              "id": "summary"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -352,3 +352,41 @@ def test_duplicate_answer_ids():
     assert 'Schema Integrity Error. Duplicate id found: block-2' in error_messages
 
     assert schema_errors == {}
+
+
+def test_invalid_list_collector_non_radio():
+    file_name = 'schemas/invalid/test_invalid_list_collector_non_radio.json'
+    json_to_validate = _open_and_load_schema_file(file_name)
+
+    validation_errors, schema_errors = validate_schema(json_to_validate)
+    error_messages = [error['message'] for error in validation_errors]
+
+    assert 'Schema Integrity Error. The list collector block list-collector does not contain a Radio answer type' \
+           in error_messages
+
+    assert schema_errors == {}
+
+
+def test_invalid_list_collector_with_routing():
+    file_name = 'schemas/invalid/test_invalid_list_collector_with_routing.json'
+    json_to_validate = _open_and_load_schema_file(file_name)
+
+    validation_errors, schema_errors = validate_schema(json_to_validate)
+    error_messages = [error['message'] for error in validation_errors]
+
+    assert 'Schema Integrity Error. The list collector block list-collector contains routing rule on the "remove_block"' in error_messages
+
+    assert schema_errors == {}
+
+
+def test_invalid_list_collector_with_no_add_option():
+    file_name = 'schemas/invalid/test_invalid_list_collector_with_no_add_option.json'
+    json_to_validate = _open_and_load_schema_file(file_name)
+
+    validation_errors, schema_errors = validate_schema(json_to_validate)
+    error_messages = [error['message'] for error in validation_errors]
+
+    assert 'Schema Integrity Error. The list collector block list-collector has an add_answer_value that is not present ' \
+           'in the answer values' in error_messages
+
+    assert schema_errors == {}


### PR DESCRIPTION
Added a `ListCollector` Block type as defined in https://github.com/ONSdigital/eq-survey-runner/blob/v3/doc/architecture/decisions/0006-make-named-lists-a-first-class-construct.md