### PR TITLE
Feature: Hub & Spoke

### DIFF
--- a/schemas/questionnaire_v1.json
+++ b/schemas/questionnaire_v1.json
@@ -137,6 +137,19 @@
     "messages": {
       "$ref": "common_definitions.json#/messages"
     },
+    "hub": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Whether or not the hub and spoke pattern is enabled for this questionnaire.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "enabled"
+      ],
+      "additionalProperties": false
+    },
     "sections": {
       "type": "array",
       "items": {

--- a/tests/schemas/invalid/test_invalid_hub_and_spoke_and_summary_confirmation_non_existent.json
+++ b/tests/schemas/invalid/test_invalid_hub_and_spoke_and_summary_confirmation_non_existent.json
@@ -1,0 +1,172 @@
+{
+  "mime_type": "application/json/ons/eq",
+  "schema_version": "0.0.1",
+  "data_version": "0.0.3",
+  "survey_id": "0",
+  "title": "Hub & Spoke",
+  "theme": "default",
+  "description": "A questionnaire to demo hub and spoke functionality",
+  "metadata": [{
+      "name": "user_id",
+      "type": "string"
+    },
+    {
+      "name": "period_id",
+      "type": "string"
+    },
+    {
+      "name": "ru_name",
+      "type": "string"
+    }
+  ],
+  "hub": {
+    "enabled": false
+  },
+  "sections": [{
+      "id": "employment-section",
+      "title": "Employment",
+      "groups": [{
+        "id": "radio",
+        "title": "Radio Optional",
+        "blocks": [{
+            "type": "Question",
+            "id": "employment-status",
+            "question": {
+              "answers": [{
+                  "id": "employment-status-answer",
+                  "mandatory": false,
+                  "options": [{
+                      "label": "Working as an employee",
+                      "value": "Working as an employee"
+                    },
+                    {
+                      "label": "Self-employed or freelance",
+                      "value": "Self-employed or freelance"
+                    },
+                    {
+                      "label": "Temporarily away from work ill, on holiday or temporarily laid off",
+                      "value": "Temporarily away from work ill, on holiday or temporarily laid off"
+                    },
+                    {
+                      "label": "On maternity or paternity leave",
+                      "value": "On maternity or paternity leave"
+                    },
+                    {
+                      "label": "Doing any other kind of paid work",
+                      "value": "Doing any other kind of paid work"
+                    }
+                  ],
+                  "type": "Checkbox"
+                },
+                {
+                  "id": "employment-status-answer-exclusive",
+                  "mandatory": false,
+                  "options": [{
+                    "label": "None of these apply",
+                    "value": "None of these apply"
+                  }],
+                  "type": "Checkbox"
+                }
+              ],
+              "guidance": {
+                "contents": [{
+                  "description": "Include casual or temporary work, even if only for one hour"
+                }]
+              },
+              "id": "employment-status-question",
+              "mandatory": true,
+              "title": "In the last seven days, were you doing any of the following?",
+              "type": "MutuallyExclusive"
+            },
+            "routing_rules": [{
+              "goto": {
+                "group": "checkboxes",
+                "when": [{
+                  "id": "employment-status-answer",
+                  "condition": "set"
+                }]
+              }
+            }, {
+              "goto": {
+                "block": "employment-type"
+              }
+            }]
+          },
+          {
+            "type": "Question",
+            "id": "employment-type",
+            "question": {
+              "answers": [{
+                "id": "employment-type-answer",
+                "mandatory": false,
+                "options": [{
+                    "description": "Whether receiving a pension or not",
+                    "label": "Retired",
+                    "value": "Retired"
+                  },
+                  {
+                    "label": "Studying",
+                    "value": "Studying"
+                  },
+                  {
+                    "label": "Looking after home or family",
+                    "value": "Looking after home or family"
+                  },
+                  {
+                    "label": "Long-term sick or disabled",
+                    "value": "Long-term sick or disabled"
+                  },
+                  {
+                    "label": "Other",
+                    "value": "Other"
+                  }
+                ],
+                "type": "Checkbox"
+              }],
+              "id": "employment-type-question",
+              "title": "Which of the following describes what you were doing in the last seven days?",
+              "type": "General"
+            }
+          }
+        ]
+      }]
+    },
+    {
+      "id": "accommodation-section",
+      "title": "accommodation",
+      "groups": [{
+        "blocks": [{
+            "id": "proxy",
+            "question": {
+              "answers": [{
+                "default": "Yes",
+                "id": "proxy-answer",
+                "mandatory": false,
+                "options": [{
+                    "label": "No, I’m answering for myself",
+                    "value": "No"
+                  },
+                  {
+                    "label": "Yes",
+                    "value": "Yes"
+                  }
+                ],
+                "type": "Radio"
+              }],
+              "id": "proxy-question",
+              "title": "Are you answering the questions on behalf of someone else?",
+              "type": "General"
+            },
+            "type": "Question"
+          },
+          {
+            "id": "accommodation-details-summary",
+            "type": "SectionSummary"
+          }
+        ],
+        "id": "checkboxes",
+        "title": ""
+      }]
+    }
+  ]
+}

--- a/tests/schemas/invalid/test_invalid_hub_and_spoke_with_summary_confirmation.json
+++ b/tests/schemas/invalid/test_invalid_hub_and_spoke_with_summary_confirmation.json
@@ -1,0 +1,173 @@
+{
+  "mime_type": "application/json/ons/eq",
+  "schema_version": "0.0.1",
+  "data_version": "0.0.3",
+  "survey_id": "0",
+  "title": "Hub & Spoke",
+  "theme": "default",
+  "description": "A questionnaire to demo hub and spoke functionality",
+  "metadata": [{
+      "name": "user_id",
+      "type": "string"
+    },
+    {
+      "name": "period_id",
+      "type": "string"
+    },
+    {
+      "name": "ru_name",
+      "type": "string"
+    }
+  ],
+  "hub": {
+    "enabled": true
+  },
+  "sections": [{
+      "id": "employment-section",
+      "title": "Employment",
+      "groups": [{
+        "id": "radio",
+        "title": "Radio Optional",
+        "blocks": [{
+            "type": "Question",
+            "id": "employment-status",
+            "question": {
+              "answers": [{
+                  "id": "employment-status-answer",
+                  "mandatory": false,
+                  "options": [{
+                      "label": "Working as an employee",
+                      "value": "Working as an employee"
+                    },
+                    {
+                      "label": "Self-employed or freelance",
+                      "value": "Self-employed or freelance"
+                    },
+                    {
+                      "label": "Temporarily away from work ill, on holiday or temporarily laid off",
+                      "value": "Temporarily away from work ill, on holiday or temporarily laid off"
+                    },
+                    {
+                      "label": "On maternity or paternity leave",
+                      "value": "On maternity or paternity leave"
+                    },
+                    {
+                      "label": "Doing any other kind of paid work",
+                      "value": "Doing any other kind of paid work"
+                    }
+                  ],
+                  "type": "Checkbox"
+                },
+                {
+                  "id": "employment-status-answer-exclusive",
+                  "mandatory": false,
+                  "options": [{
+                    "label": "None of these apply",
+                    "value": "None of these apply"
+                  }],
+                  "type": "Checkbox"
+                }
+              ],
+              "guidance": {
+                "contents": [{
+                  "description": "Include casual or temporary work, even if only for one hour"
+                }]
+              },
+              "id": "employment-status-question",
+              "mandatory": true,
+              "title": "In the last seven days, were you doing any of the following?",
+              "type": "MutuallyExclusive"
+            },
+            "routing_rules": [{
+                "goto": {
+                  "group": "checkboxes",
+                  "when": [{
+                    "id": "employment-status-answer",
+                    "condition": "set"
+                  }]
+                }
+              },
+              {
+                "goto": {
+                  "block": "employment-type"
+                }
+              }
+            ]
+          },
+          {
+            "type": "Question",
+            "id": "employment-type",
+            "question": {
+              "answers": [{
+                "id": "employment-type-answer",
+                "mandatory": false,
+                "options": [{
+                    "description": "Whether receiving a pension or not",
+                    "label": "Retired",
+                    "value": "Retired"
+                  },
+                  {
+                    "label": "Studying",
+                    "value": "Studying"
+                  },
+                  {
+                    "label": "Looking after home or family",
+                    "value": "Looking after home or family"
+                  },
+                  {
+                    "label": "Long-term sick or disabled",
+                    "value": "Long-term sick or disabled"
+                  },
+                  {
+                    "label": "Other",
+                    "value": "Other"
+                  }
+                ],
+                "type": "Checkbox"
+              }],
+              "id": "employment-type-question",
+              "title": "Which of the following describes what you were doing in the last seven days?",
+              "type": "General"
+            }
+          }
+        ]
+      }]
+    },
+    {
+      "id": "accommodation-section",
+      "title": "accommodation",
+      "groups": [{
+        "blocks": [{
+          "id": "proxy",
+          "question": {
+            "answers": [{
+              "default": "Yes",
+              "id": "proxy-answer",
+              "mandatory": false,
+              "options": [{
+                  "label": "No, I’m answering for myself",
+                  "value": "No"
+                },
+                {
+                  "label": "Yes",
+                  "value": "Yes"
+                }
+              ],
+              "type": "Radio"
+            }],
+            "id": "proxy-question",
+            "title": "Are you answering the questions on behalf of someone else?",
+            "type": "General"
+          },
+          "type": "Question"
+        }, {
+          "id": "summary",
+          "type": "Summary"
+
+        }],
+        "id": "checkboxes",
+        "title": ""
+      }]
+    }
+  ]
+}

--- a/tests/schemas/valid/test_hub_and_spoke.json
+++ b/tests/schemas/valid/test_hub_and_spoke.json
@@ -1,0 +1,172 @@
+{
+  "mime_type": "application/json/ons/eq",
+  "schema_version": "0.0.1",
+  "data_version": "0.0.3",
+  "survey_id": "0",
+  "title": "Hub & Spoke",
+  "theme": "default",
+  "description": "A questionnaire to demo hub and spoke functionality",
+  "metadata": [{
+      "name": "user_id",
+      "type": "string"
+    },
+    {
+      "name": "period_id",
+      "type": "string"
+    },
+    {
+      "name": "ru_name",
+      "type": "string"
+    }
+  ],
+  "hub": {
+    "enabled": true
+  },
+  "sections": [{
+      "id": "employment-section",
+      "title": "Employment",
+      "groups": [{
+        "id": "radio",
+        "title": "Radio Optional",
+        "blocks": [{
+            "type": "Question",
+            "id": "employment-status",
+            "question": {
+              "answers": [{
+                  "id": "employment-status-answer",
+                  "mandatory": false,
+                  "options": [{
+                      "label": "Working as an employee",
+                      "value": "Working as an employee"
+                    },
+                    {
+                      "label": "Self-employed or freelance",
+                      "value": "Self-employed or freelance"
+                    },
+                    {
+                      "label": "Temporarily away from work ill, on holiday or temporarily laid off",
+                      "value": "Temporarily away from work ill, on holiday or temporarily laid off"
+                    },
+                    {
+                      "label": "On maternity or paternity leave",
+                      "value": "On maternity or paternity leave"
+                    },
+                    {
+                      "label": "Doing any other kind of paid work",
+                      "value": "Doing any other kind of paid work"
+                    }
+                  ],
+                  "type": "Checkbox"
+                },
+                {
+                  "id": "employment-status-answer-exclusive",
+                  "mandatory": false,
+                  "options": [{
+                    "label": "None of these apply",
+                    "value": "None of these apply"
+                  }],
+                  "type": "Checkbox"
+                }
+              ],
+              "guidance": {
+                "contents": [{
+                  "description": "Include casual or temporary work, even if only for one hour"
+                }]
+              },
+              "id": "employment-status-question",
+              "mandatory": true,
+              "title": "In the last seven days, were you doing any of the following?",
+              "type": "MutuallyExclusive"
+            },
+            "routing_rules": [{
+              "goto": {
+                "group": "checkboxes",
+                "when": [{
+                  "id": "employment-status-answer",
+                  "condition": "set"
+                }]
+              }
+            }, {
+              "goto": {
+                "block": "employment-type"
+              }
+            }]
+          },
+          {
+            "type": "Question",
+            "id": "employment-type",
+            "question": {
+              "answers": [{
+                "id": "employment-type-answer",
+                "mandatory": false,
+                "options": [{
+                    "description": "Whether receiving a pension or not",
+                    "label": "Retired",
+                    "value": "Retired"
+                  },
+                  {
+                    "label": "Studying",
+                    "value": "Studying"
+                  },
+                  {
+                    "label": "Looking after home or family",
+                    "value": "Looking after home or family"
+                  },
+                  {
+                    "label": "Long-term sick or disabled",
+                    "value": "Long-term sick or disabled"
+                  },
+                  {
+                    "label": "Other",
+                    "value": "Other"
+                  }
+                ],
+                "type": "Checkbox"
+              }],
+              "id": "employment-type-question",
+              "title": "Which of the following describes what you were doing in the last seven days?",
+              "type": "General"
+            }
+          }
+        ]
+      }]
+    },
+    {
+      "id": "accommodation-section",
+      "title": "accommodation",
+      "groups": [{
+        "blocks": [{
+            "id": "proxy",
+            "question": {
+              "answers": [{
+                "default": "Yes",
+                "id": "proxy-answer",
+                "mandatory": false,
+                "options": [{
+                    "label": "No, I’m answering for myself",
+                    "value": "No"
+                  },
+                  {
+                    "label": "Yes",
+                    "value": "Yes"
+                  }
+                ],
+                "type": "Radio"
+              }],
+              "id": "proxy-question",
+              "title": "Are you answering the questions on behalf of someone else?",
+              "type": "General"
+            },
+            "type": "Question"
+          },
+          {
+            "id": "accommodation-details-summary",
+            "type": "SectionSummary"
+          }
+        ],
+        "id": "checkboxes",
+        "title": ""
+      }]
+    }
+  ]
+}

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -479,3 +479,21 @@ def test_invalid_list_name_in_when_rule():
     ]
 
     check_validation_errors(filename, expected_error_messages)
+
+
+def test_invalid_hub_and_spoke_with_summary_confirmation():
+    filename = 'schemas/invalid/test_invalid_hub_and_spoke_with_summary_confirmation.json'
+    expected_error_messages = [
+        'Schema Integrity Error. Schema can only contain one of [Confirmation page, Summary page, Hub page]'
+    ]
+
+    check_validation_errors(filename, expected_error_messages)
+
+
+def test_invalid_hub_and_spoke_and_summary_confirmation_non_existent():
+    filename = 'schemas/invalid/test_invalid_hub_and_spoke_and_summary_confirmation_non_existent.json'
+    expected_error_messages = [
+        'Schema Integrity Error. Schema must contain one of [Confirmation page, Summary page, Hub page]'
+    ]
+
+    check_validation_errors(filename, expected_error_messages)


### PR DESCRIPTION
### What is the context of this PR?
Allows the use of a top-level object for the hub and spoke feature.
Needed for: https://github.com/ONSdigital/eq-survey-runner/pull/2142

For now, the hub is defined as a top-level schema object but this is subject to change once https://trello.com/c/BJPC98fW/3086-move-final-summary-block-out-of-sections is implemented. We should potentially have a single selection of the submission type for a schema ie Summary/Confirmation/Hub.

### How to review 
Test against runner branch.
