### PR TITLE
Fix year in date format from YYYY to yyyy

### DIFF
--- a/doc/decisions/0001-define-piping-in-a-structured-way.md
+++ b/doc/decisions/0001-define-piping-in-a-structured-way.md
@@ -87,7 +87,7 @@ Proposed:
 
 ```json
 {
-    "description": "Are you able to report for the period starting on {{format_date_custom(metadata['ref_p_start_date'], 'EEEE d MMMM YYYY')}}?"
+    "description": "Are you able to report for the period starting on {{format_date_custom(metadata['ref_p_start_date'], 'EEEE d MMMM yyyy')}}?"
 }
 ```
 
@@ -109,7 +109,7 @@ Proposed:
                                 "source": "metadata",
                                 "identifier": "ref_p_start_date"
                             },
-                            "format": "EEEE d MMMM YYYY"
+                            "format": "EEEE d MMMM yyyy"
                         }
                     }
                 ]

--- a/schemas/string_interpolation/transforms/format_date.json
+++ b/schemas/string_interpolation/transforms/format_date.json
@@ -25,8 +25,8 @@
             "description": "See https://unicode.org/reports/tr35/tr35-dates.html#Date_Format_Patterns",
             "enum": [
               "EEEE d MMMM",
-              "EEEE d MMMM YYYY",
-              "d MMMM YYYY"
+              "EEEE d MMMM yyyy",
+              "d MMMM yyyy"
             ]
           }
         },


### PR DESCRIPTION
The date format is interpreted in runner using Babel. Using a format of YYYY meant an ISO year-week calendar was used and so dates close to the start of the year could get formatted with the wrong year. Using yyyy fixes this.

See http://babel.pocoo.org/en/latest/dates.html#date-fields
and https://github.com/python-babel/babel/issues/419