### PR TITLE
Remove check for placeholders on non-mandatory answers

### DIFF
--- a/app/validation/validator.py
+++ b/app/validation/validator.py
@@ -1228,13 +1228,7 @@ class Validator:  # pylint: disable=too-many-lines
                     answer_id_to_validate,
                     placeholder_definition['placeholder']
                 )))
-                continue
 
-            answer = answers_with_parent_ids[answer_id_to_validate]['answer']
-            if not answer.get('mandatory'):
-                msg = (f'Placeholder references a non-mandatory answer `{answer_id_to_validate}`'
-                       f' for placeholder `{placeholder_definition["placeholder"]}`.')
-                errors.append(self._error_message(msg))
         return errors
 
     def _validate_placeholder_metadata_ids(self, valid_metadata_ids, metadata_ids_to_validate, placeholder_name):

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -314,17 +314,6 @@ def test_invalid_placeholder_answer_ids():
     check_validation_errors(filename, expected_error_messages)
 
 
-def test_invalid_placeholder_not_mandatory():
-    filename = 'schemas/invalid/test_invalid_placeholder_question_not_mandatory.json'
-
-    expected_error_messages = [
-        'Schema Integrity Error. Placeholder references a non-mandatory answer `ref-answer0-1` for placeholder `simple_answer`.',
-        'Schema Integrity Error. Placeholder references a non-mandatory answer `ref-answer0-2-detail` for placeholder `detail_answer`.'
-    ]
-
-    check_validation_errors(filename, expected_error_messages)
-
-
 def test_single_variant_invalid():
     file_name = 'schemas/invalid/test_invalid_single_variant.json'
     json_to_validate = _open_and_load_schema_file(file_name)


### PR DESCRIPTION
Runner uses the pattern of an optional question with a
ConfirmationQuestion and later questions using the piped
answer quite often, the change being reverted does not allow
this pattern. See for example `test_confirmation.json`.

Ideally, the routing path should be worked out in validator
to allow it to check whether the piped answer will only be
displayed if the question has been answered. 

Adding the routing path is a fairly substantial piece of work, so to get things moving, I am removing the check in this PR and raising a card to manage it properly.

New trello card: https://trello.com/c/Oditc3Ne/3181-calculate-the-routing-path-in-validator