### PR TITLE
Allow detail_answer to be numeric

### DIFF
--- a/schemas/answers/definitions.json
+++ b/schemas/answers/definitions.json
@@ -20,7 +20,14 @@
                     "$ref": "../common_definitions.json#/q_code"
                 },
                 "detail_answer": {
-                    "$ref": "./text_field.json#/answer"
+                    "oneOf": [
+                        {
+                          "$ref": "./text_field.json#/answer"
+                        },
+                        {
+                          "$ref": "./number.json#/answer"
+                        }
+                      ]
                 },
                 "description": {
                     "$ref": "../string_interpolation/definitions.json#/string_with_placeholders",


### PR DESCRIPTION
### PR Context

This PR is to allow a details_answers field to be numeric

This PR [#2279](ONSdigital/eq-survey-runner/pull/2279) needs this change to allow adding the validation needed

### Checklist

* [x] eq-translations updated to support any new schema keys which need translation