### PR TITLE
Rename 'populates_list' to 'for_list'

### DIFF
--- a/app/validation/validator.py
+++ b/app/validation/validator.py
@@ -519,7 +519,7 @@ class Validator:  # pylint: disable=too-many-lines
         - Enforce the same answer_ids on add and edit sub-blocks
         """
         errors = []
-        list_name = block['populates_list']
+        list_name = block['for_list']
 
         add_block_questions = self._get_all_questions_for_block(block['add_block'])
         edit_block_questions = self._get_all_questions_for_block(block['edit_block'])
@@ -549,7 +549,7 @@ class Validator:  # pylint: disable=too-many-lines
         - Ensure that answer_ids on add blocks match between all blocks that populate a single list.
         """
         errors = []
-        list_name = block['populates_list']
+        list_name = block['for_list']
 
         add_or_edit_block_questions = self._get_all_questions_for_block(block['add_or_edit_block'])
 
@@ -1364,7 +1364,7 @@ class Validator:  # pylint: disable=too-many-lines
             for group in section['groups']:
                 for block in group['blocks']:
                     if block['type'] == 'ListCollector':
-                        list_names.append(block['populates_list'])
+                        list_names.append(block['for_list'])
         return list_names
 
     class CoreStructureError(Exception):

--- a/schemas/blocks/list_collector.json
+++ b/schemas/blocks/list_collector.json
@@ -28,7 +28,7 @@
         "type": "string",
         "enum": ["ListCollector"]
       },
-      "populates_list": {
+      "for_list": {
         "type": "string"
       },
       "add_answer": {
@@ -57,7 +57,7 @@
     "required": [
       "id",
       "type",
-      "populates_list",
+      "for_list",
       "add_answer",
       "remove_answer",
       "add_block",

--- a/schemas/blocks/primary_person_list_collector.json
+++ b/schemas/blocks/primary_person_list_collector.json
@@ -28,7 +28,7 @@
         "type": "string",
         "enum": ["PrimaryPersonListCollector"]
       },
-      "populates_list": {
+      "for_list": {
         "type": "string"
       },
       "add_or_edit_answer": {
@@ -48,7 +48,7 @@
     "required": [
       "id",
       "type",
-      "populates_list",
+      "for_list",
       "add_or_edit_answer",
       "add_or_edit_block"
     ],

--- a/tests/schemas/invalid/test_invalid_list_collector_bad_answer_reference_ids.json
+++ b/tests/schemas/invalid/test_invalid_list_collector_bad_answer_reference_ids.json
@@ -24,7 +24,7 @@
       "blocks": [{
         "id": "list-collector",
         "type": "ListCollector",
-        "populates_list": "people",
+        "for_list": "people",
         "add_answer": {
           "id": "someone-else",
           "value": "Yes"
@@ -114,7 +114,7 @@
       }, {
         "id": "another-list-collector",
         "type": "ListCollector",
-        "populates_list": "people",
+        "for_list": "people",
         "add_answer": {
           "id": "another-anyone-else",
           "value": "Yes"

--- a/tests/schemas/invalid/test_invalid_list_collector_bad_sub_block_types.json
+++ b/tests/schemas/invalid/test_invalid_list_collector_bad_sub_block_types.json
@@ -24,7 +24,7 @@
       "blocks": [{
         "id": "list-collector",
         "type": "ListCollector",
-        "populates_list": "people",
+        "for_list": "people",
         "add_answer": {
           "id": "anyone-else",
           "value": "Yes"
@@ -114,7 +114,7 @@
       }, {
         "id": "another-list-collector",
         "type": "ListCollector",
-        "populates_list": "people",
+        "for_list": "people",
         "add_answer": {
           "id": "another-anyone-else",
           "value": "Yes"

--- a/tests/schemas/invalid/test_invalid_list_collector_duplicate_ids_multiple_collectors.json
+++ b/tests/schemas/invalid/test_invalid_list_collector_duplicate_ids_multiple_collectors.json
@@ -24,7 +24,7 @@
       "blocks": [{
         "id": "list-collector",
         "type": "ListCollector",
-        "populates_list": "people",
+        "for_list": "people",
         "add_answer": {
           "id": "anyone-else",
           "value": "Yes"
@@ -114,7 +114,7 @@
       }, {
         "id": "another-list-collector",
         "type": "ListCollector",
-        "populates_list": "people",
+        "for_list": "people",
         "add_answer": {
           "id": "another-anyone-else",
           "value": "Yes"

--- a/tests/schemas/invalid/test_invalid_list_collector_non_radio.json
+++ b/tests/schemas/invalid/test_invalid_list_collector_non_radio.json
@@ -24,7 +24,7 @@
       "blocks": [{
         "id": "list-collector",
         "type": "ListCollector",
-        "populates_list": "people",
+        "for_list": "people",
         "add_answer": {
           "id": "anyone-else",
           "value": "Yes"

--- a/tests/schemas/invalid/test_invalid_list_collector_with_different_add_block_answer_ids.json
+++ b/tests/schemas/invalid/test_invalid_list_collector_with_different_add_block_answer_ids.json
@@ -24,7 +24,7 @@
       "blocks": [{
         "id": "list-collector",
         "type": "ListCollector",
-        "populates_list": "people",
+        "for_list": "people",
         "add_answer": {
           "id": "anyone-else",
           "value": "Yes"
@@ -114,7 +114,7 @@
       }, {
         "id": "another-list-collector",
         "type": "ListCollector",
-        "populates_list": "people",
+        "for_list": "people",
         "add_answer": {
           "id": "another-anyone-else",
           "value": "Yes"

--- a/tests/schemas/invalid/test_invalid_list_collector_with_different_answer_ids_in_add_and_edit.json
+++ b/tests/schemas/invalid/test_invalid_list_collector_with_different_answer_ids_in_add_and_edit.json
@@ -24,7 +24,7 @@
       "blocks": [{
         "id": "list-collector",
         "type": "ListCollector",
-        "populates_list": "people",
+        "for_list": "people",
         "add_answer": {
           "id": "anyone-else",
           "value": "Yes"

--- a/tests/schemas/invalid/test_invalid_list_collector_with_no_add_option.json
+++ b/tests/schemas/invalid/test_invalid_list_collector_with_no_add_option.json
@@ -24,7 +24,7 @@
       "blocks": [{
         "id": "list-collector",
         "type": "ListCollector",
-        "populates_list": "people",
+        "for_list": "people",
         "add_answer": {
           "id": "anyone-else",
           "value": "SomethingElse"

--- a/tests/schemas/invalid/test_invalid_list_collector_with_routing.json
+++ b/tests/schemas/invalid/test_invalid_list_collector_with_routing.json
@@ -24,7 +24,7 @@
       "blocks": [{
         "id": "list-collector",
         "type": "ListCollector",
-        "populates_list": "people",
+        "for_list": "people",
         "add_answer": {
           "id": "anyone-else",
           "value": "Yes"

--- a/tests/schemas/invalid/test_invalid_primary_person_list_collector_add_block.json
+++ b/tests/schemas/invalid/test_invalid_primary_person_list_collector_add_block.json
@@ -24,7 +24,7 @@
       "blocks": [{
         "id": "primary-person-list-collector",
         "type": "PrimaryPersonListCollector",
-        "populates_list": "people",
+        "for_list": "people",
         "add_or_edit_answer": {
           "id": "you-live-here",
           "value": "Yes"

--- a/tests/schemas/invalid/test_invalid_primary_person_list_collector_bad_answer_id.json
+++ b/tests/schemas/invalid/test_invalid_primary_person_list_collector_bad_answer_id.json
@@ -24,7 +24,7 @@
       "blocks": [{
         "id": "primary-person-list-collector",
         "type": "PrimaryPersonListCollector",
-        "populates_list": "people",
+        "for_list": "people",
         "add_or_edit_answer": {
           "id": "fake-answer-id",
           "value": "Yes"

--- a/tests/schemas/invalid/test_invalid_primary_person_list_collector_bad_answer_value.json
+++ b/tests/schemas/invalid/test_invalid_primary_person_list_collector_bad_answer_value.json
@@ -24,7 +24,7 @@
       "blocks": [{
         "id": "primary-person-list-collector",
         "type": "PrimaryPersonListCollector",
-        "populates_list": "people",
+        "for_list": "people",
         "add_or_edit_answer": {
           "id": "you-live-here",
           "value": "I do"

--- a/tests/schemas/invalid/test_invalid_primary_person_list_collector_different_answer_ids_multi_collectors.json
+++ b/tests/schemas/invalid/test_invalid_primary_person_list_collector_different_answer_ids_multi_collectors.json
@@ -24,7 +24,7 @@
       "blocks": [{
           "id": "primary-person-list-collector",
           "type": "PrimaryPersonListCollector",
-          "populates_list": "people",
+          "for_list": "people",
           "add_or_edit_answer": {
             "id": "you-live-here",
             "value": "Yes"
@@ -69,7 +69,7 @@
         }, {
           "id": "primary-person-list-collector2",
           "type": "PrimaryPersonListCollector",
-          "populates_list": "people",
+          "for_list": "people",
           "add_or_edit_answer": {
             "id": "you-live-here2",
             "value": "Yes"

--- a/tests/schemas/invalid/test_invalid_primary_person_list_collector_no_radio.json
+++ b/tests/schemas/invalid/test_invalid_primary_person_list_collector_no_radio.json
@@ -24,7 +24,7 @@
       "blocks": [{
         "id": "primary-person-list-collector",
         "type": "PrimaryPersonListCollector",
-        "populates_list": "people",
+        "for_list": "people",
         "add_or_edit_answer": {
           "id": "you-live-here",
           "value": "Yes"

--- a/tests/schemas/invalid/test_invalid_primary_person_list_collector_routing.json
+++ b/tests/schemas/invalid/test_invalid_primary_person_list_collector_routing.json
@@ -24,7 +24,7 @@
       "blocks": [{
         "id": "primary-person-list-collector",
         "type": "PrimaryPersonListCollector",
-        "populates_list": "people",
+        "for_list": "people",
         "add_or_edit_answer": {
           "id": "you-live-here",
           "value": "Yes"

--- a/tests/schemas/invalid/test_invalid_relationship_multiple_answers.json
+++ b/tests/schemas/invalid/test_invalid_relationship_multiple_answers.json
@@ -28,7 +28,7 @@
       "blocks": [{
           "id": "list-collector",
           "type": "ListCollector",
-          "populates_list": "people",
+          "for_list": "people",
           "add_answer": {
             "id": "anyone-else",
             "value": "Yes"

--- a/tests/schemas/invalid/test_invalid_relationship_no_list_specified.json
+++ b/tests/schemas/invalid/test_invalid_relationship_no_list_specified.json
@@ -28,7 +28,7 @@
       "blocks": [{
           "id": "list-collector",
           "type": "ListCollector",
-          "populates_list": "people",
+          "for_list": "people",
           "add_answer": {
             "id": "anyone-else",
             "value": "Yes"

--- a/tests/schemas/invalid/test_invalid_relationship_wrong_answer_type.json
+++ b/tests/schemas/invalid/test_invalid_relationship_wrong_answer_type.json
@@ -28,7 +28,7 @@
       "blocks": [{
           "id": "list-collector",
           "type": "ListCollector",
-          "populates_list": "people",
+          "for_list": "people",
           "add_answer": {
             "id": "anyone-else",
             "value": "Yes"

--- a/tests/schemas/valid/test_list_collector.json
+++ b/tests/schemas/valid/test_list_collector.json
@@ -24,7 +24,7 @@
       "blocks": [{
         "id": "list-collector",
         "type": "ListCollector",
-        "populates_list": "people",
+        "for_list": "people",
         "add_answer": {
           "id": "anyone-else",
           "value": "Yes"
@@ -114,7 +114,7 @@
       }, {
         "id": "another-list-collector",
         "type": "ListCollector",
-        "populates_list": "people",
+        "for_list": "people",
         "add_answer": {
           "id": "another-anyone-else",
           "value": "Yes"

--- a/tests/schemas/valid/test_primary_person_list_collector.json
+++ b/tests/schemas/valid/test_primary_person_list_collector.json
@@ -24,7 +24,7 @@
       "blocks": [{
         "id": "primary-person-list-collector",
         "type": "PrimaryPersonListCollector",
-        "populates_list": "people",
+        "for_list": "people",
         "add_or_edit_answer": {
           "id": "you-live-here",
           "value": "Yes"

--- a/tests/schemas/valid/test_relationship_collector.json
+++ b/tests/schemas/valid/test_relationship_collector.json
@@ -28,7 +28,7 @@
       "blocks": [{
           "id": "list-collector",
           "type": "ListCollector",
-          "populates_list": "people",
+          "for_list": "people",
           "add_answer": {
             "id": "anyone-else",
             "value": "Yes"


### PR DESCRIPTION
To align with RelationshipCollector schema, ListCollector and PrimaryPersonListCollector  now uses `for_list` instead of `populates_list`.


### How to review

Ensure:
- No change in behaviour, everything works as expected.