### PR TITLE
Update format_date to work with fixed values

### DIFF
--- a/schemas/string_interpolation/definitions.json
+++ b/schemas/string_interpolation/definitions.json
@@ -144,5 +144,15 @@
       "source",
       "identifier"
     ]
+  },
+  "date_value": {
+    "type:": "object",
+    "properties": {
+      "value": {
+        "type": "string",
+        "pattern": "^(\\d{4}-\\d{2}-\\d{2}|\\d{4}-\\d{2}|\\d{4}|now)$"
+      }
+    },
+    "additionalProperties": false
   }
 }

--- a/schemas/string_interpolation/transforms/calculate_years_difference.json
+++ b/schemas/string_interpolation/transforms/calculate_years_difference.json
@@ -16,7 +16,7 @@
                 "$ref": "../definitions.json#/value_sources" 
               },
               {
-                "$ref": "#/date_value" 
+                "$ref": "../definitions.json#/date_value" 
               }
             ]
           },
@@ -26,7 +26,7 @@
                 "$ref": "../definitions.json#/value_sources" 
               },
               {
-                "$ref": "#/date_value" 
+                "$ref": "../definitions.json#/date_value" 
               }
             ]
           }
@@ -43,15 +43,5 @@
       "transform",
       "arguments"
     ]
-  },
-  "date_value": {
-    "type:": "object",
-    "properties": {
-      "value": {
-        "type": "string",
-        "pattern": "^(\\d{4}-\\d{2}-\\d{2}|\\d{4}-\\d{2}|\\d{4}|now)$"
-      }
-    },
-    "additionalProperties": false
   }
 }

--- a/schemas/string_interpolation/transforms/format_date.json
+++ b/schemas/string_interpolation/transforms/format_date.json
@@ -11,7 +11,14 @@
         "type": "object",
         "properties": {
           "date_to_format": {
-            "$ref": "../definitions.json#/value_sources" 
+            "oneOf": [
+              {
+                "$ref": "../definitions.json#/value_sources" 
+              },
+              {
+                "$ref": "../definitions.json#/date_value" 
+              }
+            ]
           },
           "date_format": {
             "type": "string",

--- a/tests/schemas/valid/test_string_transforms.json
+++ b/tests/schemas/valid/test_string_transforms.json
@@ -215,6 +215,29 @@
                             ]
                         }]
                     }
+                  },
+                  {
+                    "id": "answer6",
+                    "mandatory": false,
+                    "type": "TextField",
+                    "label": "format_date with fixed value",
+                    "description": {
+                        "text": "test {value}",
+                        "placeholders": [{
+                            "placeholder": "value",
+                            "transforms": [
+                                {
+                                    "transform": "format_date",
+                                    "arguments": {
+                                        "date_to_format": {
+                                           "value": "2019-01-01"
+                                        },
+                                        "date_format": "EEEE d MMMM"
+                                    }
+                                }
+                            ]
+                        }]
+                    }
                   }
                 ]
               }


### PR DESCRIPTION
format_date only allowed a date value to come from a source e.g. answers or metadata. This pull request extends the format_date transform to allow a fixed value.