### PR TITLE
Enfore consistent ids across variants

### DIFF
--- a/schemas/common_definitions.json
+++ b/schemas/common_definitions.json
@@ -457,6 +457,7 @@
   },
   "question_variants": {
     "type": "array",
+    "description": "All question ids within question_variants must match",
     "minItems": 2,
     "items": {
       "$ref": "variants/question_variant.json#/question_variant"

--- a/tests/schemas/invalid/test_invalid_inconsistent_ids_in_variants.json
+++ b/tests/schemas/invalid/test_invalid_inconsistent_ids_in_variants.json
@@ -1,0 +1,116 @@
+{
+  "mime_type": "application/json/ons/eq",
+  "schema_version": "0.0.1",
+  "data_version": "0.0.2",
+  "survey_id": "0",
+  "session_timeout_in_seconds": 3,
+  "title": "Test Question Variants",
+  "theme": "default",
+  "description": "A questionnaire to test question variants and variant choices",
+  "metadata": [
+    {
+      "name": "user_id",
+      "validator": "string"
+    },
+    {
+      "name": "period_id",
+      "validator": "string"
+    },
+    {
+      "name": "ru_name",
+      "validator": "string"
+    }
+  ],
+  "sections": [
+    {
+      "id": "section",
+      "groups": [
+        {
+          "id": "group",
+          "title": "Variants",
+          "blocks": [
+            {
+              "type": "Question",
+              "id": "block-1",
+              "title": "questions only",
+              "question": {
+                "id": "question-1",
+                "type": "General",
+                "title": "What is your age?",
+                "answers": [
+                  {
+                    "id": "answer-1",
+                    "label": "Your age?",
+                    "mandatory": false,
+                    "type": "Number"
+                  }
+                ]
+              }
+            },
+            {
+              "type": "Question",
+              "id": "block-2",
+              "title": "variants only",
+              "question_variants": [
+                {
+                  "question": {
+                    "id": "question-2",
+                    "type": "General",
+                    "title": "What is your age?",
+                    "answers": [
+                      {
+                        "id": "answer-2",
+                        "label": "Your age?",
+                        "mandatory": false,
+                        "type": "Number"
+                      }
+                    ]
+                  },
+                  "when": [
+                    {
+                      "id": "answer-1",
+                      "condition": "greater than",
+                      "value": "16"
+                    }
+                  ]
+                },
+                {
+                  "question": {
+                    "id": "question-2-variant",
+                    "type": "General",
+                    "title": "What is your age?",
+                    "answers": [
+                      {
+                        "id": "answer-2-variant",
+                        "label": "Your age?",
+                        "mandatory": false,
+                        "type": "Number"
+                      },
+                      {
+                        "id": "answer-3",
+                        "label": "Your age?",
+                        "mandatory": false,
+                        "type": "Number"
+                      }
+                    ]
+                  },
+                  "when": [
+                    {
+                      "id": "answer-1",
+                      "condition": "less than or equal to",
+                      "value": "16"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "Summary",
+              "id": "summary"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -392,3 +392,25 @@ def test_invalid_list_collector_with_no_add_option():
            'in the answer values' in error_messages
 
     assert schema_errors == {}
+
+
+def test_inconsistent_ids_in_variants():
+    file_name = 'schemas/invalid/test_invalid_inconsistent_ids_in_variants.json'
+    json_to_validate = _open_and_load_schema_file(file_name)
+
+    validation_errors, schema_errors = validate_schema(json_to_validate)
+    error_messages = [error['message'] for error in validation_errors]
+
+    fuzzy_error_messages = ['Schema Integrity Error. Variants contain more than one question_id for block: block-2. Found ids',
+                            'question-2',
+                            'question-2-variant',
+                            'Schema Integrity Error. Variants have mismatched answer_ids for block: block-2.']
+
+    for fuzzy_error in fuzzy_error_messages:
+        assert any(fuzzy_error in error_message for error_message in error_messages)
+
+    assert 'Schema Integrity Error. Variants in block: block-2 contain different numbers of answers' in error_messages
+
+    assert len(validation_errors) == 3
+
+    assert schema_errors == {}


### PR DESCRIPTION
To make the implementation of variants simpler in runner, this enforces that all question_ids are the same between each question_variant in a block. See https://github.com/ONSdigital/eq-survey-runner/pull/2021

I can't think of any situation where having multiple question_ids within a block is useful to us. 