### PR TITLE
Validate Placeholder Source Ids

### DIFF
--- a/tests/schemas/invalid/test_invalid_placeholder_source_ids.json
+++ b/tests/schemas/invalid/test_invalid_placeholder_source_ids.json
@@ -1,0 +1,214 @@
+{
+  "eq_id": "3",
+  "form_type": "3",
+  "mime_type": "application/json/ons/eq",
+  "schema_version": "0.0.1",
+  "data_version": "0.0.2",
+  "survey_id": "3",
+  "title": "String Transforms",
+  "theme": "default",
+  "legal_basis": "StatisticsOfTradeAct",
+  "navigation": {
+    "visible": false
+  },
+  "metadata": [
+    {
+      "name": "user_id",
+      "validator": "string"
+    },
+    {
+      "name": "period_id",
+      "validator": "string"
+    },
+    {
+      "name": "ru_name",
+      "validator": "string"
+    },
+    {
+      "name": "test_metadata",
+      "validator": "string"
+    }
+  ],
+  "sections": [
+    {
+      "id": "section1",
+      "groups": [
+        {
+          "id": "group1",
+          "title": "",
+          "blocks": [
+            {
+              "id": "block1",
+              "title": "",
+              "type": "Question",
+              "question": {
+                "id": "question1",
+                "title": "",
+                "description": "",
+                "type": "General",
+                "answers": [
+                  {
+                    "id": "answer0",
+                    "mandatory": false,
+                    "type": "TextField",
+                    "label": "Simple value from answer store",
+                    "description": "description with no placeholders"
+                  },
+                  {
+                    "id": "answer1",
+                    "mandatory": false,
+                    "type": "TextField",
+                    "label": "Simple value from answer store",
+                    "description": {
+                      "text": "test {simple_answer}",
+                      "placeholders": [
+                        {
+                          "placeholder": "simple_answer",
+                          "value": {
+                            "source": "answers",
+                            "identifier": "invalid-answer0"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "id": "block2",
+              "title": "",
+              "type": "Question",
+              "question": {
+                "id": "question2",
+                "title": "",
+                "description": "",
+                "type": "General",
+                "answers": [
+                  {
+                    "id": "answer2",
+                    "mandatory": false,
+                    "type": "TextField",
+                    "label": "Simple value from answer store",
+                    "description": "description with no placeholders"
+                  },
+                  {
+                    "id": "answer3",
+                    "mandatory": false,
+                    "type": "TextField",
+                    "label": "Simple value from answer store",
+                    "description": {
+                      "text": "test {answer1}",
+                      "placeholders": [
+                        {
+                          "placeholder": "answer1",
+                          "transforms": [
+                            {
+                              "transform": "format_number",
+                              "arguments": {
+                                "number": {
+                                  "source": "answers",
+                                  "identifier": "invalid-answer1"
+                                }
+                              }
+                            },
+                            {
+                              "transform": "format_number",
+                              "arguments": {
+                                "number": {
+                                  "source": "previous_transform"
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "id": "block3",
+              "title": "",
+              "type": "Question",
+              "question": {
+                "id": "question3",
+                "title": "",
+                "description": "",
+                "type": "General",
+                "answers": [
+                  {
+                    "id": "answer4",
+                    "mandatory": false,
+                    "type": "TextField",
+                    "label": "Simple value from answer store",
+                    "description": "description with no placeholders"
+                  },
+                  {
+                    "id": "answer5",
+                    "mandatory": false,
+                    "type": "TextField",
+                    "label": "Simple value from answer store",
+                    "description": {
+                      "text": "test {simple_answer}",
+                      "placeholders": [
+                        {
+                          "placeholder": "simple_answer",
+                          "value": {
+                            "source": "answers",
+                            "identifier": "answer4"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "id": "block4",
+              "title": "",
+              "type": "Question",
+              "question": {
+                "id": "question4",
+                "title": "",
+                "description": "",
+                "type": "General",
+                "answers": [
+                  {
+                    "id": "answer6",
+                    "mandatory": false,
+                    "type": "TextField",
+                    "label": "Simple value from answer store",
+                    "description": {
+                      "text": "test {simple_metadata}",
+                      "placeholders": [
+                        {
+                          "placeholder": "simple_metadata",
+                          "value": {
+                            "source": "metadata",
+                            "identifier": "invalid-metadata-ref"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "id": "confirmation",
+              "type": "Confirmation",
+              "description": "",
+              "title": "",
+              "content": [{
+                "title": "Confirm"
+              }]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/schemas/invalid/test_invalid_string_transforms.json
+++ b/tests/schemas/invalid/test_invalid_string_transforms.json
@@ -15,6 +15,39 @@
           "title": "",
           "blocks": [
             {
+              "id": "block0",
+              "type": "Question",
+              "question": {
+                "id": "question0",
+                "title": "",
+                "description": "",
+                "type": "General",
+                "answers": [
+                  {
+                    "id": "ref-answer0",
+                    "mandatory": true,
+                    "type": "TextField",
+                    "label": "An answer which transforms may reference",
+                    "description": "description with no placeholders"
+                  },
+                  {
+                    "id": "ref-answer1",
+                    "mandatory": true,
+                    "type": "TextField",
+                    "label": "A second answer which transforms may reference",
+                    "description": ""
+                  },
+                  {
+                    "id": "ref-answer2",
+                    "mandatory": true,
+                    "type": "TextField",
+                    "label": "A third answer which transforms may reference",
+                    "description": ""
+                  }
+                ]
+              }
+            },
+            {
               "id": "block1",
               "title": "",
               "type": "Question",
@@ -36,7 +69,7 @@
                           "placeholder": "answer2",
                           "value": {
                             "source": "answers",
-                            "identifier": "answer1"
+                            "identifier": "ref-answer0"
                           }
                         }
                       ]
@@ -67,7 +100,7 @@
                           "placeholder": "answer1",
                           "value": {
                             "source": "answers",
-                            "identifier": "answer1"
+                            "identifier": "ref-answer1"
                           }
                         }
                       ]
@@ -98,14 +131,14 @@
                           "placeholder": "answer1",
                           "value": {
                             "source": "answers",
-                            "identifier": "answer1"
+                            "identifier": "ref-answer1"
                           }
                         },
                         {
                           "placeholder": "answer2",
                           "value": {
                             "source": "answers",
-                            "identifier": "answer2"
+                            "identifier": "ref-answer2"
                           }
                         }
                       ]
@@ -177,7 +210,7 @@
                               "arguments": {
                                 "number": {
                                   "source": "answers",
-                                  "identifier": "answer1"
+                                  "identifier": "ref-answer1"
                                 }
                               }
                             },
@@ -186,7 +219,7 @@
                               "arguments": {
                                 "number": {
                                   "source": "answers",
-                                  "identifier": "answer1"
+                                  "identifier": "ref-answer1"
                                 }
                               }
                             }

--- a/tests/schemas/valid/test_placeholder_source_ids.json
+++ b/tests/schemas/valid/test_placeholder_source_ids.json
@@ -1,0 +1,142 @@
+{
+  "eq_id": "3",
+  "form_type": "3",
+  "mime_type": "application/json/ons/eq",
+  "schema_version": "0.0.1",
+  "data_version": "0.0.2",
+  "survey_id": "3",
+  "title": "String Transforms",
+  "theme": "default",
+  "legal_basis": "StatisticsOfTradeAct",
+  "navigation": {
+    "visible": false
+  },
+  "metadata": [
+    {
+      "name": "user_id",
+      "validator": "string"
+    },
+    {
+      "name": "period_id",
+      "validator": "string"
+    },
+    {
+      "name": "ru_name",
+      "validator": "string"
+    },
+    {
+      "name": "test_metadata",
+      "validator": "string"
+    }
+  ],
+  "sections": [
+    {
+      "id": "section1",
+      "groups": [
+        {
+          "id": "group1",
+          "title": "",
+          "blocks": [
+            {
+              "id": "block0",
+              "type": "Question",
+              "question": {
+                "id": "question0",
+                "title": "",
+                "description": "",
+                "type": "General",
+                "answers": [
+                  {
+                    "id": "ref-answer0",
+                    "mandatory": true,
+                    "type": "TextField",
+                    "label": "An answer which transforms may reference",
+                    "description": "description with no placeholders"
+                  }
+                ]
+              }
+            },
+            {
+              "id": "block1",
+              "title": "",
+              "type": "Question",
+              "question": {
+                "id": "question1",
+                "title": "",
+                "description": "",
+                "type": "General",
+                "answers": [
+                  {
+                    "id": "answer0",
+                    "mandatory": false,
+                    "type": "TextField",
+                    "label": "Simple value from answer store",
+                    "description": "description with no placeholders"
+                  },
+                  {
+                    "id": "answer1",
+                    "mandatory": false,
+                    "type": "TextField",
+                    "label": "Simple value from answer store",
+                    "description": {
+                      "text": "test {simple_answer}",
+                      "placeholders": [
+                        {
+                          "placeholder": "simple_answer",
+                          "value": {
+                            "source": "answers",
+                            "identifier": "ref-answer0"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "id": "block2",
+              "title": "",
+              "type": "Question",
+              "question": {
+                "id": "question2",
+                "title": "",
+                "description": "",
+                "type": "General",
+                "answers": [
+                  {
+                    "id": "answer2",
+                    "mandatory": false,
+                    "type": "TextField",
+                    "label": "Simple value from answer store",
+                    "description": {
+                      "text": "test {simple_metadata}",
+                      "placeholders": [
+                        {
+                          "placeholder": "simple_metadata",
+                          "value": {
+                            "source": "metadata",
+                            "identifier": "period_id"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "id": "confirmation",
+              "type": "Confirmation",
+              "description": "",
+              "title": "",
+              "content": [{
+                "title": "Confirm"
+              }]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/schemas/valid/test_string_transforms.json
+++ b/tests/schemas/valid/test_string_transforms.json
@@ -38,6 +38,39 @@
           "title": "",
           "blocks": [
             {
+              "id": "block0",
+              "type": "Question",
+              "question": {
+                "id": "question0",
+                "title": "",
+                "description": "",
+                "type": "General",
+                "answers": [
+                  {
+                    "id": "ref-answer0",
+                    "mandatory": true,
+                    "type": "TextField",
+                    "label": "An answer which transforms may reference",
+                    "description": "description with no placeholders"
+                  },
+                  {
+                    "id": "ref-answer1",
+                    "mandatory": true,
+                    "type": "TextField",
+                    "label": "A second answer which transforms may reference",
+                    "description": ""
+                  },
+                  {
+                    "id": "ref-answer2",
+                    "mandatory": true,
+                    "type": "TextField",
+                    "label": "A third answer which transforms may reference",
+                    "description": ""
+                  }
+                ]
+              }
+            },
+            {
               "id": "block1",
               "title": "",
               "type": "Question",
@@ -66,7 +99,7 @@
                           "placeholder": "simple_answer",
                           "value": {
                             "source": "answers",
-                            "identifier": "answer1"
+                            "identifier": "ref-answer1"
                           }
                         }
                       ]
@@ -88,7 +121,7 @@
                               "arguments": {
                                 "number": {
                                   "source": "answers",
-                                  "identifier": "answer2"
+                                  "identifier": "ref-answer2"
                                 }
                               }
                             }
@@ -113,11 +146,11 @@
                               "arguments": {
                                 "start_date": {
                                   "source": "answers",
-                                  "identifier": "answer3"
+                                  "identifier": "ref-answer2"
                                 },
                                 "end_date": {
                                   "source": "answers",
-                                  "identifier": "answer3"
+                                  "identifier": "ref-answer2"
                                 }
                               }
                             }
@@ -142,7 +175,7 @@
                               "arguments": {
                                 "number": {
                                   "source": "answers",
-                                  "identifier": "answer4"
+                                  "identifier": "ref-answer1"
                                 }
                               }
                             },
@@ -174,7 +207,7 @@
                                     "arguments": {
                                         "date_to_format": {
                                             "source": "answers",
-                                            "identifier": "answer5"
+                                            "identifier": "ref-answer2"
                                         },
                                         "date_format": "EEEE d MMMM"
                                     }
@@ -239,7 +272,7 @@
                               "arguments": {
                                 "first_date": {
                                   "source": "answers",
-                                  "identifier": "q2-answer-1"
+                                  "identifier": "ref-answer1"
                                 },
                                 "second_date": {
                                   "value": "2019-01-20"
@@ -267,11 +300,11 @@
                               "arguments": {
                                 "first_date": {
                                   "source": "answers",
-                                  "identifier": "q2-answer-1"
+                                  "identifier": "ref-answer1"
                                 },
                                 "second_date": {
                                   "source": "answers",
-                                  "identifier": "q2-answer-2"
+                                  "identifier": "ref-answer2"
                                 }
                               }
                             }
@@ -296,7 +329,7 @@
                               "arguments": {
                                 "first_date": {
                                   "source": "answers",
-                                  "identifier": "q2-answer-1"
+                                  "identifier": "ref-answer1"
                                 },
                                 "second_date": {
                                   "value": "now"
@@ -337,7 +370,7 @@
                               "arguments": {
                                 "list_to_concatenate": {
                                   "source": "answers",
-                                  "identifier": "q2-answer-1"
+                                  "identifier": "ref-answer1"
                                 },
                                 "delimiter": " "
                               }
@@ -364,8 +397,8 @@
                                 "list_to_concatenate": {
                                   "source": "answers",
                                   "identifier": [
-                                    "q2-answer-1",
-                                    "q2-answer-2"
+                                    "ref-answer1",
+                                    "ref-answer2"
                                   ]
                                 },
                                 "delimiter": ", "
@@ -405,7 +438,7 @@
                               "arguments": {
                                 "string_to_format": {
                                   "source": "answers",
-                                  "identifier": "q3-answer-1"
+                                  "identifier": "ref-answer0"
                                 }
                               }
                             }
@@ -431,8 +464,8 @@
                                 "list_to_concatenate": {
                                   "source": "answers",
                                   "identifier": [
-                                    "q2-answer-1",
-                                    "q2-answer-2"
+                                    "ref-answer1",
+                                    "ref-answer2"
                                   ]
                                 },
                                 "delimiter": " "
@@ -481,8 +514,8 @@
                                 "list_to_format": {
                                   "source": "answers",
                                   "identifier": [
-                                    "q2-answer-1",
-                                    "q2-answer-2"
+                                    "ref-answer1",
+                                    "ref-answer2"
                                   ]
                                 }
                               }
@@ -520,7 +553,7 @@
                               "placeholder": "simple_answer",
                               "value": {
                                 "source": "answers",
-                                "identifier": "answer1"
+                                "identifier": "ref-answer1"
                               }
                             }
                           ]
@@ -561,7 +594,7 @@
                               "placeholder": "simple_answer",
                               "value": {
                                 "source": "answers",
-                                "identifier": "answer1"
+                                "identifier": "ref-answer1"
                               }
                             }
                           ]

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -301,17 +301,6 @@ def test_decimal_places_must_be_defined_when_using_totaliser():
     check_validation_errors(filename, expected_error_messages)
 
 
-def test_metadata_defined_but_not_used_is_valid():
-    """ Ensures that there are no errors when metadata is defined in the schema but not used """
-    file_name = 'schemas/valid/test_valid_metadata.json'
-    json_to_validate = _open_and_load_schema_file(file_name)
-
-    validation_errors, schema_errors = validate_schema(json_to_validate)
-
-    assert validation_errors == []
-    assert schema_errors == {}
-
-
 def test_invalid_string_transforms():
     filename = 'schemas/invalid/test_invalid_string_transforms.json'
 
@@ -321,6 +310,19 @@ def test_invalid_string_transforms():
         "Schema Integrity Error. Placeholders in 'text' doesn't match 'placeholders' definition for block id 'block3'",
         "Schema Integrity Error. Can't reference `previous_transform` in a first transform in block id 'block4'",
         "Schema Integrity Error. `previous_transform` not referenced in chained transform in block id 'block5'"
+    ]
+
+    check_validation_errors(filename, expected_error_messages)
+
+
+def test_invalid_placeholder_answer_ids():
+    filename = 'schemas/invalid/test_invalid_placeholder_source_ids.json'
+
+    expected_error_messages = [
+        'Schema Integrity Error. Invalid answer id reference `answer4` for placeholder `simple_answer` (self-reference)',
+        'Schema Integrity Error. Invalid answer id reference `invalid-answer0` for placeholder `simple_answer`',
+        'Schema Integrity Error. Invalid answer id reference `invalid-answer1` for placeholder `answer1`',
+        'Schema Integrity Error. Invalid metadata reference `invalid-metadata-ref` for placeholder `simple_metadata`'
     ]
 
     check_validation_errors(filename, expected_error_messages)


### PR DESCRIPTION
**Motivation**

It's currently possible to insert invalid references to answer ids within placeholders, for example those that reference the same block or don't exist in the schema at all.

https://trello.com/c/s9gGN5wZ/2821-placeholder-answer-source-identifier-must-be-valid

**Changes**

Validate against invalid answer ids and update current schemas that use invalid answer ids.