### PR TITLE
Validate variants question type and answer type

### DIFF
--- a/tests/schemas/invalid/test_invalid_inconsistent_types_in_variants.json
+++ b/tests/schemas/invalid/test_invalid_inconsistent_types_in_variants.json
@@ -1,0 +1,122 @@
+{
+  "mime_type": "application/json/ons/eq",
+  "schema_version": "0.0.1",
+  "data_version": "0.0.2",
+  "survey_id": "0",
+  "session_timeout_in_seconds": 3,
+  "title": "Test Question Variants",
+  "theme": "default",
+  "description": "A questionnaire to test question variants and variant choices",
+  "metadata": [
+    {
+      "name": "user_id",
+      "validator": "string"
+    },
+    {
+      "name": "period_id",
+      "validator": "string"
+    },
+    {
+      "name": "ru_name",
+      "validator": "string"
+    }
+  ],
+  "sections": [
+    {
+      "id": "section",
+      "groups": [
+        {
+          "id": "group",
+          "title": "Variants",
+          "blocks": [
+            {
+              "type": "Question",
+              "id": "block-1",
+              "title": "questions only",
+              "question": {
+                "id": "question-1",
+                "type": "General",
+                "title": "What is your age?",
+                "answers": [
+                  {
+                    "id": "answer-1",
+                    "label": "Your age?",
+                    "mandatory": false,
+                    "type": "Number"
+                  }
+                ]
+              }
+            },
+            {
+              "type": "Question",
+              "id": "block-2",
+              "title": "variants only",
+              "question_variants": [
+                {
+                  "question": {
+                    "id": "question-2",
+                    "type": "General",
+                    "title": "What is your age?",
+                    "answers": [
+                      {
+                        "id": "answer-2",
+                        "label": "Your age?",
+                        "mandatory": false,
+                        "type": "NotANumber"
+                      },
+                      {
+                        "id": "answer-3",
+                        "label": "Your age?",
+                        "mandatory": false,
+                        "type": "Number"
+                      }
+                   ]
+                  },
+                  "when": [
+                    {
+                      "id": "answer-1",
+                      "condition": "greater than",
+                      "value": "16"
+                    }
+                  ]
+                },
+                {
+                  "question": {
+                    "id": "question-2",
+                    "type": "NotGeneral",
+                    "title": "What is your age?",
+                    "answers": [
+                      {
+                        "id": "answer-2",
+                        "label": "Your age?",
+                        "mandatory": false,
+                        "type": "Number"
+                      },
+                      {
+                        "id": "answer-3",
+                        "label": "Your age?",
+                        "mandatory": false,
+                        "type": "Number"
+                      }
+                    ]
+                  },
+                  "when": [
+                    {
+                      "id": "answer-1",
+                      "condition": "less than or equal to",
+                      "value": "16"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "Summary",
+              "id": "summary"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -392,3 +392,21 @@ def test_inconsistent_ids_in_variants():
     assert len(validation_errors) == 3
 
     assert schema_errors == {}
+
+
+def test_inconsistent_types_in_variants():
+    file_name = 'schemas/invalid/test_invalid_inconsistent_types_in_variants.json'
+    json_to_validate = _open_and_load_schema_file(file_name)
+
+    validation_errors, _ = validate_schema(json_to_validate)
+    error_messages = [error['message'] for error in validation_errors]
+
+    fuzzy_error_messages = (
+        'Schema Integrity Error. Variants have more than one question type for block: block-2',
+        'Schema Integrity Error. Variants have mismatched answer types for block: block-2. Found types:',
+    )
+
+    for fuzzy_error in fuzzy_error_messages:
+        assert any(fuzzy_error in error_message for error_message in error_messages)
+
+    assert len(validation_errors) == 2


### PR DESCRIPTION
Add a schema validation step that checks question types and answer types within blocks are identical, including across variants.