### PR TITLE
Adds definitions for relationship collector

### DIFF
--- a/schemas/answers/relationships.json
+++ b/schemas/answers/relationships.json
@@ -1,0 +1,68 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema",
+    "answer": {
+        "type": "object",
+        "properties": {
+            "id": {
+                "$ref": "../common_definitions.json#/id"
+            },
+            "label": {
+                "type": "string"
+            },
+            "guidance": {
+                "$ref": "definitions.json#/answer_guidance"
+            },
+            "description": {
+                "$ref": "../string_interpolation/definitions.json#/string_with_placeholders"
+            },
+            "type": {
+                "type": "string",
+                "enum": [
+                    "Relationships"
+                ]
+            },
+            "options": {
+                "type": "array",
+                "uniqueItems": true,
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "label": {
+                            "type": "string"
+                        },
+                        "value": {
+                            "type": "string"
+                        },
+                        "relationship_title": {
+                            "$ref": "../string_interpolation/definitions.json#/string_with_placeholders"
+                        },
+                        "relationship_playback": {
+                            "$ref": "../string_interpolation/definitions.json#/string_with_placeholders"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "label",
+                        "value",
+                        "relationship_title",
+                        "relationship_playback"
+                    ]
+                }
+            },
+            "mandatory": {
+                "type": "boolean"
+            },
+            "playback": {
+                "type": "string"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "id",
+            "type",
+            "mandatory",
+            "options",
+            "playback"
+        ]
+    }
+}

--- a/schemas/blocks/relationship_collector.json
+++ b/schemas/blocks/relationship_collector.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema",
+  "block": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "$ref": "../common_definitions.json#/id"
+      },
+      "type": {
+        "type": "string",
+        "enum": ["RelationshipCollector"]
+      },
+      "title": {
+        "type": "string"
+      },
+      "list": {
+        "type": "string"
+      },
+      "question": {
+        "$ref": "../questions/definitions.json#/question"
+      },
+      "question_variants": {
+        "$ref": "definitions.json#/question_variants"
+      },
+      "routing_rules": {
+          "$ref": "../common_definitions.json#/routing_rules"
+      },
+      "skip_conditions": {
+          "$ref": "../common_definitions.json#/skip_conditions"
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "id",
+      "type",
+      "list"
+    ],
+    "oneOf": [
+      {
+        "required": [
+          "question"
+        ]
+      },
+      {
+        "required": [
+          "question_variants"
+        ]
+      }
+    ]
+  }
+}

--- a/schemas/questionnaire_v1.json
+++ b/schemas/questionnaire_v1.json
@@ -202,6 +202,9 @@
                         "$ref": "blocks/question.json#/block"
                       },
                       {
+                        "$ref": "blocks/relationship_collector.json#/block"
+                      },
+                      {
                         "$ref": "blocks/summary.json#/block"
                       }
                     ]

--- a/schemas/questions/types/general.json
+++ b/schemas/questions/types/general.json
@@ -71,6 +71,9 @@
             },
             {
               "$ref": "../../answers/dropdown.json#/answer"
+            },
+            {
+              "$ref": "../../answers/relationships.json#/answer"
             }
           ]
         }

--- a/tests/schemas/invalid/test_invalid_relationship_no_list_specified.json
+++ b/tests/schemas/invalid/test_invalid_relationship_no_list_specified.json
@@ -1,0 +1,76 @@
+{
+    "mime_type": "application/json/ons/eq",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.3",
+    "survey_id": "0",
+    "title": "Test Relationships",
+    "theme": "default",
+    "description": "A questionnaire to test capturing of relationships.",
+    "messages": {},
+    "metadata": [
+        {
+            "name": "user_id",
+            "type": "string"
+        },
+        {
+            "name": "period_id",
+            "type": "string"
+        },
+        {
+            "name": "ru_name",
+            "type": "string"
+        }
+    ],
+    "sections": [
+        {
+            "id": "section",
+            "groups": [
+                {
+                    "id": "group",
+                    "title": "Relationships",
+                    "blocks": [
+                        {
+                            "type": "RelationshipCollector",
+                            "id": "relationships",
+                            "title": "This will iterate over the people list, capturing the one way relationships.",
+                            "question": {
+                                "id": "relationship-question",
+                                "type": "General",
+                                "title": "Thinking of {first_person_name}, {second_person_name} is their <em>...</em>",
+                                "answers": [
+                                    {
+                                        "id": "relationship-answer",
+                                        "mandatory": true,
+                                        "type": "Relationships",
+                                        "playback": "{second_person_name} is {first_person_name} <em>…</em>",
+                                        "options": [
+                                            {
+                                                "value": "husband-or-wife",
+                                                "label": "Husband or Wife",
+                                                "relationship_title": "Thinking of {first_person_name}, {second_person_name} is their <em>husband or wife</em>",
+                                                "relationship_playback": "{second_person_name} is {first_person_name} <em>husband or wife</em>"
+                                            },
+                                            {
+                                                "value": "legally-registered-civil-partner",
+                                                "label": "Legally registered civil partner",
+                                                "relationship_title": "Thinking of {first_person_name}, {second_person_name} is their <em>legally registered civil partner</em>",
+                                                "relationship_playback": "{second_person_name} is {first_person_name} <em>legally registered civil partner</em>"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "type": "Confirmation",
+                            "id": "confirmation",
+                            "content": {
+                                "title": "Thank you for your answers, do you wish to submit"
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/tests/schemas/valid/test_relationship_collector.json
+++ b/tests/schemas/valid/test_relationship_collector.json
@@ -1,0 +1,77 @@
+{
+    "mime_type": "application/json/ons/eq",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.3",
+    "survey_id": "0",
+    "title": "Test Relationships",
+    "theme": "default",
+    "description": "A questionnaire to test capturing of relationships.",
+    "messages": {},
+    "metadata": [
+        {
+            "name": "user_id",
+            "type": "string"
+        },
+        {
+            "name": "period_id",
+            "type": "string"
+        },
+        {
+            "name": "ru_name",
+            "type": "string"
+        }
+    ],
+    "sections": [
+        {
+            "id": "section",
+            "groups": [
+                {
+                    "id": "group",
+                    "title": "Relationships",
+                    "blocks": [
+                        {
+                            "type": "RelationshipCollector",
+                            "id": "relationships",
+                            "title": "This will iterate over the people list, capturing the one way relationships.",
+                            "list": "people",
+                            "question": {
+                                "id": "relationship-question",
+                                "type": "General",
+                                "title": "Thinking of {first_person_name}, {second_person_name} is their <em>...</em>",
+                                "answers": [
+                                    {
+                                        "id": "relationship-answer",
+                                        "mandatory": true,
+                                        "type": "Relationships",
+                                        "playback": "{second_person_name} is {first_person_name} <em>…</em>",
+                                        "options": [
+                                            {
+                                                "value": "husband-or-wife",
+                                                "label": "Husband or Wife",
+                                                "relationship_title": "Thinking of {first_person_name}, {second_person_name} is their <em>husband or wife</em>",
+                                                "relationship_playback": "{second_person_name} is {first_person_name} <em>husband or wife</em>"
+                                            },
+                                            {
+                                                "value": "legally-registered-civil-partner",
+                                                "label": "Legally registered civil partner",
+                                                "relationship_title": "Thinking of {first_person_name}, {second_person_name} is their <em>legally registered civil partner</em>",
+                                                "relationship_playback": "{second_person_name} is {first_person_name} <em>legally registered civil partner</em>"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "type": "Confirmation",
+                            "id": "confirmation",
+                            "content": {
+                                "title": "Thank you for your answers, do you wish to submit"
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
#### This PR adds new schema definitions to support the collection of relationships in surveys.

There are two new definitions:
1) `/schemas/blocks/relationships_collector.json` uses a new enum, `RelationshipsCollector`, and uses a new mandatory `list` property. This is the id of the list that contains the list items for which relationships need to be collected.
2) `/schemas/answers/relationships.json` defines new answer options properties `relationships_title` sand `relationships_playback` that are unique to and mandatory for relationships answers.