### PR TITLE
Add Location Comparisons to when rules

### DIFF
--- a/schemas/when_rule/compare_to_answer_store.json
+++ b/schemas/when_rule/compare_to_answer_store.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema",
   "type": "object",
-  "description": "Checks if the answer is answered or not answered",
+  "description": "Comparison against an answer",
   "properties": {
     "id": {
       "$ref": "definitions.json#/answer_identifier"

--- a/schemas/when_rule/compare_to_location.json
+++ b/schemas/when_rule/compare_to_location.json
@@ -1,30 +1,29 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema",
   "type": "object",
-  "description": "Comparison against a list count",
+  "description": "Comparison against a location object",
   "properties": {
+    "id_selector": {
+      "$ref": "definitions.json#/id_selector"
+    },
     "list": {
       "$ref": "definitions.json#/list"
     },
+    "comparison": {
+      "$ref": "definitions.json#/location_comparison_object"
+    },
     "condition": {
       "enum": [
-        "equals",
         "not equals",
-        "greater than",
-        "less than",
-        "greater than or equal to",
-        "less than or equal to"
+        "equals"
       ]
-    },
-    "value": {
-      "type": "integer",
-      "description": "The value to compare against"
     }
   },
   "required": [
+    "id_selector",
     "list",
     "condition",
-    "value"
+    "comparison"
   ],
   "additionalProperties": false
 }

--- a/schemas/when_rule/compare_to_multiple_values.json
+++ b/schemas/when_rule/compare_to_multiple_values.json
@@ -20,8 +20,8 @@
     "values": {
       "$ref": "definitions.json#/comparison_values"
     },
-    "comparison_id": {
-      "$ref": "definitions.json#/comparison_identifier"
+    "comparison": {
+      "$ref": "definitions.json#/answer_comparison_object"
     }
   },
   "required": [
@@ -51,7 +51,7 @@
         },
         {
           "required": [
-            "comparison_id"
+            "comparison"
           ]
         }
       ]

--- a/schemas/when_rule/compare_to_value.json
+++ b/schemas/when_rule/compare_to_value.json
@@ -24,8 +24,8 @@
     "value": {
       "$ref": "definitions.json#/comparison_value"
     },
-    "comparison_id": {
-      "$ref": "definitions.json#/comparison_identifier"
+    "comparison": {
+      "$ref": "definitions.json#/answer_comparison_object"
     },
     "date_comparison": {
       "$ref": "definitions.json#/date_comparison_value"
@@ -58,7 +58,7 @@
         },
         {
           "required": [
-            "comparison_id"
+            "comparison"
           ]
         },
         {

--- a/schemas/when_rule/definitions.json
+++ b/schemas/when_rule/definitions.json
@@ -8,6 +8,9 @@
           "$ref": "compare_to_value.json"
         },
         {
+          "$ref": "compare_to_location.json"
+        },
+        {
           "$ref": "compare_to_multiple_values.json"
         },
         {
@@ -23,6 +26,10 @@
   "answer_identifier": {
     "type": "string",
     "description": "The id of an answer from which to obtain the value"
+  },
+  "location_identifier": {
+    "type": "string",
+    "description": "The id of a location attribute from which to obtain the value"
   },
   "metadata_identifier": {
     "type": "string",
@@ -41,9 +48,35 @@
     "description": "An array of values to compare against",
     "minItems": 1
   },
-  "comparison_identifier": {
-    "type": "string",
-    "description": "The id of an answer from which to obtain the value and compare to"
+  "answer_comparison_object": {
+    "type": "object",
+    "description": "The answer object from which to obtain the value and compare to",
+    "additionalProperties": false,
+    "properties": {
+      "id": {
+        "$ref": "definitions.json#/answer_identifier"
+      },
+      "source": {
+        "type": "string",
+        "enum": ["answers"]
+      }
+    },
+    "required": ["id", "source"]
+  },
+  "location_comparison_object": {
+    "type": "object",
+    "description": "The location object from which to obtain the value and compare to",
+    "additionalProperties": false,
+    "properties": {
+      "id": {
+        "$ref": "definitions.json#/location_identifier"
+      },
+      "source": {
+        "type": "string",
+        "enum": ["location"]
+      }
+    },
+    "required": ["id", "source"]
   },
   "date_comparison_value": {
     "type": "object",
@@ -80,5 +113,13 @@
         ]
       }
     ]
+  },
+  "list": {
+    "type": "string",
+    "description": "The name of a list"
+  },
+  "id_selector": {
+    "type": "string",
+    "description": "The attribute to use from the list as the identifier"
   }
 }

--- a/tests/schemas/invalid/test_invalid_answer_comparison_id.json
+++ b/tests/schemas/invalid/test_invalid_answer_comparison_id.json
@@ -58,7 +58,10 @@
             "when": [{
               "id": "route-comparison-2-answer",
               "condition": "greater than",
-              "comparison_id": "bad-answer-id-2"
+              "comparison": {
+                "id": "bad-answer-id-2",
+                "source": "answers"
+              }
             }]
           }
         }, {
@@ -117,7 +120,10 @@
           "when": [{
             "id": "comparison-1-answer",
             "condition": "not equals",
-            "comparison_id": "bad-answer-id-3"
+            "comparison": {
+              "id": "bad-answer-id-3",
+              "source": "answers"
+            }
           }]
         }],
         "content": {
@@ -130,13 +136,19 @@
           "when": [{
             "id": "comparison-1-answer",
             "condition": "greater than",
-            "comparison_id": "bad-answer-id-4"
+            "comparison": {
+              "id": "bad-answer-id-4",
+              "source": "answers"
+            }
           }]
         }, {
           "when": [{
             "id": "comparison-1-answer",
             "condition": "equals",
-            "comparison_id": "bad-answer-id-5"
+            "comparison": {
+              "id": "bad-answer-id-5",
+              "source": "answers"
+            }
           }]
         }],
         "content": {
@@ -149,13 +161,19 @@
           "when": [{
             "id": "comparison-1-answer",
             "condition": "less than",
-            "comparison_id": "bad-answer-id-6"
+            "comparison": {
+              "id": "bad-answer-id-6",
+              "source": "answers"
+            }
           }]
         }, {
           "when": [{
             "id": "bad-answer-id-7",
             "condition": "equals",
-            "comparison_id": "comparison-2-answer"
+            "comparison": {
+              "id": "comparison-2-answer",
+              "source": "answers"
+            }
           }]
         }],
         "content": {

--- a/tests/schemas/invalid/test_invalid_answer_comparison_types.json
+++ b/tests/schemas/invalid/test_invalid_answer_comparison_types.json
@@ -58,11 +58,17 @@
             "when": [{
               "id": "route-comparison-2-answer",
               "condition": "greater than",
-              "comparison_id": "route-comparison-1-answer"
+              "comparison": {
+                "id": "route-comparison-1-answer",
+                "source": "answers"
+              }
             }, {
               "id": "route-comparison-1-answer",
               "condition": "equals any",
-              "comparison_id": "route-comparison-2-answer"
+              "comparison": {
+                "id": "route-comparison-2-answer",
+                "source": "answers"
+              }
             }]
           }
         }, {
@@ -133,7 +139,10 @@
           "when": [{
             "id": "comparison-1-answer",
             "condition": "not equals",
-            "comparison_id": "comparison-1-answer"
+            "comparison": {
+              "id": "comparison-1-answer",
+              "source": "answers"
+            }
           }]
         }, {
           "question": {
@@ -151,7 +160,10 @@
           "when": [{
             "id": "comparison-1-answer",
             "condition": "equals",
-            "comparison_id": "comparison-1-answer"
+            "comparison": {
+              "id": "comparison-1-answer",
+              "source": "answers"
+            }
           }]
         }]
       }, {
@@ -164,7 +176,10 @@
           "when": [{
             "id": "comparison-1-answer",
             "condition": "not equals",
-            "comparison_id": "comparison-2-answer"
+            "comparison": {
+              "id": "comparison-2-answer",
+              "source": "answers"
+            }
           }]
         }]
       }, {
@@ -177,13 +192,19 @@
           "when": [{
             "id": "comparison-1-answer",
             "condition": "greater than",
-            "comparison_id": "comparison-2-answer"
+            "comparison": {
+              "id": "comparison-2-answer",
+              "source": "answers"
+            }
           }]
         }, {
           "when": [{
             "id": "comparison-1-answer",
             "condition": "equals",
-            "comparison_id": "comparison-2-answer"
+            "comparison": {
+              "id": "comparison-2-answer",
+              "source": "answers"
+            }
           }]
         }]
       }],

--- a/tests/schemas/invalid/test_invalid_when_comparison_list.json
+++ b/tests/schemas/invalid/test_invalid_when_comparison_list.json
@@ -1,0 +1,96 @@
+{
+  "mime_type": "application/json/ons/eq",
+  "schema_version": "0.0.1",
+  "data_version": "0.0.3",
+  "survey_id": "001",
+  "title": "Test Routing Location Comparisons",
+  "theme": "default",
+  "legal_basis": "StatisticsOfTradeAct",
+  "description": "A test survey for routing based comparison with a location",
+  "metadata": [{
+      "name": "user_id",
+      "type": "string"
+    },
+    {
+      "name": "period_id",
+      "type": "string"
+    },
+    {
+      "name": "ru_name",
+      "type": "string"
+    }
+  ],
+  "sections": [{
+    "id": "default-section",
+    "groups": [{
+        "id": "route-group",
+        "title": "",
+        "blocks": [{
+            "type": "Question",
+            "id": "route-comparison-1",
+            "question": {
+              "answers": [{
+                "id": "route-comparison-1-answer",
+                "label": "Number",
+                "mandatory": true,
+                "type": "Number"
+              }],
+              "description": "",
+              "id": "route-comparison-1-question",
+              "title": "Enter a number",
+              "type": "General"
+            },
+            "routing_rules": [{
+                "goto": {
+                  "block": "route-comparison-3",
+                  "when": [{
+                    "list": "people",
+                    "id_selector": "primary_person",
+                    "condition": "equals",
+                    "comparison": {
+                      "id": "from_list_item_id",
+                      "source": "location"
+                    }
+                  }]
+                }
+              },
+              {
+                "goto": {
+                  "block": "route-comparison-3"
+                }
+              }
+            ]
+          },
+          {
+            "type": "Interstitial",
+            "id": "route-comparison-2",
+            "content": {
+              "title": "You are not the primary person",
+              "contents": [{
+                "description": "This page should be skipped if you are identified as the primary person in the household"
+              }]
+            }
+          },
+          {
+            "type": "Interstitial",
+            "id": "route-comparison-3",
+            "content": {
+              "title": "This will be shown to all household members",
+              "contents": [{
+                "description": "This page should never be skipped"
+              }]
+            }
+          }
+        ]
+      },
+      {
+        "id": "summary-group",
+        "title": "",
+        "blocks": [{
+          "type": "Summary",
+          "id": "summary"
+        }]
+      }
+    ]
+  }]
+}

--- a/tests/schemas/invalid/test_invalid_when_condition_property.json
+++ b/tests/schemas/invalid/test_invalid_when_condition_property.json
@@ -88,7 +88,10 @@
             "when": [{
               "id": "country-checkbox-answer",
               "condition": "contains any",
-              "comparison_id": "country-checkbox-answer2"
+              "comparison": {
+                "id": "country-checkbox-answer2",
+                "source": "answers"
+              }
             }]
           }
         }, {

--- a/tests/schemas/valid/test_when_location_comparison.json
+++ b/tests/schemas/valid/test_when_location_comparison.json
@@ -1,0 +1,195 @@
+{
+  "mime_type": "application/json/ons/eq",
+  "schema_version": "0.0.1",
+  "data_version": "0.0.3",
+  "survey_id": "001",
+  "title": "Test Routing Location Comparisons",
+  "theme": "default",
+  "legal_basis": "StatisticsOfTradeAct",
+  "description": "A test survey for routing based comparison with a location",
+  "metadata": [{
+      "name": "user_id",
+      "type": "string"
+    },
+    {
+      "name": "period_id",
+      "type": "string"
+    },
+    {
+      "name": "ru_name",
+      "type": "string"
+    }
+  ],
+  "sections": [{
+      "id": "section",
+      "groups": [{
+        "id": "group",
+        "title": "List",
+        "blocks": [{
+          "id": "list-collector",
+          "type": "ListCollector",
+          "for_list": "people",
+          "add_answer": {
+            "id": "anyone-else",
+            "value": "Yes"
+          },
+          "remove_answer": {
+            "id": "remove-confirmation",
+            "value": "Yeah"
+          },
+          "question": {
+            "id": "confirmation-question",
+            "type": "General",
+            "title": "Does anyone else live here?",
+            "answers": [{
+              "id": "anyone-else",
+              "mandatory": true,
+              "type": "Radio",
+              "options": [{
+                "label": "Yes",
+                "value": "Yes"
+              }, {
+                "label": "No",
+                "value": "No"
+              }]
+            }]
+          },
+          "add_block": {
+            "id": "add-person",
+            "type": "ListAddQuestion",
+            "question": {
+              "id": "add-question",
+              "type": "General",
+              "title": "What is the name of the person?",
+              "answers": [{
+                "id": "first-name",
+                "label": "First name",
+                "mandatory": true,
+                "type": "TextField"
+              }, {
+                "id": "last-name",
+                "label": "Last name",
+                "mandatory": true,
+                "type": "TextField"
+              }]
+            }
+          },
+          "edit_block": {
+            "id": "edit-person",
+            "type": "ListEditQuestion",
+            "question": {
+              "id": "edit-question",
+              "type": "General",
+              "title": "What is the name of the person?",
+              "answers": [{
+                "id": "first-name",
+                "label": "First name",
+                "mandatory": true,
+                "type": "TextField"
+              }, {
+                "id": "last-name",
+                "label": "Last name",
+                "mandatory": true,
+                "type": "TextField"
+              }]
+            }
+          },
+          "remove_block": {
+            "id": "remove-person",
+            "type": "ListRemoveQuestion",
+            "question": {
+              "id": "remove-question",
+              "type": "General",
+              "title": "Are you sure you want to remove this person?",
+              "answers": [{
+                "id": "remove-confirmation",
+                "mandatory": true,
+                "type": "Radio",
+                "options": [{
+                  "label": "Yeah",
+                  "value": "Yeah"
+                }, {
+                  "label": "No",
+                  "value": "No"
+                }]
+              }]
+            }
+          }
+        }]
+      }]
+    },
+    {
+      "id": "default-section",
+      "groups": [{
+          "id": "route-group",
+          "title": "",
+          "blocks": [{
+              "type": "Question",
+              "id": "route-comparison-1",
+              "question": {
+                "answers": [{
+                  "id": "route-comparison-1-answer",
+                  "label": "Number",
+                  "mandatory": true,
+                  "type": "Number"
+                }],
+                "description": "",
+                "id": "route-comparison-1-question",
+                "title": "Enter a number",
+                "type": "General"
+              },
+              "routing_rules": [{
+                  "goto": {
+                    "block": "route-comparison-3",
+                    "when": [{
+                      "list": "people",
+                      "id_selector": "primary_person",
+                      "condition": "equals",
+                      "comparison": {
+                        "id": "from_list_item_id",
+                        "source": "location"
+                      }
+                    }]
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "route-comparison-3"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "Interstitial",
+              "id": "route-comparison-2",
+              "content": {
+                "title": "You are not the primary person",
+                "contents": [{
+                  "description": "This page should be skipped if you are identified as the primary person in the household"
+                }]
+              }
+            },
+            {
+              "type": "Interstitial",
+              "id": "route-comparison-3",
+              "content": {
+                "title": "This will be shown to all household members",
+                "contents": [{
+                  "description": "This page should never be skipped"
+                }]
+              }
+            }
+          ]
+        },
+        {
+          "id": "summary-group",
+          "title": "",
+          "blocks": [{
+            "type": "Summary",
+            "id": "summary"
+          }]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -52,7 +52,7 @@ def check_validation_errors(filename, expected_validation_error_messages, expect
 
     assert len(validation_errors) == expected_number_validation_errors
 
-    return (validation_errors, schema_errors)
+    return validation_errors, schema_errors
 
 
 def test_param_valid_schemas(valid_schema_filename):
@@ -85,8 +85,8 @@ def test_invalid_schema_block():
         'default not defined for answer [conditional-routing-answer] '
         "missing options ['no']",
 
-        'Schema Integrity Error. The answer id - AnAnswerThatDoesNotExist in the id '
-        'key of the "when" clause for response-yes does not exist',
+        'Schema Integrity Error. The answer id - AnAnswerThatDoesNotExist in the id key of the '
+        '"when" clause for response-yes does not exist',
     ]
 
     check_validation_errors(filename, expected_error_messages)
@@ -225,19 +225,19 @@ def test_answer_comparisons_different_types():
     filename = 'schemas/invalid/test_invalid_answer_comparison_types.json'
 
     expected_error_messages = [
-        'Schema Integrity Error. The answers used as comparison_id `route-comparison-1-answer` and answer_id `route-comparison-2-answer` '
+        'Schema Integrity Error. The answers used as comparison id `route-comparison-1-answer` and answer_id `route-comparison-2-answer` '
         'in the `when` clause for `route-comparison-2` have different types',
 
-        'Schema Integrity Error. The comparison_id `route-comparison-2-answer` is not of answer type `Checkbox`. '
+        'Schema Integrity Error. The comparison id `route-comparison-2-answer` is not of answer type `Checkbox`. '
         'The condition `equals any` can only reference `Checkbox` answers when using `comparison id`',
 
-        'Schema Integrity Error. The answers used as comparison_id `comparison-2-answer` and answer_id `comparison-1-answer` in the `when` '
+        'Schema Integrity Error. The answers used as comparison id `comparison-2-answer` and answer_id `comparison-1-answer` in the `when` '
         'clause for `equals-answers` have different types',
 
-        'Schema Integrity Error. The answers used as comparison_id `comparison-2-answer` and answer_id `comparison-1-answer` in the `when` '
+        'Schema Integrity Error. The answers used as comparison id `comparison-2-answer` and answer_id `comparison-1-answer` in the `when` '
         'clause for `less-than-answers` have different types',
 
-        'Schema Integrity Error. The answers used as comparison_id `comparison-2-answer` and answer_id `comparison-1-answer` in the `when` '
+        'Schema Integrity Error. The answers used as comparison id `comparison-2-answer` and answer_id `comparison-1-answer` in the `when` '
         'clause for `less-than-answers` have different types',
     ]
 
@@ -249,15 +249,15 @@ def test_answer_comparisons_invalid_comparison_id():
     filename = 'schemas/invalid/test_invalid_answer_comparison_id.json'
 
     expected_error_messages = [
-        'Schema Integrity Error. The answer id - bad-answer-id-2 in the comparison_id key of the "when" '
+        'Schema Integrity Error. The answer id - bad-answer-id-2 in the comparison.id key of the "when" '
         'clause for route-comparison-2 does not exist',
-        'Schema Integrity Error. The answer id - bad-answer-id-3 in the comparison_id key of the "when" '
+        'Schema Integrity Error. The answer id - bad-answer-id-3 in the comparison.id key of the "when" '
         'clause for equals-answers does not exist',
-        'Schema Integrity Error. The answer id - bad-answer-id-4 in the comparison_id key of the "when" '
+        'Schema Integrity Error. The answer id - bad-answer-id-4 in the comparison.id key of the "when" '
         'clause for less-than-answers does not exist',
-        'Schema Integrity Error. The answer id - bad-answer-id-5 in the comparison_id key of the "when" '
+        'Schema Integrity Error. The answer id - bad-answer-id-5 in the comparison.id key of the "when" '
         'clause for less-than-answers does not exist',
-        'Schema Integrity Error. The answer id - bad-answer-id-6 in the comparison_id key of the "when" '
+        'Schema Integrity Error. The answer id - bad-answer-id-6 in the comparison.id key of the "when" '
         'clause for greater-than-answers does not exist',
         'Schema Integrity Error. The answer id - bad-answer-id-7 in the id key of the "when" '
         'clause for greater-than-answers does not exist',
@@ -505,7 +505,7 @@ def test_invalid_when_condition_property():
     error_messages = [error['message'] for error in validation_errors]
 
     fuzzy_error_messages = [
-        'Schema Integrity Error. The comparison_id `country-checkbox-answer2` is not of answer type `Checkbox`. '
+        'Schema Integrity Error. The comparison id `country-checkbox-answer2` is not of answer type `Checkbox`. '
         'The condition `contains any` can only reference `Checkbox` answers when using `comparison id`',
 
         'Schema Integrity Error. The condition `equals any` cannot be used with `Checkbox` answer type.'
@@ -568,7 +568,7 @@ def test_invalid_relationship_multiple_answers():
 def test_invalid_relationship_wrong_answer_type():
     filename = 'schemas/invalid/test_invalid_relationship_wrong_answer_type.json'
     expected_error_message = [
-        'Schema Integrity Error. Ony answers of type Relationship are valid in RelationshipCollector blocks.'
+        'Schema Integrity Error. Only answers of type Relationship are valid in RelationshipCollector blocks.'
     ]
 
     check_validation_errors(filename, expected_error_message)


### PR DESCRIPTION
### Motivation

Runner needs to be capable of displaying question variants based on the primary person, which is only available in the relationship location.

### Changes

Modify comparisons to be structured in objects coming from either a 'answers' or 'location' source.

    "comparison": {
      "source": "location",
      "id": "from_list_item_id"
    }

Additionally, I've modified RelationshipCollector validation to work with variants.