### PR TITLE
Add ListCollector keys for SectionSummary

### DIFF
--- a/schemas/blocks/list_collector.json
+++ b/schemas/blocks/list_collector.json
@@ -36,7 +36,7 @@
     },
     "additionalProperties": false,
     "required": [
-        "item_title", "add_link_text", "empty_list_text", "title"
+        "item_title", "title"
     ]
   },
   "block": {

--- a/schemas/blocks/list_collector.json
+++ b/schemas/blocks/list_collector.json
@@ -23,11 +23,20 @@
     "properties":{
       "item_title": {
           "$ref": "../string_interpolation/definitions.json#/string_with_placeholders"
+      },
+      "add_link_text": {
+        "type": "string"
+      },
+      "empty_list_text": {
+        "type": "string"
+      },
+      "title": {
+        "$ref": "../string_interpolation/definitions.json#/string_with_placeholders"
       }
     },
     "additionalProperties": false,
     "required": [
-        "item_title"
+        "item_title", "add_link_text", "empty_list_text", "title"
     ]
   },
   "block": {
@@ -66,6 +75,9 @@
       },
       "summary": {
         "$ref": "list_collector.json#/summary"
+      },
+      "hide_on_section_summary": {
+        "type": "boolean"
       }
     },
     "additionalProperties": false,

--- a/schemas/blocks/primary_person_list_collector.json
+++ b/schemas/blocks/primary_person_list_collector.json
@@ -42,9 +42,6 @@
       },
       "add_or_edit_block": {
         "$ref": "question.json#/block"
-      },
-      "hide_on_section_summary": {
-        "type": "boolean"
       }
     },
     "additionalProperties": false,

--- a/schemas/blocks/primary_person_list_collector.json
+++ b/schemas/blocks/primary_person_list_collector.json
@@ -42,6 +42,9 @@
       },
       "add_or_edit_block": {
         "$ref": "question.json#/block"
+      },
+      "hide_on_section_summary": {
+        "type": "boolean"
       }
     },
     "additionalProperties": false,

--- a/tests/schemas/valid/test_list_collector.json
+++ b/tests/schemas/valid/test_list_collector.json
@@ -202,6 +202,9 @@
           }
         },
         "summary": {
+          "title": "Household members",
+          "add_link_text": "Add another person to this household",
+          "empty_list_text": "There are no people",
           "item_title": {
             "text": "{person_name}",
             "placeholders": [{
@@ -221,7 +224,8 @@
               }]
             }]
           }
-        }
+        },
+        "hide_on_section_summary": false
       }, {
         "type": "Summary",
         "id": "summary"


### PR DESCRIPTION
### PR Context

Adding new keys for summaries shown when a section contains list collectors. These are used when a ListCollector is shown on SectionSummary blocks.

### Checklist

* [x] eq-translations updated to support any new schema keys which need translation
