### PR TITLE
Update metadata schema to use `type` not `validator`

### DIFF
--- a/schemas/questionnaire_v1.json
+++ b/schemas/questionnaire_v1.json
@@ -62,21 +62,40 @@
             "type": "string",
             "pattern": "^[a-zA-Z0-9-_]+$"
           },
-          "validator": {
+          "type": {
             "type": "string",
             "enum": [
               "boolean",
               "date",
               "string",
-              "optional_string",
-              "uuid"
+              "uuid",
+              "url"
             ]
+          },
+          "min_length": {
+            "type": "integer",
+            "description": "The minimum length of a string field",
+            "minimum": 1
+          },
+          "max_length": {
+            "type": "integer",
+            "description": "The maximum length of a string field",
+            "minimum": 1
+          },
+          "length": {
+            "type": "integer",
+            "description": "The length of a string field must be equal to this",
+            "minimum": 0
+          },
+          "optional": {
+            "description": "Whether an error should be raised if this field is not provided.",
+            "type": "boolean"
           }
         },
         "additionalProperties": false,
         "required": [
           "name",
-          "validator"
+          "type"
         ]
       }
     },

--- a/tests/schemas/invalid/test_invalid_answer_comparison_id.json
+++ b/tests/schemas/invalid/test_invalid_answer_comparison_id.json
@@ -10,15 +10,15 @@
   "metadata": [
     {
       "name": "user_id",
-      "validator": "string"
+      "type": "string"
     },
     {
       "name": "period_id",
-      "validator": "string"
+      "type": "string"
     },
     {
       "name": "ru_name",
-      "validator": "string"
+      "type": "string"
     }
   ],
   "sections": [

--- a/tests/schemas/invalid/test_invalid_answer_comparison_types.json
+++ b/tests/schemas/invalid/test_invalid_answer_comparison_types.json
@@ -10,15 +10,15 @@
   "metadata": [
     {
       "name": "user_id",
-      "validator": "string"
+      "type": "string"
     },
     {
       "name": "period_id",
-      "validator": "string"
+      "type": "string"
     },
     {
       "name": "ru_name",
-      "validator": "string"
+      "type": "string"
     }
   ],
   "sections": [

--- a/tests/schemas/invalid/test_invalid_calculated_summary.json
+++ b/tests/schemas/invalid/test_invalid_calculated_summary.json
@@ -10,15 +10,15 @@
   "metadata": [
     {
       "name": "user_id",
-      "validator": "string"
+      "type": "string"
     },
     {
       "name": "period_id",
-      "validator": "string"
+      "type": "string"
     },
     {
       "name": "ru_name",
-      "validator": "string"
+      "type": "string"
     }
   ],
   "sections": [

--- a/tests/schemas/invalid/test_invalid_date_range_period.json
+++ b/tests/schemas/invalid/test_invalid_date_range_period.json
@@ -5,15 +5,15 @@
   "metadata": [
     {
       "name": "user_id",
-      "validator": "string"
+      "type": "string"
     },
     {
       "name": "ru_name",
-      "validator": "string"
+      "type": "string"
     },
     {
       "name": "period_id",
-      "validator": "string"
+      "type": "string"
     }
   ],
   "mime_type": "application/json/ons/eq",

--- a/tests/schemas/invalid/test_invalid_decimal_places_must_be_defined_when_using_totaliser.json
+++ b/tests/schemas/invalid/test_invalid_decimal_places_must_be_defined_when_using_totaliser.json
@@ -8,13 +8,13 @@
     "description": "A survey that tests the totalling of percentage input fields",
     "metadata": [{
         "name": "user_id",
-        "validator": "string"
+        "type": "string"
     }, {
         "name": "period_id",
-        "validator": "string"
+        "type": "string"
     }, {
         "name": "ru_name",
-        "validator": "string"
+        "type": "string"
     }],
     "sections": [{
         "id": "default-section",

--- a/tests/schemas/invalid/test_invalid_duplicate_ids.json
+++ b/tests/schemas/invalid/test_invalid_duplicate_ids.json
@@ -9,15 +9,15 @@
     "description": "A questionnaire to test duplication of id fields",
     "metadata": [{
         "name": "user_id",
-        "validator": "string"
+        "type": "string"
     },
         {
             "name": "period_id",
-            "validator": "string"
+            "type": "string"
         },
         {
             "name": "ru_name",
-            "validator": "string"
+            "type": "string"
         }
     ],
     "sections": [{

--- a/tests/schemas/invalid/test_invalid_id_in_grouped_answers_to_calculate.json
+++ b/tests/schemas/invalid/test_invalid_id_in_grouped_answers_to_calculate.json
@@ -5,15 +5,15 @@
   "metadata": [
     {
       "name": "user_id",
-      "validator": "string"
+      "type": "string"
     },
     {
       "name": "ru_name",
-      "validator": "string"
+      "type": "string"
     },
     {
       "name": "period_id",
-      "validator": "string"
+      "type": "string"
     }
   ],
   "mime_type": "application/json/ons/eq",

--- a/tests/schemas/invalid/test_invalid_inconsistent_ids_in_variants.json
+++ b/tests/schemas/invalid/test_invalid_inconsistent_ids_in_variants.json
@@ -10,15 +10,15 @@
   "metadata": [
     {
       "name": "user_id",
-      "validator": "string"
+      "type": "string"
     },
     {
       "name": "period_id",
-      "validator": "string"
+      "type": "string"
     },
     {
       "name": "ru_name",
-      "validator": "string"
+      "type": "string"
     }
   ],
   "sections": [

--- a/tests/schemas/invalid/test_invalid_inconsistent_types_in_variants.json
+++ b/tests/schemas/invalid/test_invalid_inconsistent_types_in_variants.json
@@ -10,15 +10,15 @@
   "metadata": [
     {
       "name": "user_id",
-      "validator": "string"
+      "type": "string"
     },
     {
       "name": "period_id",
-      "validator": "string"
+      "type": "string"
     },
     {
       "name": "ru_name",
-      "validator": "string"
+      "type": "string"
     }
   ],
   "sections": [

--- a/tests/schemas/invalid/test_invalid_list_collector_bad_answer_reference_ids.json
+++ b/tests/schemas/invalid/test_invalid_list_collector_bad_answer_reference_ids.json
@@ -9,15 +9,15 @@
   "metadata": [
     {
       "name": "user_id",
-      "validator": "string"
+      "type": "string"
     },
     {
       "name": "period_id",
-      "validator": "string"
+      "type": "string"
     },
     {
       "name": "ru_name",
-      "validator": "string"
+      "type": "string"
     }
   ],
   "sections": [

--- a/tests/schemas/invalid/test_invalid_list_collector_bad_sub_block_types.json
+++ b/tests/schemas/invalid/test_invalid_list_collector_bad_sub_block_types.json
@@ -9,15 +9,15 @@
   "metadata": [
     {
       "name": "user_id",
-      "validator": "string"
+      "type": "string"
     },
     {
       "name": "period_id",
-      "validator": "string"
+      "type": "string"
     },
     {
       "name": "ru_name",
-      "validator": "string"
+      "type": "string"
     }
   ],
   "sections": [

--- a/tests/schemas/invalid/test_invalid_list_collector_duplicate_ids_multiple_collectors.json
+++ b/tests/schemas/invalid/test_invalid_list_collector_duplicate_ids_multiple_collectors.json
@@ -9,15 +9,15 @@
   "metadata": [
     {
       "name": "user_id",
-      "validator": "string"
+      "type": "string"
     },
     {
       "name": "period_id",
-      "validator": "string"
+      "type": "string"
     },
     {
       "name": "ru_name",
-      "validator": "string"
+      "type": "string"
     }
   ],
   "sections": [

--- a/tests/schemas/invalid/test_invalid_list_collector_non_radio.json
+++ b/tests/schemas/invalid/test_invalid_list_collector_non_radio.json
@@ -9,15 +9,15 @@
   "metadata": [
     {
       "name": "user_id",
-      "validator": "string"
+      "type": "string"
     },
     {
       "name": "period_id",
-      "validator": "string"
+      "type": "string"
     },
     {
       "name": "ru_name",
-      "validator": "string"
+      "type": "string"
     }
   ],
   "sections": [

--- a/tests/schemas/invalid/test_invalid_list_collector_with_different_add_block_answer_ids.json
+++ b/tests/schemas/invalid/test_invalid_list_collector_with_different_add_block_answer_ids.json
@@ -9,15 +9,15 @@
   "metadata": [
     {
       "name": "user_id",
-      "validator": "string"
+      "type": "string"
     },
     {
       "name": "period_id",
-      "validator": "string"
+      "type": "string"
     },
     {
       "name": "ru_name",
-      "validator": "string"
+      "type": "string"
     }
   ],
   "sections": [

--- a/tests/schemas/invalid/test_invalid_list_collector_with_different_answer_ids_in_add_and_edit.json
+++ b/tests/schemas/invalid/test_invalid_list_collector_with_different_answer_ids_in_add_and_edit.json
@@ -9,15 +9,15 @@
   "metadata": [
     {
       "name": "user_id",
-      "validator": "string"
+      "type": "string"
     },
     {
       "name": "period_id",
-      "validator": "string"
+      "type": "string"
     },
     {
       "name": "ru_name",
-      "validator": "string"
+      "type": "string"
     }
   ],
   "sections": [

--- a/tests/schemas/invalid/test_invalid_list_collector_with_no_add_option.json
+++ b/tests/schemas/invalid/test_invalid_list_collector_with_no_add_option.json
@@ -9,15 +9,15 @@
   "metadata": [
     {
       "name": "user_id",
-      "validator": "string"
+      "type": "string"
     },
     {
       "name": "period_id",
-      "validator": "string"
+      "type": "string"
     },
     {
       "name": "ru_name",
-      "validator": "string"
+      "type": "string"
     }
   ],
   "sections": [

--- a/tests/schemas/invalid/test_invalid_list_collector_with_routing.json
+++ b/tests/schemas/invalid/test_invalid_list_collector_with_routing.json
@@ -9,15 +9,15 @@
   "metadata": [
     {
       "name": "user_id",
-      "validator": "string"
+      "type": "string"
     },
     {
       "name": "period_id",
-      "validator": "string"
+      "type": "string"
     },
     {
       "name": "ru_name",
-      "validator": "string"
+      "type": "string"
     }
   ],
   "sections": [

--- a/tests/schemas/invalid/test_invalid_metadata.json
+++ b/tests/schemas/invalid/test_invalid_metadata.json
@@ -5,55 +5,55 @@
   "metadata": [
     {
       "name": "return_by",
-      "validator": "date"
+      "type": "date"
     },
     {
       "name": "period_id",
-      "validator": "string"
+      "type": "string"
     },
     {
       "name": "region_code",
-      "validator": "string"
+      "type": "string"
     },
     {
       "name": "invalid_metadata",
-      "validator": "string"
+      "type": "string"
     },
     {
       "name": "ref_p_start_date",
-      "validator": "date"
+      "type": "date"
     },
     {
       "name": "trad_as_or_ru_name",
-      "validator": "string"
+      "type": "string"
     },
     {
       "name": "trad_as",
-      "validator": "string"
+      "type": "string"
     },
     {
       "name": "user_id",
-      "validator": "string"
+      "type": "string"
     },
     {
       "name": "ref_p_end_date",
-      "validator": "date"
+      "type": "date"
     },
     {
       "name": "employment_date",
-      "validator": "date"
+      "type": "date"
     },
     {
       "name": "flag",
-      "validator": "boolean"
+      "type": "boolean"
     },
     {
       "name": "period_str",
-      "validator": "string"
+      "type": "string"
     },
     {
       "name": "case_id",
-      "validator": "uuid"
+      "type": "uuid"
     }
   ],
   "mime_type": "application/json/ons/eq",

--- a/tests/schemas/invalid/test_invalid_mm_yyyy_date_range_period.json
+++ b/tests/schemas/invalid/test_invalid_mm_yyyy_date_range_period.json
@@ -5,23 +5,23 @@
   "metadata": [
     {
       "name": "user_id",
-      "validator": "string"
+      "type": "string"
     },
     {
       "name": "ref_p_end_date",
-      "validator": "date"
+      "type": "date"
     },
     {
       "name": "ref_p_start_date",
-      "validator": "date"
+      "type": "date"
     },
     {
       "name": "ru_name",
-      "validator": "string"
+      "type": "string"
     },
     {
       "name": "period_id",
-      "validator": "string"
+      "type": "string"
     }
   ],
   "mime_type": "application/json/ons/eq",

--- a/tests/schemas/invalid/test_invalid_mutually_exclusive_conditions.json
+++ b/tests/schemas/invalid/test_invalid_mutually_exclusive_conditions.json
@@ -9,15 +9,15 @@
   "metadata": [
     {
       "name": "user_id",
-      "validator": "string"
+      "type": "string"
     },
     {
       "name": "period_id",
-      "validator": "string"
+      "type": "string"
     },
     {
       "name": "ru_name",
-      "validator": "string"
+      "type": "string"
     }
   ],
   "sections": [

--- a/tests/schemas/invalid/test_invalid_numeric_answers.json
+++ b/tests/schemas/invalid/test_invalid_numeric_answers.json
@@ -5,15 +5,15 @@
   "metadata": [
     {
       "name": "user_id",
-      "validator": "string"
+      "type": "string"
     },
     {
       "name": "ru_name",
-      "validator": "string"
+      "type": "string"
     },
     {
       "name": "period_id",
-      "validator": "string"
+      "type": "string"
     }
   ],
   "mime_type": "application/json/ons/eq",

--- a/tests/schemas/invalid/test_invalid_placeholder_source_ids.json
+++ b/tests/schemas/invalid/test_invalid_placeholder_source_ids.json
@@ -14,19 +14,19 @@
   "metadata": [
     {
       "name": "user_id",
-      "validator": "string"
+      "type": "string"
     },
     {
       "name": "period_id",
-      "validator": "string"
+      "type": "string"
     },
     {
       "name": "ru_name",
-      "validator": "string"
+      "type": "string"
     },
     {
       "name": "test_metadata",
-      "validator": "string"
+      "type": "string"
     }
   ],
   "sections": [

--- a/tests/schemas/invalid/test_invalid_routing_block.json
+++ b/tests/schemas/invalid/test_invalid_routing_block.json
@@ -5,15 +5,15 @@
   "metadata": [
     {
       "name": "user_id",
-      "validator": "string"
+      "type": "string"
     },
     {
       "name": "ru_name",
-      "validator": "string"
+      "type": "string"
     },
     {
       "name": "period_id",
-      "validator": "string"
+      "type": "string"
     }
   ],
   "mime_type": "application/json/ons/eq",

--- a/tests/schemas/invalid/test_invalid_single_date_min_max_period.json
+++ b/tests/schemas/invalid/test_invalid_single_date_min_max_period.json
@@ -5,15 +5,15 @@
   "metadata": [
     {
       "name": "user_id",
-      "validator": "string"
+      "type": "string"
     },
     {
       "name": "ru_name",
-      "validator": "string"
+      "type": "string"
     },
     {
       "name": "period_id",
-      "validator": "string"
+      "type": "string"
     }
   ],
   "mime_type": "application/json/ons/eq",

--- a/tests/schemas/invalid/test_invalid_single_variant.json
+++ b/tests/schemas/invalid/test_invalid_single_variant.json
@@ -9,15 +9,15 @@
     "description": "A questionnaire to test question variants and variant choices",
     "metadata": [{
         "name": "user_id",
-        "validator": "string"
+        "type": "string"
     },
         {
             "name": "period_id",
-            "validator": "string"
+            "type": "string"
         },
         {
             "name": "ru_name",
-            "validator": "string"
+            "type": "string"
         }
     ],
     "sections": [{

--- a/tests/schemas/invalid/test_invalid_string_transforms.json
+++ b/tests/schemas/invalid/test_invalid_string_transforms.json
@@ -255,19 +255,19 @@
   "metadata": [
     {
       "name": "user_id",
-      "validator": "string"
+      "type": "string"
     },
     {
       "name": "period_id",
-      "validator": "string"
+      "type": "string"
     },
     {
       "name": "ru_name",
-      "validator": "string"
+      "type": "string"
     },
     {
       "name": "test_metadata",
-      "validator": "string"
+      "type": "string"
     }
   ]
 }

--- a/tests/schemas/invalid/test_invalid_survey_id_whitespace.json
+++ b/tests/schemas/invalid/test_invalid_survey_id_whitespace.json
@@ -11,19 +11,19 @@
   "metadata": [
     {
       "name": "user_id",
-      "validator": "string"
+      "type": "string"
     },
     {
       "name": "period_id",
-      "validator": "string"
+      "type": "string"
     },
     {
       "name": "ru_name",
-      "validator": "string"
+      "type": "string"
     },
     {
       "name": "test_metadata",
-      "validator": "string"
+      "type": "string"
     }
   ],
   "schema_version": "0.0.1",

--- a/tests/schemas/invalid/test_invalid_when_condition_property.json
+++ b/tests/schemas/invalid/test_invalid_when_condition_property.json
@@ -9,15 +9,15 @@
   "metadata": [
     {
       "name": "user_id",
-      "validator": "string"
+      "type": "string"
     },
     {
       "name": "period_id",
-      "validator": "string"
+      "type": "string"
     },
     {
       "name": "ru_name",
-      "validator": "string"
+      "type": "string"
     }
   ],
   "sections": [

--- a/tests/schemas/invalid/test_invalid_yyyy_date_range_period.json
+++ b/tests/schemas/invalid/test_invalid_yyyy_date_range_period.json
@@ -5,23 +5,23 @@
   "metadata": [
     {
       "name": "user_id",
-      "validator": "string"
+      "type": "string"
     },
     {
       "name": "ref_p_end_date",
-      "validator": "date"
+      "type": "date"
     },
     {
       "name": "ref_p_start_date",
-      "validator": "date"
+      "type": "date"
     },
     {
       "name": "ru_name",
-      "validator": "string"
+      "type": "string"
     },
     {
       "name": "period_id",
-      "validator": "string"
+      "type": "string"
     }
   ],
   "mime_type": "application/json/ons/eq",

--- a/tests/schemas/valid/test_content_variants.json
+++ b/tests/schemas/valid/test_content_variants.json
@@ -9,15 +9,15 @@
     "description": "A questionnaire to test content variants and variant choices",
     "metadata": [{
             "name": "user_id",
-            "validator": "string"
+            "type": "string"
         },
         {
             "name": "period_id",
-            "validator": "string"
+            "type": "string"
         },
         {
             "name": "ru_name",
-            "validator": "string"
+            "type": "string"
         }
     ],
     "sections": [{

--- a/tests/schemas/valid/test_list_collector.json
+++ b/tests/schemas/valid/test_list_collector.json
@@ -9,15 +9,15 @@
   "metadata": [
     {
       "name": "user_id",
-      "validator": "string"
+      "type": "string"
     },
     {
       "name": "period_id",
-      "validator": "string"
+      "type": "string"
     },
     {
       "name": "ru_name",
-      "validator": "string"
+      "type": "string"
     }
   ],
   "sections": [

--- a/tests/schemas/valid/test_numeric_default_with_routing.json
+++ b/tests/schemas/valid/test_numeric_default_with_routing.json
@@ -5,15 +5,15 @@
   "metadata": [
     {
       "name": "user_id",
-      "validator": "string"
+      "type": "string"
     },
     {
       "name": "ru_name",
-      "validator": "string"
+      "type": "string"
     },
     {
       "name": "period_id",
-      "validator": "string"
+      "type": "string"
     }
   ],
   "mime_type": "application/json/ons/eq",

--- a/tests/schemas/valid/test_placeholder_source_ids.json
+++ b/tests/schemas/valid/test_placeholder_source_ids.json
@@ -14,19 +14,19 @@
   "metadata": [
     {
       "name": "user_id",
-      "validator": "string"
+      "type": "string"
     },
     {
       "name": "period_id",
-      "validator": "string"
+      "type": "string"
     },
     {
       "name": "ru_name",
-      "validator": "string"
+      "type": "string"
     },
     {
       "name": "test_metadata",
-      "validator": "string"
+      "type": "string"
     }
   ],
   "sections": [

--- a/tests/schemas/valid/test_question_variants.json
+++ b/tests/schemas/valid/test_question_variants.json
@@ -10,15 +10,15 @@
   "metadata": [
     {
       "name": "user_id",
-      "validator": "string"
+      "type": "string"
     },
     {
       "name": "period_id",
-      "validator": "string"
+      "type": "string"
     },
     {
       "name": "ru_name",
-      "validator": "string"
+      "type": "string"
     }
   ],
   "sections": [

--- a/tests/schemas/valid/test_schema_id_regex.json
+++ b/tests/schemas/valid/test_schema_id_regex.json
@@ -5,15 +5,15 @@
   "metadata": [
     {
       "name": "user_id",
-      "validator": "string"
+      "type": "string"
     },
     {
       "name": "ru_name",
-      "validator": "string"
+      "type": "string"
     },
     {
       "name": "period_id",
-      "validator": "string"
+      "type": "string"
     }
   ],
   "mime_type": "application/json/ons/eq",

--- a/tests/schemas/valid/test_string_transforms.json
+++ b/tests/schemas/valid/test_string_transforms.json
@@ -14,19 +14,19 @@
   "metadata": [
     {
       "name": "user_id",
-      "validator": "string"
+      "type": "string"
     },
     {
       "name": "period_id",
-      "validator": "string"
+      "type": "string"
     },
     {
       "name": "ru_name",
-      "validator": "string"
+      "type": "string"
     },
     {
       "name": "test_metadata",
-      "validator": "string"
+      "type": "string"
     }
   ],
   "sections": [

--- a/tests/schemas/valid/test_valid_metadata.json
+++ b/tests/schemas/valid/test_valid_metadata.json
@@ -13,19 +13,19 @@
   },
   "metadata": [{
     "name": "user_id",
-    "validator": "string"
+    "type": "string"
   },
     {
       "name": "period_id",
-      "validator": "string"
+      "type": "string"
     },
     {
       "name": "ru_name",
-      "validator": "string"
+      "type": "string"
     },
     {
       "name": "test_metadata",
-      "validator": "string"
+      "type": "string"
     }
   ],
   "sections": [{

--- a/tests/schemas/valid/test_when_condition_property.json
+++ b/tests/schemas/valid/test_when_condition_property.json
@@ -8,15 +8,15 @@
     "description": "A questionnaire to demo checkbox field combined contains routing",
     "metadata": [{
             "name": "user_id",
-            "validator": "string"
+            "type": "string"
         },
         {
             "name": "period_id",
-            "validator": "string"
+            "type": "string"
         },
         {
             "name": "ru_name",
-            "validator": "string"
+            "type": "string"
         }
     ],
     "sections": [{


### PR DESCRIPTION
In combination with: https://github.com/ONSdigital/eq-survey-runner/pull/2076

Adds the schema definitions for metadata. Uses `type` rather than `validator` and allows length validation and optional fields.