### PR TITLE
Allow default value for Radio answer and fix date comparision error

### DIFF
--- a/app/validation/validator.py
+++ b/app/validation/validator.py
@@ -1116,7 +1116,7 @@ class Validator:  # pylint: disable=too-many-lines
 
         if 'offset_by' in answer_min_or_max:
             offset = answer_min_or_max['offset_by']
-            value = self._get_relative_date(value, offset)
+            value = self._get_relative_date(value, offset).strftime('%Y-%m-%d')
 
         return value
 

--- a/schemas/answers/currency.json
+++ b/schemas/answers/currency.json
@@ -36,7 +36,7 @@
       },
       "default": {
         "type": "integer",
-        "description": "Default value on POST if none given"
+        "description": "Default value if no answer given"
       },
       "max_value": {
         "$ref": "definitions.json#/max_value"

--- a/schemas/answers/number.json
+++ b/schemas/answers/number.json
@@ -36,7 +36,7 @@
       },
       "default": {
         "type": "integer",
-        "description": "Default value on POST if none given"
+        "description": "Default value if no answer given"
       },
       "max_value": {
         "$ref": "definitions.json#/max_value"

--- a/schemas/answers/percentage.json
+++ b/schemas/answers/percentage.json
@@ -34,7 +34,7 @@
       },
       "default": {
         "type": "integer",
-        "description": "Default value on POST if none given"
+        "description": "Default value if no answer given"
       },
       "max_value": {
         "$ref": "definitions.json#/max_value"

--- a/schemas/answers/radio.json
+++ b/schemas/answers/radio.json
@@ -36,6 +36,10 @@
       "mandatory": {
         "type": "boolean"
       },
+      "default": {
+        "type": "string",
+        "description": "Default value if no answer given"
+      },
       "validation": {
         "type": "object",
         "properties": {

--- a/schemas/answers/unit.json
+++ b/schemas/answers/unit.json
@@ -34,7 +34,7 @@
       },
       "default": {
         "type": "integer",
-        "description": "Default value on POST if none given"
+        "description": "Default value if no answer given"
       },
       "max_value": {
         "$ref": "definitions.json#/max_value"


### PR DESCRIPTION
Allows the use of defaults for 'Radio' answer types as on the census, if for proxy they want to treat unanswered the same as if the user answered 'Yes', so instead of duplication the rule 100+ times, this solves the problem if we are happy modifying the user's answer.

Have also fixed an issue with `_get_offset_date_value` which was causing validation errors where it was possible to compare a *string* object with a *datetime* object when one of min/max had an offset defined but the other did not.

A test did not seem necessary for these changes as one is fixing an *Exception* and the other is done by JSON schema.

Needed for: https://github.com/ONSdigital/eq-survey-runner/pull/2098