### PR TITLE
Adds definitions for relationship collector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,4 +108,6 @@ secrets.yml
 *.bak
 .vscode/
 .pytest_cache/
-node_modules/
+
+#Node Modules
+node_modules

--- a/schemas/answers/relationship.json
+++ b/schemas/answers/relationship.json
@@ -1,0 +1,68 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema",
+    "answer": {
+        "type": "object",
+        "properties": {
+            "id": {
+                "$ref": "../common_definitions.json#/id"
+            },
+            "label": {
+                "type": "string"
+            },
+            "guidance": {
+                "$ref": "definitions.json#/answer_guidance"
+            },
+            "description": {
+                "$ref": "../string_interpolation/definitions.json#/string_with_placeholders"
+            },
+            "type": {
+                "type": "string",
+                "enum": [
+                    "Relationship"
+                ]
+            },
+            "options": {
+                "type": "array",
+                "uniqueItems": true,
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "label": {
+                            "type": "string"
+                        },
+                        "value": {
+                            "type": "string"
+                        },
+                        "title": {
+                            "$ref": "../string_interpolation/definitions.json#/string_with_placeholders"
+                        },
+                        "playback": {
+                            "$ref": "../string_interpolation/definitions.json#/string_with_placeholders"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "label",
+                        "value",
+                        "title",
+                        "playback"
+                    ]
+                }
+            },
+            "mandatory": {
+                "type": "boolean"
+            },
+            "playback": {
+                "type": "string"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "id",
+            "type",
+            "mandatory",
+            "options",
+            "playback"
+        ]
+    }
+}

--- a/schemas/blocks/relationship_collector.json
+++ b/schemas/blocks/relationship_collector.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema",
+  "block": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "$ref": "../common_definitions.json#/id"
+      },
+      "type": {
+        "type": "string",
+        "enum": ["RelationshipCollector"]
+      },
+      "title": {
+        "type": "string"
+      },
+      "for_list": {
+        "type": "string"
+      },
+      "question": {
+        "$ref": "../questions/definitions.json#/question"
+      },
+      "question_variants": {
+        "$ref": "definitions.json#/question_variants"
+      },
+      "routing_rules": {
+          "$ref": "../common_definitions.json#/routing_rules"
+      },
+      "skip_conditions": {
+          "$ref": "../common_definitions.json#/skip_conditions"
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "id",
+      "type",
+      "for_list"
+    ],
+    "oneOf": [
+      {
+        "required": [
+          "question"
+        ]
+      },
+      {
+        "required": [
+          "question_variants"
+        ]
+      }
+    ]
+  }
+}

--- a/schemas/questionnaire_v1.json
+++ b/schemas/questionnaire_v1.json
@@ -218,6 +218,9 @@
                         "$ref": "blocks/question.json#/block"
                       },
                       {
+                        "$ref": "blocks/relationship_collector.json#/block"
+                      },
+                      {
                         "$ref": "blocks/summary.json#/block"
                       }
                     ]

--- a/schemas/questions/types/general.json
+++ b/schemas/questions/types/general.json
@@ -71,6 +71,9 @@
             },
             {
               "$ref": "../../answers/dropdown.json#/answer"
+            },
+            {
+              "$ref": "../../answers/relationship.json#/answer"
             }
           ]
         }

--- a/tests/schemas/invalid/test_invalid_relationship_list_doesnt_exist.json
+++ b/tests/schemas/invalid/test_invalid_relationship_list_doesnt_exist.json
@@ -1,0 +1,68 @@
+{
+  "mime_type": "application/json/ons/eq",
+  "schema_version": "0.0.1",
+  "data_version": "0.0.3",
+  "survey_id": "0",
+  "title": "Test Relationships",
+  "theme": "default",
+  "description": "A questionnaire to test capturing of relationships.",
+  "messages": {},
+  "metadata": [{
+      "name": "user_id",
+      "type": "string"
+    },
+    {
+      "name": "period_id",
+      "type": "string"
+    },
+    {
+      "name": "ru_name",
+      "type": "string"
+    }
+  ],
+  "sections": [{
+    "id": "section",
+    "groups": [{
+      "id": "group",
+      "title": "Relationships",
+      "blocks": [{
+          "type": "RelationshipCollector",
+          "id": "relationships",
+          "title": "This will iterate over the people list, capturing the one way relationships.",
+          "for_list": "not-a-list",
+          "question": {
+            "id": "relationship-question",
+            "type": "General",
+            "title": "Thinking of {first_person_name}, {second_person_name} is their <em>...</em>",
+            "answers": [{
+              "id": "relationship-answer",
+              "mandatory": true,
+              "type": "Relationship",
+              "playback": "{second_person_name} is {first_person_name} <em>…</em>",
+              "options": [{
+                  "value": "Husband or Wife",
+                  "label": "husband or Wife",
+                  "title": "Thinking of {first_person_name}, {second_person_name} is their <em>husband or wife</em>",
+                  "playback": "{second_person_name} is {first_person_name} <em>husband or wife</em>"
+                },
+                {
+                  "value": "Legally Registered Civil Partner",
+                  "label": "Legally Registered Civil Partner",
+                  "title": "Thinking of {first_person_name}, {second_person_name} is their <em>legally registered civil partner</em>",
+                  "playback": "{second_person_name} is {first_person_name} <em>legally registered civil partner</em>"
+                }
+              ]
+            }]
+          }
+        },
+        {
+          "type": "Confirmation",
+          "id": "confirmation",
+          "content": {
+            "title": "Thank you for your answers, do you wish to submit"
+          }
+        }
+      ]
+    }]
+  }]
+}

--- a/tests/schemas/invalid/test_invalid_relationship_multiple_answers.json
+++ b/tests/schemas/invalid/test_invalid_relationship_multiple_answers.json
@@ -1,0 +1,187 @@
+{
+  "mime_type": "application/json/ons/eq",
+  "schema_version": "0.0.1",
+  "data_version": "0.0.3",
+  "survey_id": "0",
+  "title": "Test Relationships",
+  "theme": "default",
+  "description": "A questionnaire to test capturing of relationships.",
+  "messages": {},
+  "metadata": [{
+      "name": "user_id",
+      "type": "string"
+    },
+    {
+      "name": "period_id",
+      "type": "string"
+    },
+    {
+      "name": "ru_name",
+      "type": "string"
+    }
+  ],
+  "sections": [{
+    "id": "section",
+    "groups": [{
+      "id": "group",
+      "title": "Relationships",
+      "blocks": [{
+          "id": "list-collector",
+          "type": "ListCollector",
+          "populates_list": "people",
+          "add_answer": {
+            "id": "anyone-else",
+            "value": "Yes"
+          },
+          "remove_answer": {
+            "id": "remove-confirmation",
+            "value": "Yeah"
+          },
+          "question": {
+            "id": "confirmation-question",
+            "type": "General",
+            "title": "Does anyone else live here?",
+            "answers": [{
+              "id": "anyone-else",
+              "mandatory": true,
+              "type": "Radio",
+              "options": [{
+                  "label": "Yes",
+                  "value": "Yes"
+                },
+                {
+                  "label": "No",
+                  "value": "No"
+                }
+              ]
+            }]
+          },
+          "add_block": {
+            "id": "add-person",
+            "type": "ListAddQuestion",
+            "question": {
+              "id": "add-question",
+              "type": "General",
+              "title": "What is the name of the person?",
+              "answers": [{
+                  "id": "first-name",
+                  "label": "First name",
+                  "mandatory": true,
+                  "type": "TextField"
+                },
+                {
+                  "id": "last-name",
+                  "label": "Last name",
+                  "mandatory": true,
+                  "type": "TextField"
+                }
+              ]
+            }
+          },
+          "edit_block": {
+            "id": "edit-person",
+            "type": "ListEditQuestion",
+            "question": {
+              "id": "edit-question",
+              "type": "General",
+              "title": "What is the name of the person?",
+              "answers": [{
+                  "id": "first-name",
+                  "label": "First name",
+                  "mandatory": true,
+                  "type": "TextField"
+                },
+                {
+                  "id": "last-name",
+                  "label": "Last name",
+                  "mandatory": true,
+                  "type": "TextField"
+                }
+              ]
+            }
+          },
+          "remove_block": {
+            "id": "remove-person",
+            "type": "ListRemoveQuestion",
+            "question": {
+              "id": "remove-question",
+              "type": "General",
+              "title": "Are you sure you want to remove this person?",
+              "answers": [{
+                "id": "remove-confirmation",
+                "mandatory": true,
+                "type": "Radio",
+                "options": [{
+                    "label": "Yeah",
+                    "value": "Yeah"
+                  },
+                  {
+                    "label": "No",
+                    "value": "No"
+                  }
+                ]
+              }]
+            }
+          }
+        },
+        {
+          "type": "RelationshipCollector",
+          "id": "relationships",
+          "title": "This will iterate over the people list, capturing the one way relationships.",
+          "for_list": "people",
+          "question": {
+            "id": "relationship-question",
+            "type": "General",
+            "title": "Thinking of {first_person_name}, {second_person_name} is their <em>...</em>",
+            "answers": [{
+                "id": "relationship-answer",
+                "mandatory": true,
+                "type": "Relationship",
+                "playback": "{second_person_name} is {first_person_name} <em>…</em>",
+                "options": [{
+                    "value": "Husband or Wife",
+                    "label": "husband or Wife",
+                    "title": "Thinking of {first_person_name}, {second_person_name} is their <em>husband or wife</em>",
+                    "playback": "{second_person_name} is {first_person_name} <em>husband or wife</em>"
+                  },
+                  {
+                    "value": "Legally Registered Civil Partner",
+                    "label": "Legally Registered Civil Partner",
+                    "title": "Thinking of {first_person_name}, {second_person_name} is their <em>legally registered civil partner</em>",
+                    "playback": "{second_person_name} is {first_person_name} <em>legally registered civil partner</em>"
+                  }
+                ]
+              },
+              {
+                "id": "relationship-answer2",
+                "mandatory": true,
+                "type": "Relationship",
+                "playback": "{second_person_name} is {first_person_name} <em>…</em>",
+                "options": [{
+                    "value": "Husband or Wife",
+                    "label": "husband or Wife",
+                    "title": "Thinking of {first_person_name}, {second_person_name} is their <em>husband or wife</em>",
+                    "playback": "{second_person_name} is {first_person_name} <em>husband or wife</em>"
+                  },
+                  {
+                    "value": "Legally Registered Civil Partner",
+                    "label": "Legally Registered Civil Partner",
+                    "title": "Thinking of {first_person_name}, {second_person_name} is their <em>legally registered civil partner</em>",
+                    "playback": "{second_person_name} is {first_person_name} <em>legally registered civil partner</em>"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "type": "Confirmation",
+          "id": "confirmation",
+          "content": {
+            "title": "Thank you for your answers, do you wish to submit"
+          }
+        }
+      ]
+    }]
+  }]
+}

--- a/tests/schemas/invalid/test_invalid_relationship_no_list_specified.json
+++ b/tests/schemas/invalid/test_invalid_relationship_no_list_specified.json
@@ -1,0 +1,166 @@
+{
+  "mime_type": "application/json/ons/eq",
+  "schema_version": "0.0.1",
+  "data_version": "0.0.3",
+  "survey_id": "0",
+  "title": "Test Relationships",
+  "theme": "default",
+  "description": "A questionnaire to test capturing of relationships.",
+  "messages": {},
+  "metadata": [{
+      "name": "user_id",
+      "type": "string"
+    },
+    {
+      "name": "period_id",
+      "type": "string"
+    },
+    {
+      "name": "ru_name",
+      "type": "string"
+    }
+  ],
+  "sections": [{
+    "id": "section",
+    "groups": [{
+      "id": "group",
+      "title": "Relationships",
+      "blocks": [{
+          "id": "list-collector",
+          "type": "ListCollector",
+          "populates_list": "people",
+          "add_answer": {
+            "id": "anyone-else",
+            "value": "Yes"
+          },
+          "remove_answer": {
+            "id": "remove-confirmation",
+            "value": "Yeah"
+          },
+          "question": {
+            "id": "confirmation-question",
+            "type": "General",
+            "title": "Does anyone else live here?",
+            "answers": [{
+              "id": "anyone-else",
+              "mandatory": true,
+              "type": "Radio",
+              "options": [{
+                  "label": "Yes",
+                  "value": "Yes"
+                },
+                {
+                  "label": "No",
+                  "value": "No"
+                }
+              ]
+            }]
+          },
+          "add_block": {
+            "id": "add-person",
+            "type": "ListAddQuestion",
+            "question": {
+              "id": "add-question",
+              "type": "General",
+              "title": "What is the name of the person?",
+              "answers": [{
+                  "id": "first-name",
+                  "label": "First name",
+                  "mandatory": true,
+                  "type": "TextField"
+                },
+                {
+                  "id": "last-name",
+                  "label": "Last name",
+                  "mandatory": true,
+                  "type": "TextField"
+                }
+              ]
+            }
+          },
+          "edit_block": {
+            "id": "edit-person",
+            "type": "ListEditQuestion",
+            "question": {
+              "id": "edit-question",
+              "type": "General",
+              "title": "What is the name of the person?",
+              "answers": [{
+                  "id": "first-name",
+                  "label": "First name",
+                  "mandatory": true,
+                  "type": "TextField"
+                },
+                {
+                  "id": "last-name",
+                  "label": "Last name",
+                  "mandatory": true,
+                  "type": "TextField"
+                }
+              ]
+            }
+          },
+          "remove_block": {
+            "id": "remove-person",
+            "type": "ListRemoveQuestion",
+            "question": {
+              "id": "remove-question",
+              "type": "General",
+              "title": "Are you sure you want to remove this person?",
+              "answers": [{
+                "id": "remove-confirmation",
+                "mandatory": true,
+                "type": "Radio",
+                "options": [{
+                    "label": "Yeah",
+                    "value": "Yeah"
+                  },
+                  {
+                    "label": "No",
+                    "value": "No"
+                  }
+                ]
+              }]
+            }
+          }
+        },
+        {
+          "type": "RelationshipCollector",
+          "id": "relationships",
+          "title": "This will iterate over the people list, capturing the one way relationships.",
+          "question": {
+            "id": "relationship-question",
+            "type": "General",
+            "title": "Thinking of {first_person_name}, {second_person_name} is their <em>...</em>",
+            "answers": [{
+              "id": "relationship-answer",
+              "mandatory": true,
+              "type": "Relationship",
+              "playback": "{second_person_name} is {first_person_name} <em>…</em>",
+              "options": [{
+                  "value": "Husband or Wife",
+                  "label": "Husband or Wife",
+                  "title": "Thinking of {first_person_name}, {second_person_name} is their <em>husband or wife</em>",
+                  "playback": "{second_person_name} is {first_person_name} <em>husband or wife</em>"
+                },
+                {
+                  "value": "Legally Registered Civil Partner",
+                  "label": "Legally Registered Civil Partner",
+                  "title": "Thinking of {first_person_name}, {second_person_name} is their <em>legally registered civil partner</em>",
+                  "playback": "{second_person_name} is {first_person_name} <em>legally registered civil partner</em>"
+                }
+              ]
+            }]
+          }
+        },
+        {
+          "type": "Confirmation",
+          "id": "confirmation",
+          "content": {
+            "title": "Thank you for your answers, do you wish to submit"
+          }
+        }
+      ]
+    }]
+  }]
+}

--- a/tests/schemas/invalid/test_invalid_relationship_wrong_answer_type.json
+++ b/tests/schemas/invalid/test_invalid_relationship_wrong_answer_type.json
@@ -1,0 +1,154 @@
+{
+  "mime_type": "application/json/ons/eq",
+  "schema_version": "0.0.1",
+  "data_version": "0.0.3",
+  "survey_id": "0",
+  "title": "Test Relationships",
+  "theme": "default",
+  "description": "A questionnaire to test capturing of relationships.",
+  "messages": {},
+  "metadata": [{
+      "name": "user_id",
+      "type": "string"
+    },
+    {
+      "name": "period_id",
+      "type": "string"
+    },
+    {
+      "name": "ru_name",
+      "type": "string"
+    }
+  ],
+  "sections": [{
+    "id": "section",
+    "groups": [{
+      "id": "group",
+      "title": "Relationships",
+      "blocks": [{
+          "id": "list-collector",
+          "type": "ListCollector",
+          "populates_list": "people",
+          "add_answer": {
+            "id": "anyone-else",
+            "value": "Yes"
+          },
+          "remove_answer": {
+            "id": "remove-confirmation",
+            "value": "Yeah"
+          },
+          "question": {
+            "id": "confirmation-question",
+            "type": "General",
+            "title": "Does anyone else live here?",
+            "answers": [{
+              "id": "anyone-else",
+              "mandatory": true,
+              "type": "Radio",
+              "options": [{
+                  "label": "Yes",
+                  "value": "Yes"
+                },
+                {
+                  "label": "No",
+                  "value": "No"
+                }
+              ]
+            }]
+          },
+          "add_block": {
+            "id": "add-person",
+            "type": "ListAddQuestion",
+            "question": {
+              "id": "add-question",
+              "type": "General",
+              "title": "What is the name of the person?",
+              "answers": [{
+                  "id": "first-name",
+                  "label": "First name",
+                  "mandatory": true,
+                  "type": "TextField"
+                },
+                {
+                  "id": "last-name",
+                  "label": "Last name",
+                  "mandatory": true,
+                  "type": "TextField"
+                }
+              ]
+            }
+          },
+          "edit_block": {
+            "id": "edit-person",
+            "type": "ListEditQuestion",
+            "question": {
+              "id": "edit-question",
+              "type": "General",
+              "title": "What is the name of the person?",
+              "answers": [{
+                  "id": "first-name",
+                  "label": "First name",
+                  "mandatory": true,
+                  "type": "TextField"
+                },
+                {
+                  "id": "last-name",
+                  "label": "Last name",
+                  "mandatory": true,
+                  "type": "TextField"
+                }
+              ]
+            }
+          },
+          "remove_block": {
+            "id": "remove-person",
+            "type": "ListRemoveQuestion",
+            "question": {
+              "id": "remove-question",
+              "type": "General",
+              "title": "Are you sure you want to remove this person?",
+              "answers": [{
+                "id": "remove-confirmation",
+                "mandatory": true,
+                "type": "Radio",
+                "options": [{
+                    "label": "Yeah",
+                    "value": "Yeah"
+                  },
+                  {
+                    "label": "No",
+                    "value": "No"
+                  }
+                ]
+              }]
+            }
+          }
+        },
+        {
+          "type": "RelationshipCollector",
+          "id": "relationships",
+          "title": "This will iterate over the people list, capturing the one way relationships.",
+          "for_list": "people",
+          "question": {
+            "id": "relationship-question",
+            "type": "General",
+            "title": "Thinking of {first_person_name}, {second_person_name} is their <em>...</em>",
+            "answers": [{
+              "id": "answer-1",
+              "label": "Your age?",
+              "mandatory": false,
+              "type": "Number"
+            }]
+          }
+        },
+        {
+          "type": "Confirmation",
+          "id": "confirmation",
+          "content": {
+            "title": "Thank you for your answers, do you wish to submit"
+          }
+        }
+      ]
+    }]
+  }]
+}

--- a/tests/schemas/valid/test_relationship_collector.json
+++ b/tests/schemas/valid/test_relationship_collector.json
@@ -1,0 +1,167 @@
+{
+  "mime_type": "application/json/ons/eq",
+  "schema_version": "0.0.1",
+  "data_version": "0.0.3",
+  "survey_id": "0",
+  "title": "Test Relationships",
+  "theme": "default",
+  "description": "A questionnaire to test capturing of relationships.",
+  "messages": {},
+  "metadata": [{
+      "name": "user_id",
+      "type": "string"
+    },
+    {
+      "name": "period_id",
+      "type": "string"
+    },
+    {
+      "name": "ru_name",
+      "type": "string"
+    }
+  ],
+  "sections": [{
+    "id": "section",
+    "groups": [{
+      "id": "group",
+      "title": "Relationships",
+      "blocks": [{
+          "id": "list-collector",
+          "type": "ListCollector",
+          "populates_list": "people",
+          "add_answer": {
+            "id": "anyone-else",
+            "value": "Yes"
+          },
+          "remove_answer": {
+            "id": "remove-confirmation",
+            "value": "Yeah"
+          },
+          "question": {
+            "id": "confirmation-question",
+            "type": "General",
+            "title": "Does anyone else live here?",
+            "answers": [{
+              "id": "anyone-else",
+              "mandatory": true,
+              "type": "Radio",
+              "options": [{
+                  "label": "Yes",
+                  "value": "Yes"
+                },
+                {
+                  "label": "No",
+                  "value": "No"
+                }
+              ]
+            }]
+          },
+          "add_block": {
+            "id": "add-person",
+            "type": "ListAddQuestion",
+            "question": {
+              "id": "add-question",
+              "type": "General",
+              "title": "What is the name of the person?",
+              "answers": [{
+                  "id": "first-name",
+                  "label": "First name",
+                  "mandatory": true,
+                  "type": "TextField"
+                },
+                {
+                  "id": "last-name",
+                  "label": "Last name",
+                  "mandatory": true,
+                  "type": "TextField"
+                }
+              ]
+            }
+          },
+          "edit_block": {
+            "id": "edit-person",
+            "type": "ListEditQuestion",
+            "question": {
+              "id": "edit-question",
+              "type": "General",
+              "title": "What is the name of the person?",
+              "answers": [{
+                  "id": "first-name",
+                  "label": "First name",
+                  "mandatory": true,
+                  "type": "TextField"
+                },
+                {
+                  "id": "last-name",
+                  "label": "Last name",
+                  "mandatory": true,
+                  "type": "TextField"
+                }
+              ]
+            }
+          },
+          "remove_block": {
+            "id": "remove-person",
+            "type": "ListRemoveQuestion",
+            "question": {
+              "id": "remove-question",
+              "type": "General",
+              "title": "Are you sure you want to remove this person?",
+              "answers": [{
+                "id": "remove-confirmation",
+                "mandatory": true,
+                "type": "Radio",
+                "options": [{
+                    "label": "Yeah",
+                    "value": "Yeah"
+                  },
+                  {
+                    "label": "No",
+                    "value": "No"
+                  }
+                ]
+              }]
+            }
+          }
+        },
+        {
+          "type": "RelationshipCollector",
+          "id": "relationships",
+          "title": "This will iterate over the people list, capturing the one way relationships.",
+          "for_list": "people",
+          "question": {
+            "id": "relationship-question",
+            "type": "General",
+            "title": "Thinking of {first_person_name}, {second_person_name} is their <em>...</em>",
+            "answers": [{
+              "id": "relationship-answer",
+              "mandatory": true,
+              "type": "Relationship",
+              "playback": "{second_person_name} is {first_person_name} <em>…</em>",
+              "options": [{
+                  "value": "Husband or Wife",
+                  "label": "Husband or Wife",
+                  "title": "Thinking of {first_person_name}, {second_person_name} is their <em>husband or wife</em>",
+                  "playback": "{second_person_name} is {first_person_name} <em>husband or wife</em>"
+                },
+                {
+                  "value": "Legally Registered Civil Partner",
+                  "label": "Legally Registered Civil Partner",
+                  "title": "Thinking of {first_person_name}, {second_person_name} is their <em>legally registered civil partner</em>",
+                  "playback": "{second_person_name} is {first_person_name} <em>legally registered civil partner</em>"
+                }
+              ]
+            }]
+          }
+        },
+        {
+          "type": "Confirmation",
+          "id": "confirmation",
+          "content": {
+            "title": "Thank you for your answers, do you wish to submit"
+          }
+        }
+      ]
+    }]
+  }]
+}

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -533,6 +533,33 @@ def test_invalid_list_name_in_when_rule():
     check_validation_errors(filename, expected_error_messages)
 
 
+def test_invalid_relationship_no_list_specified():
+    filename = 'schemas/invalid/test_invalid_relationship_list_doesnt_exist.json'
+    expected_error_message = [
+        "Schema Integrity Error. for_list 'not-a-list' in RelationshipCollector is not populated by any ListCollector blocks",
+    ]
+
+    check_validation_errors(filename, expected_error_message)
+
+
+def test_invalid_relationship_multiple_answers():
+    filename = 'schemas/invalid/test_invalid_relationship_multiple_answers.json'
+    expected_error_message = [
+        'Schema Integrity Error. RelationshipCollector contains more than one answer.'
+    ]
+
+    check_validation_errors(filename, expected_error_message)
+
+
+def test_invalid_relationship_wrong_answer_type():
+    filename = 'schemas/invalid/test_invalid_relationship_wrong_answer_type.json'
+    expected_error_message = [
+        'Schema Integrity Error. Ony answers of type Relationship are valid in RelationshipCollector blocks.'
+    ]
+
+    check_validation_errors(filename, expected_error_message)
+
+
 def test_invalid_hub_and_spoke_with_summary_confirmation():
     filename = 'schemas/invalid/test_invalid_hub_and_spoke_with_summary_confirmation.json'
     expected_error_messages = [


### PR DESCRIPTION
#### This PR adds new schema definitions to support the collection of relationships in surveys.

There are two new definitions:
1) `/schemas/blocks/relationships_collector.json` uses a new enum, `RelationshipsCollector`, and uses a new mandatory `list` property. This is the id of the list that contains the list items for which relationships need to be collected.
2) `/schemas/answers/relationships.json` defines new answer options properties `relationships_title` sand `relationships_playback` that are unique to and mandatory for relationships answers.