### PR TITLE
Reduce the restriction on the format of an id

### DIFF
--- a/schemas/common_definitions.json
+++ b/schemas/common_definitions.json
@@ -3,7 +3,7 @@
   "id": {
     "type": "string",
     "description": "Used to identify groups, blocks, questions and answers.",
-    "pattern": "^[a-z0-9][a-z0-9\\-]*[a-z0-9]$"
+    "pattern": "^[a-z0-9A-Z\\-_]+$"
   },
   "q_code": {
     "type": "string",

--- a/tests/test_schema_id_regex.py
+++ b/tests/test_schema_id_regex.py
@@ -75,6 +75,26 @@ class TestSchemaIdRegEx(unittest.TestCase):
         # Then
         self.assertEqual(len(errors), 0, errors)
 
+    def test_id_with_capital_letters_should_pass_validation(self):
+        # Given
+        json_to_validate = create_schema_with_id('A-VALID-ID')
+
+        # When
+        errors = self.validator.validate_schema(json_to_validate)
+
+        # Then
+        self.assertEqual(len(errors), 0, errors)
+
+    def test_id_with_underscores_should_pass_validation(self):
+        # Given
+        json_to_validate = create_schema_with_id('a_valid_id')
+
+        # When
+        errors = self.validator.validate_schema(json_to_validate)
+
+        # Then
+        self.assertEqual(len(errors), 0, errors)
+
     def test_id_with_punctuation_should_fail_validation(self):
         # Given
         json_to_validate = create_schema_with_id('!n0t-@-valid-id')
@@ -89,28 +109,6 @@ class TestSchemaIdRegEx(unittest.TestCase):
     def test_id_with_spaces_should_fail_validation(self):
         # Given
         json_to_validate = create_schema_with_id('not a valid id')
-
-        # When
-        error = self.validator.validate_schema(json_to_validate)
-
-        # Then
-        self.assertTrue(isinstance(error, dict))
-        self.assertTrue('is not valid under any of the given schemas' in error['message'])
-
-    def test_id_with_capital_letters_should_fail_validation(self):
-        # Given
-        json_to_validate = create_schema_with_id('NOT-A-VALID-ID')
-
-        # When
-        error = self.validator.validate_schema(json_to_validate)
-
-        # Then
-        self.assertTrue(isinstance(error, dict))
-        self.assertTrue('is not valid under any of the given schemas' in error['message'])
-
-    def test_id_with_underscores_should_pass_validation(self):
-        # Given
-        json_to_validate = create_schema_with_id('not_a_valid_id')
 
         # When
         error = self.validator.validate_schema(json_to_validate)


### PR DESCRIPTION
Author is changing to use a short id instead of a guid for the ids as our urls are being incredibly long and cumbersome with guids. However, we are still using our ids as the entity ids in runner and this causes runner to reject them.

A short id is between 7 and 14 characters and can use any of A-Z, a-z, 0-9, - or _. The previous regex was too restrictive for these.

AFAICT there is no reason for the id regex to be so restrictive. So I have changed it which resolves the issue in author.

Please confirm this is acceptable.