### PR TITLE
Relationship name piping

### DIFF
--- a/schemas/answers/relationship.json
+++ b/schemas/answers/relationship.json
@@ -53,7 +53,7 @@
                 "type": "boolean"
             },
             "playback": {
-                "type": "string"
+                "$ref": "../string_interpolation/definitions.json#/string_with_placeholders"
             }
         },
         "additionalProperties": false,

--- a/schemas/string_interpolation/definitions.json
+++ b/schemas/string_interpolation/definitions.json
@@ -1,9 +1,13 @@
 {
+
   "$schema": "http://json-schema.org/draft-04/schema",
   "string_with_placeholders": {
     "oneOf": [{
         "description": "String with no placeholders.",
-        "type": "string"
+        "type": "string",
+        "not": {
+            "pattern": "({[_a-zA-Z0-9]*})+"
+        }
       },
       {
         "description": "An object that represents a string with placeholders.",
@@ -137,6 +141,25 @@
       "identifier": {
         "description": "The identifier of the item in the data source. This would be an answer id for answers, and a metadata property name for metadata. The array option allows multiple values to be passed as a list to a transform.",
         "type": ["string", "array"]
+      },
+      "list_item_selector": {
+        "description": "The identifier and source of the list item.",
+        "type": "object",
+        "properties": {
+            "source": {
+                "description": "The source of the data.",
+                "type": "string",
+                "enum": ["location"]
+            },
+            "id": {
+                "description": "The unique id of the object.",
+                "type": "string",
+                "enum": [
+                  "list_item_id",
+                  "to_list_item_id"
+                ]
+            }
+        }
       }
     },
     "additionalProperties": false,

--- a/tests/schemas/invalid/test_invalid_relationship_list_doesnt_exist.json
+++ b/tests/schemas/invalid/test_invalid_relationship_list_doesnt_exist.json
@@ -33,23 +33,245 @@
           "question": {
             "id": "relationship-question",
             "type": "General",
-            "title": "Thinking of {first_person_name}, {second_person_name} is their <em>...</em>",
+            "title": {
+              "text": "Thinking of {first_person_name}, {second_person_name} is their <em>...</em>",
+              "placeholders": [{
+                  "placeholder": "first_person_name",
+                  "transforms": [{
+                    "transform": "concatenate_list",
+                    "arguments": {
+                      "list_to_concatenate": {
+                        "source": "answers",
+                        "identifier": ["first-name", "last-name"],
+                        "list_item_selector": {
+                          "source": "location",
+                          "id": "list_item_id"
+                        }
+                      },
+                      "delimiter": " "
+                    }
+                  }]
+                },
+                {
+                  "placeholder": "second_person_name",
+                  "transforms": [{
+                    "transform": "concatenate_list",
+                    "arguments": {
+                      "list_to_concatenate": {
+                        "source": "answers",
+                        "identifier": ["first-name", "last-name"],
+                        "list_item_selector": {
+                          "source": "location",
+                          "id": "to_list_item_id"
+                        }
+                      },
+                      "delimiter": " "
+                    }
+                  }]
+                }
+              ]
+            },
             "answers": [{
               "id": "relationship-answer",
               "mandatory": true,
               "type": "Relationship",
-              "playback": "{second_person_name} is {first_person_name} <em>…</em>",
+              "playback": {
+                "text": "{second_person_name} is {first_person_name} <em>…</em>",
+                "placeholders": [{
+                    "placeholder": "first_person_name",
+                    "transforms": [{
+                      "transform": "concatenate_list",
+                      "arguments": {
+                        "list_to_concatenate": {
+                          "source": "answers",
+                          "identifier": ["first-name", "last-name"],
+                          "list_item_selector": {
+                            "source": "location",
+                            "id": "list_item_id"
+                          }
+                        },
+                        "delimiter": " "
+                      }
+                    }]
+                  },
+                  {
+                    "placeholder": "second_person_name",
+                    "transforms": [{
+                      "transform": "concatenate_list",
+                      "arguments": {
+                        "list_to_concatenate": {
+                          "source": "answers",
+                          "identifier": ["first-name", "last-name"],
+                          "list_item_selector": {
+                            "source": "location",
+                            "id": "to_list_item_id"
+                          }
+                        },
+                        "delimiter": " "
+                      }
+                    }]
+                  }
+                ]
+              },
               "options": [{
                   "value": "Husband or Wife",
                   "label": "husband or Wife",
-                  "title": "Thinking of {first_person_name}, {second_person_name} is their <em>husband or wife</em>",
-                  "playback": "{second_person_name} is {first_person_name} <em>husband or wife</em>"
+                  "title": {
+                    "text": "Thinking of {first_person_name}, {second_person_name} is their <em>husband or wife</em>",
+                    "placeholders": [{
+                        "placeholder": "first_person_name",
+                        "transforms": [{
+                          "transform": "concatenate_list",
+                          "arguments": {
+                            "list_to_concatenate": {
+                              "source": "answers",
+                              "identifier": ["first-name", "last-name"],
+                              "list_item_selector": {
+                                "source": "location",
+                                "id": "list_item_id"
+                              }
+                            },
+                            "delimiter": " "
+                          }
+                        }]
+                      },
+                      {
+                        "placeholder": "second_person_name",
+                        "transforms": [{
+                          "transform": "concatenate_list",
+                          "arguments": {
+                            "list_to_concatenate": {
+                              "source": "answers",
+                              "identifier": ["first-name", "last-name"],
+                              "list_item_selector": {
+                                "source": "location",
+                                "id": "to_list_item_id"
+                              }
+                            },
+                            "delimiter": " "
+                          }
+                        }]
+                      }
+                    ]
+                  },
+                  "playback": {
+                    "text": "{second_person_name} is {first_person_name} <em>legally registered civil partner</em>",
+                    "placeholders": [{
+                        "placeholder": "first_person_name",
+                        "transforms": [{
+                          "transform": "concatenate_list",
+                          "arguments": {
+                            "list_to_concatenate": {
+                              "source": "answers",
+                              "identifier": ["first-name", "last-name"],
+                              "list_item_selector": {
+                                "source": "location",
+                                "id": "list_item_id"
+                              }
+                            },
+                            "delimiter": " "
+                          }
+                        }]
+                      },
+                      {
+                        "placeholder": "second_person_name",
+                        "transforms": [{
+                          "transform": "concatenate_list",
+                          "arguments": {
+                            "list_to_concatenate": {
+                              "source": "answers",
+                              "identifier": ["first-name", "last-name"],
+                              "list_item_selector": {
+                                "source": "location",
+                                "id": "to_list_item_id"
+                              }
+                            },
+                            "delimiter": " "
+                          }
+                        }]
+                      }
+                    ]
+                  }
                 },
                 {
                   "value": "Legally Registered Civil Partner",
                   "label": "Legally Registered Civil Partner",
-                  "title": "Thinking of {first_person_name}, {second_person_name} is their <em>legally registered civil partner</em>",
-                  "playback": "{second_person_name} is {first_person_name} <em>legally registered civil partner</em>"
+                  "title": {
+                    "text": "Thinking of {first_person_name}, {second_person_name} is their <em>legally registered civil partner</em>",
+                    "placeholders": [{
+                        "placeholder": "first_person_name",
+                        "transforms": [{
+                          "transform": "concatenate_list",
+                          "arguments": {
+                            "list_to_concatenate": {
+                              "source": "answers",
+                              "identifier": ["first-name", "last-name"],
+                              "list_item_selector": {
+                                "source": "location",
+                                "id": "list_item_id"
+                              }
+                            },
+                            "delimiter": " "
+                          }
+                        }]
+                      },
+                      {
+                        "placeholder": "second_person_name",
+                        "transforms": [{
+                          "transform": "concatenate_list",
+                          "arguments": {
+                            "list_to_concatenate": {
+                              "source": "answers",
+                              "identifier": ["first-name", "last-name"],
+                              "list_item_selector": {
+                                "source": "location",
+                                "id": "to_list_item_id"
+                              }
+                            },
+                            "delimiter": " "
+                          }
+                        }]
+                      }
+                    ]
+                  },
+                  "playback": {
+                    "text": "{second_person_name} is {first_person_name} <em>legally registered civil partner</em>",
+                    "placeholders": [{
+                        "placeholder": "first_person_name",
+                        "transforms": [{
+                          "transform": "concatenate_list",
+                          "arguments": {
+                            "list_to_concatenate": {
+                              "source": "answers",
+                              "identifier": ["first-name", "last-name"],
+                              "list_item_selector": {
+                                "source": "location",
+                                "id": "list_item_id"
+                              }
+                            },
+                            "delimiter": " "
+                          }
+                        }]
+                      },
+                      {
+                        "placeholder": "second_person_name",
+                        "transforms": [{
+                          "transform": "concatenate_list",
+                          "arguments": {
+                            "list_to_concatenate": {
+                              "source": "answers",
+                              "identifier": ["first-name", "last-name"],
+                              "list_item_selector": {
+                                "source": "location",
+                                "id": "to_list_item_id"
+                              }
+                            },
+                            "delimiter": " "
+                          }
+                        }]
+                      }
+                    ]
+                  }
                 }
               ]
             }]

--- a/tests/schemas/invalid/test_invalid_relationship_multiple_answers.json
+++ b/tests/schemas/invalid/test_invalid_relationship_multiple_answers.json
@@ -132,23 +132,245 @@
           "question": {
             "id": "relationship-question",
             "type": "General",
-            "title": "Thinking of {first_person_name}, {second_person_name} is their <em>...</em>",
+            "title": {
+              "text": "Thinking of {first_person_name}, {second_person_name} is their <em>...</em>",
+              "placeholders": [{
+                  "placeholder": "first_person_name",
+                  "transforms": [{
+                    "transform": "concatenate_list",
+                    "arguments": {
+                      "list_to_concatenate": {
+                        "source": "answers",
+                        "identifier": ["first-name", "last-name"],
+                        "list_item_selector": {
+                          "source": "location",
+                          "id": "list_item_id"
+                        }
+                      },
+                      "delimiter": " "
+                    }
+                  }]
+                },
+                {
+                  "placeholder": "second_person_name",
+                  "transforms": [{
+                    "transform": "concatenate_list",
+                    "arguments": {
+                      "list_to_concatenate": {
+                        "source": "answers",
+                        "identifier": ["first-name", "last-name"],
+                        "list_item_selector": {
+                          "source": "location",
+                          "id": "to_list_item_id"
+                        }
+                      },
+                      "delimiter": " "
+                    }
+                  }]
+                }
+              ]
+            },
             "answers": [{
                 "id": "relationship-answer",
                 "mandatory": true,
                 "type": "Relationship",
-                "playback": "{second_person_name} is {first_person_name} <em>…</em>",
+                "playback": {
+                  "text": "{second_person_name} is {first_person_name} <em>…</em>",
+                  "placeholders": [{
+                      "placeholder": "first_person_name",
+                      "transforms": [{
+                        "transform": "concatenate_list",
+                        "arguments": {
+                          "list_to_concatenate": {
+                            "source": "answers",
+                            "identifier": ["first-name", "last-name"],
+                            "list_item_selector": {
+                              "source": "location",
+                              "id": "list_item_id"
+                            }
+                          },
+                          "delimiter": " "
+                        }
+                      }]
+                    },
+                    {
+                      "placeholder": "second_person_name",
+                      "transforms": [{
+                        "transform": "concatenate_list",
+                        "arguments": {
+                          "list_to_concatenate": {
+                            "source": "answers",
+                            "identifier": ["first-name", "last-name"],
+                            "list_item_selector": {
+                              "source": "location",
+                              "id": "to_list_item_id"
+                            }
+                          },
+                          "delimiter": " "
+                        }
+                      }]
+                    }
+                  ]
+                },
                 "options": [{
                     "value": "Husband or Wife",
                     "label": "husband or Wife",
-                    "title": "Thinking of {first_person_name}, {second_person_name} is their <em>husband or wife</em>",
-                    "playback": "{second_person_name} is {first_person_name} <em>husband or wife</em>"
+                    "title": {
+                      "text": "Thinking of {first_person_name}, {second_person_name} is their <em>husband or wife</em>",
+                      "placeholders": [{
+                          "placeholder": "first_person_name",
+                          "transforms": [{
+                            "transform": "concatenate_list",
+                            "arguments": {
+                              "list_to_concatenate": {
+                                "source": "answers",
+                                "identifier": ["first-name", "last-name"],
+                                "list_item_selector": {
+                                  "source": "location",
+                                  "id": "list_item_id"
+                                }
+                              },
+                              "delimiter": " "
+                            }
+                          }]
+                        },
+                        {
+                          "placeholder": "second_person_name",
+                          "transforms": [{
+                            "transform": "concatenate_list",
+                            "arguments": {
+                              "list_to_concatenate": {
+                                "source": "answers",
+                                "identifier": ["first-name", "last-name"],
+                                "list_item_selector": {
+                                  "source": "location",
+                                  "id": "to_list_item_id"
+                                }
+                              },
+                              "delimiter": " "
+                            }
+                          }]
+                        }
+                      ]
+                    },
+                    "playback": {
+                      "text": "{second_person_name} is {first_person_name} <em>husband or wife</em>",
+                      "placeholders": [{
+                          "placeholder": "first_person_name",
+                          "transforms": [{
+                            "transform": "concatenate_list",
+                            "arguments": {
+                              "list_to_concatenate": {
+                                "source": "answers",
+                                "identifier": ["first-name", "last-name"],
+                                "list_item_selector": {
+                                  "source": "location",
+                                  "id": "list_item_id"
+                                }
+                              },
+                              "delimiter": " "
+                            }
+                          }]
+                        },
+                        {
+                          "placeholder": "second_person_name",
+                          "transforms": [{
+                            "transform": "concatenate_list",
+                            "arguments": {
+                              "list_to_concatenate": {
+                                "source": "answers",
+                                "identifier": ["first-name", "last-name"],
+                                "list_item_selector": {
+                                  "source": "location",
+                                  "id": "to_list_item_id"
+                                }
+                              },
+                              "delimiter": " "
+                            }
+                          }]
+                        }
+                      ]
+                    }
                   },
                   {
                     "value": "Legally Registered Civil Partner",
                     "label": "Legally Registered Civil Partner",
-                    "title": "Thinking of {first_person_name}, {second_person_name} is their <em>legally registered civil partner</em>",
-                    "playback": "{second_person_name} is {first_person_name} <em>legally registered civil partner</em>"
+                    "title": {
+                      "text": "Thinking of {first_person_name}, {second_person_name} is their <em>legally registered civil partner</em>",
+                      "placeholders": [{
+                          "placeholder": "first_person_name",
+                          "transforms": [{
+                            "transform": "concatenate_list",
+                            "arguments": {
+                              "list_to_concatenate": {
+                                "source": "answers",
+                                "identifier": ["first-name", "last-name"],
+                                "list_item_selector": {
+                                  "source": "location",
+                                  "id": "list_item_id"
+                                }
+                              },
+                              "delimiter": " "
+                            }
+                          }]
+                        },
+                        {
+                          "placeholder": "second_person_name",
+                          "transforms": [{
+                            "transform": "concatenate_list",
+                            "arguments": {
+                              "list_to_concatenate": {
+                                "source": "answers",
+                                "identifier": ["first-name", "last-name"],
+                                "list_item_selector": {
+                                  "source": "location",
+                                  "id": "to_list_item_id"
+                                }
+                              },
+                              "delimiter": " "
+                            }
+                          }]
+                        }
+                      ]
+                    },
+                    "playback": {
+                      "text": "{second_person_name} is {first_person_name} <em>legally registered civil partner</em>",
+                      "placeholders": [{
+                          "placeholder": "first_person_name",
+                          "transforms": [{
+                            "transform": "concatenate_list",
+                            "arguments": {
+                              "list_to_concatenate": {
+                                "source": "answers",
+                                "identifier": ["first-name", "last-name"],
+                                "list_item_selector": {
+                                  "source": "location",
+                                  "id": "list_item_id"
+                                }
+                              },
+                              "delimiter": " "
+                            }
+                          }]
+                        },
+                        {
+                          "placeholder": "second_person_name",
+                          "transforms": [{
+                            "transform": "concatenate_list",
+                            "arguments": {
+                              "list_to_concatenate": {
+                                "source": "answers",
+                                "identifier": ["first-name", "last-name"],
+                                "list_item_selector": {
+                                  "source": "location",
+                                  "id": "to_list_item_id"
+                                }
+                              },
+                              "delimiter": " "
+                            }
+                          }]
+                        }
+                      ]
+                    }
                   }
                 ]
               },
@@ -156,18 +378,203 @@
                 "id": "relationship-answer2",
                 "mandatory": true,
                 "type": "Relationship",
-                "playback": "{second_person_name} is {first_person_name} <em>…</em>",
+                "playback": {
+                  "text": "{second_person_name} is {first_person_name} <em>…</em>",
+                  "placeholders": [{
+                      "placeholder": "first_person_name",
+                      "transforms": [{
+                        "transform": "concatenate_list",
+                        "arguments": {
+                          "list_to_concatenate": {
+                            "source": "answers",
+                            "identifier": ["first-name", "last-name"],
+                            "list_item_selector": {
+                              "source": "location",
+                              "id": "list_item_id"
+                            }
+                          },
+                          "delimiter": " "
+                        }
+                      }]
+                    },
+                    {
+                      "placeholder": "second_person_name",
+                      "transforms": [{
+                        "transform": "concatenate_list",
+                        "arguments": {
+                          "list_to_concatenate": {
+                            "source": "answers",
+                            "identifier": ["first-name", "last-name"],
+                            "list_item_selector": {
+                              "source": "location",
+                              "id": "to_list_item_id"
+                            }
+                          },
+                          "delimiter": " "
+                        }
+                      }]
+                    }
+                  ]
+                },
                 "options": [{
                     "value": "Husband or Wife",
                     "label": "husband or Wife",
-                    "title": "Thinking of {first_person_name}, {second_person_name} is their <em>husband or wife</em>",
-                    "playback": "{second_person_name} is {first_person_name} <em>husband or wife</em>"
+                    "title": {
+                      "text": "Thinking of {first_person_name}, {second_person_name} is their <em>husband or wife</em>",
+                      "placeholders": [{
+                          "placeholder": "first_person_name",
+                          "transforms": [{
+                            "transform": "concatenate_list",
+                            "arguments": {
+                              "list_to_concatenate": {
+                                "source": "answers",
+                                "identifier": ["first-name", "last-name"],
+                                "list_item_selector": {
+                                  "source": "location",
+                                  "id": "list_item_id"
+                                }
+                              },
+                              "delimiter": " "
+                            }
+                          }]
+                        },
+                        {
+                          "placeholder": "second_person_name",
+                          "transforms": [{
+                            "transform": "concatenate_list",
+                            "arguments": {
+                              "list_to_concatenate": {
+                                "source": "answers",
+                                "identifier": ["first-name", "last-name"],
+                                "list_item_selector": {
+                                  "source": "location",
+                                  "id": "to_list_item_id"
+                                }
+                              },
+                              "delimiter": " "
+                            }
+                          }]
+                        }
+                      ]
+                    },
+                    "playback": {
+                      "text": "{second_person_name} is {first_person_name} <em>husband or wife</em>",
+                      "placeholders": [{
+                          "placeholder": "first_person_name",
+                          "transforms": [{
+                            "transform": "concatenate_list",
+                            "arguments": {
+                              "list_to_concatenate": {
+                                "source": "answers",
+                                "identifier": ["first-name", "last-name"],
+                                "list_item_selector": {
+                                  "source": "location",
+                                  "id": "list_item_id"
+                                }
+                              },
+                              "delimiter": " "
+                            }
+                          }]
+                        },
+                        {
+                          "placeholder": "second_person_name",
+                          "transforms": [{
+                            "transform": "concatenate_list",
+                            "arguments": {
+                              "list_to_concatenate": {
+                                "source": "answers",
+                                "identifier": ["first-name", "last-name"],
+                                "list_item_selector": {
+                                  "source": "location",
+                                  "id": "to_list_item_id"
+                                }
+                              },
+                              "delimiter": " "
+                            }
+                          }]
+                        }
+                      ]
+                    }
                   },
                   {
                     "value": "Legally Registered Civil Partner",
                     "label": "Legally Registered Civil Partner",
-                    "title": "Thinking of {first_person_name}, {second_person_name} is their <em>legally registered civil partner</em>",
-                    "playback": "{second_person_name} is {first_person_name} <em>legally registered civil partner</em>"
+                    "title": {
+                      "text": "Thinking of {first_person_name}, {second_person_name} is their <em>legally registered civil partner</em>",
+                      "placeholders": [{
+                          "placeholder": "first_person_name",
+                          "transforms": [{
+                            "transform": "concatenate_list",
+                            "arguments": {
+                              "list_to_concatenate": {
+                                "source": "answers",
+                                "identifier": ["first-name", "last-name"],
+                                "list_item_selector": {
+                                  "source": "location",
+                                  "id": "list_item_id"
+                                }
+                              },
+                              "delimiter": " "
+                            }
+                          }]
+                        },
+                        {
+                          "placeholder": "second_person_name",
+                          "transforms": [{
+                            "transform": "concatenate_list",
+                            "arguments": {
+                              "list_to_concatenate": {
+                                "source": "answers",
+                                "identifier": ["first-name", "last-name"],
+                                "list_item_selector": {
+                                  "source": "location",
+                                  "id": "to_list_item_id"
+                                }
+                              },
+                              "delimiter": " "
+                            }
+                          }]
+                        }
+                      ]
+                    },
+                    "playback": {
+                      "text": "{second_person_name} is {first_person_name} <em>legally registered civil partner</em>",
+                      "placeholders": [{
+                          "placeholder": "first_person_name",
+                          "transforms": [{
+                            "transform": "concatenate_list",
+                            "arguments": {
+                              "list_to_concatenate": {
+                                "source": "answers",
+                                "identifier": ["first-name", "last-name"],
+                                "list_item_selector": {
+                                  "source": "location",
+                                  "id": "list_item_id"
+                                }
+                              },
+                              "delimiter": " "
+                            }
+                          }]
+                        },
+                        {
+                          "placeholder": "second_person_name",
+                          "transforms": [{
+                            "transform": "concatenate_list",
+                            "arguments": {
+                              "list_to_concatenate": {
+                                "source": "answers",
+                                "identifier": ["first-name", "last-name"],
+                                "list_item_selector": {
+                                  "source": "location",
+                                  "id": "to_list_item_id"
+                                }
+                              },
+                              "delimiter": " "
+                            }
+                          }]
+                        }
+                      ]
+                    }
                   }
                 ]
               }

--- a/tests/schemas/invalid/test_invalid_relationship_no_list_specified.json
+++ b/tests/schemas/invalid/test_invalid_relationship_no_list_specified.json
@@ -131,23 +131,245 @@
           "question": {
             "id": "relationship-question",
             "type": "General",
-            "title": "Thinking of {first_person_name}, {second_person_name} is their <em>...</em>",
+            "title": {
+              "text": "Thinking of {first_person_name}, {second_person_name} is their <em>...</em>",
+              "placeholders": [{
+                  "placeholder": "first_person_name",
+                  "transforms": [{
+                    "transform": "concatenate_list",
+                    "arguments": {
+                      "list_to_concatenate": {
+                        "source": "answers",
+                        "identifier": ["first-name", "last-name"],
+                        "list_item_selector": {
+                          "source": "location",
+                          "id": "list_item_id"
+                        }
+                      },
+                      "delimiter": " "
+                    }
+                  }]
+                },
+                {
+                  "placeholder": "second_person_name",
+                  "transforms": [{
+                    "transform": "concatenate_list",
+                    "arguments": {
+                      "list_to_concatenate": {
+                        "source": "answers",
+                        "identifier": ["first-name", "last-name"],
+                        "list_item_selector": {
+                          "source": "location",
+                          "id": "to_list_item_id"
+                        }
+                      },
+                      "delimiter": " "
+                    }
+                  }]
+                }
+              ]
+            },
             "answers": [{
               "id": "relationship-answer",
               "mandatory": true,
               "type": "Relationship",
-              "playback": "{second_person_name} is {first_person_name} <em>…</em>",
+              "playback": {
+                "text": "{second_person_name} is {first_person_name} <em>…</em>",
+                "placeholders": [{
+                    "placeholder": "first_person_name",
+                    "transforms": [{
+                      "transform": "concatenate_list",
+                      "arguments": {
+                        "list_to_concatenate": {
+                          "source": "answers",
+                          "identifier": ["first-name", "last-name"],
+                          "list_item_selector": {
+                            "source": "location",
+                            "id": "list_item_id"
+                          }
+                        },
+                        "delimiter": " "
+                      }
+                    }]
+                  },
+                  {
+                    "placeholder": "second_person_name",
+                    "transforms": [{
+                      "transform": "concatenate_list",
+                      "arguments": {
+                        "list_to_concatenate": {
+                          "source": "answers",
+                          "identifier": ["first-name", "last-name"],
+                          "list_item_selector": {
+                            "source": "location",
+                            "id": "to_list_item_id"
+                          }
+                        },
+                        "delimiter": " "
+                      }
+                    }]
+                  }
+                ]
+              },
               "options": [{
                   "value": "Husband or Wife",
                   "label": "Husband or Wife",
-                  "title": "Thinking of {first_person_name}, {second_person_name} is their <em>husband or wife</em>",
-                  "playback": "{second_person_name} is {first_person_name} <em>husband or wife</em>"
+                  "title": {
+                    "text": "Thinking of {first_person_name}, {second_person_name} is their <em>husband or wife</em>",
+                    "placeholders": [{
+                        "placeholder": "first_person_name",
+                        "transforms": [{
+                          "transform": "concatenate_list",
+                          "arguments": {
+                            "list_to_concatenate": {
+                              "source": "answers",
+                              "identifier": ["first-name", "last-name"],
+                              "list_item_selector": {
+                                "source": "location",
+                                "id": "list_item_id"
+                              }
+                            },
+                            "delimiter": " "
+                          }
+                        }]
+                      },
+                      {
+                        "placeholder": "second_person_name",
+                        "transforms": [{
+                          "transform": "concatenate_list",
+                          "arguments": {
+                            "list_to_concatenate": {
+                              "source": "answers",
+                              "identifier": ["first-name", "last-name"],
+                              "list_item_selector": {
+                                "source": "location",
+                                "id": "to_list_item_id"
+                              }
+                            },
+                            "delimiter": " "
+                          }
+                        }]
+                      }
+                    ]
+                  },
+                  "playback": {
+                    "text": "{second_person_name} is {first_person_name} <em>husband or wife</em>",
+                    "placeholders": [{
+                        "placeholder": "first_person_name",
+                        "transforms": [{
+                          "transform": "concatenate_list",
+                          "arguments": {
+                            "list_to_concatenate": {
+                              "source": "answers",
+                              "identifier": ["first-name", "last-name"],
+                              "list_item_selector": {
+                                "source": "location",
+                                "id": "list_item_id"
+                              }
+                            },
+                            "delimiter": " "
+                          }
+                        }]
+                      },
+                      {
+                        "placeholder": "second_person_name",
+                        "transforms": [{
+                          "transform": "concatenate_list",
+                          "arguments": {
+                            "list_to_concatenate": {
+                              "source": "answers",
+                              "identifier": ["first-name", "last-name"],
+                              "list_item_selector": {
+                                "source": "location",
+                                "id": "to_list_item_id"
+                              }
+                            },
+                            "delimiter": " "
+                          }
+                        }]
+                      }
+                    ]
+                  }
                 },
                 {
                   "value": "Legally Registered Civil Partner",
                   "label": "Legally Registered Civil Partner",
-                  "title": "Thinking of {first_person_name}, {second_person_name} is their <em>legally registered civil partner</em>",
-                  "playback": "{second_person_name} is {first_person_name} <em>legally registered civil partner</em>"
+                  "title": {
+                    "text": "Thinking of {first_person_name}, {second_person_name} is their <em>legally registered civil partner</em>",
+                    "placeholders": [{
+                        "placeholder": "first_person_name",
+                        "transforms": [{
+                          "transform": "concatenate_list",
+                          "arguments": {
+                            "list_to_concatenate": {
+                              "source": "answers",
+                              "identifier": ["first-name", "last-name"],
+                              "list_item_selector": {
+                                "source": "location",
+                                "id": "list_item_id"
+                              }
+                            },
+                            "delimiter": " "
+                          }
+                        }]
+                      },
+                      {
+                        "placeholder": "second_person_name",
+                        "transforms": [{
+                          "transform": "concatenate_list",
+                          "arguments": {
+                            "list_to_concatenate": {
+                              "source": "answers",
+                              "identifier": ["first-name", "last-name"],
+                              "list_item_selector": {
+                                "source": "location",
+                                "id": "to_list_item_id"
+                              }
+                            },
+                            "delimiter": " "
+                          }
+                        }]
+                      }
+                    ]
+                  },
+                  "playback": {
+                    "text": "{second_person_name} is {first_person_name} <em>legally registered civil partner</em>",
+                    "placeholders": [{
+                        "placeholder": "first_person_name",
+                        "transforms": [{
+                          "transform": "concatenate_list",
+                          "arguments": {
+                            "list_to_concatenate": {
+                              "source": "answers",
+                              "identifier": ["first-name", "last-name"],
+                              "list_item_selector": {
+                                "source": "location",
+                                "id": "list_item_id"
+                              }
+                            },
+                            "delimiter": " "
+                          }
+                        }]
+                      },
+                      {
+                        "placeholder": "second_person_name",
+                        "transforms": [{
+                          "transform": "concatenate_list",
+                          "arguments": {
+                            "list_to_concatenate": {
+                              "source": "answers",
+                              "identifier": ["first-name", "last-name"],
+                              "list_item_selector": {
+                                "source": "location",
+                                "id": "to_list_item_id"
+                              }
+                            },
+                            "delimiter": " "
+                          }
+                        }]
+                      }
+                    ]
+                  }
                 }
               ]
             }]

--- a/tests/schemas/invalid/test_invalid_relationship_wrong_answer_type.json
+++ b/tests/schemas/invalid/test_invalid_relationship_wrong_answer_type.json
@@ -132,7 +132,44 @@
           "question": {
             "id": "relationship-question",
             "type": "General",
-            "title": "Thinking of {first_person_name}, {second_person_name} is their <em>...</em>",
+            "title": {
+              "text": "Thinking of {first_person_name}, {second_person_name} is their <em>...</em>",
+              "placeholders": [{
+                  "placeholder": "first_person_name",
+                  "transforms": [{
+                    "transform": "concatenate_list",
+                    "arguments": {
+                      "list_to_concatenate": {
+                        "source": "answers",
+                        "identifier": ["first-name", "last-name"],
+                        "list_item_selector": {
+                          "source": "location",
+                          "id": "list_item_id"
+                        }
+                      },
+                      "delimiter": " "
+                    }
+                  }]
+                },
+                {
+                  "placeholder": "second_person_name",
+                  "transforms": [{
+                    "transform": "concatenate_list",
+                    "arguments": {
+                      "list_to_concatenate": {
+                        "source": "answers",
+                        "identifier": ["first-name", "last-name"],
+                        "list_item_selector": {
+                          "source": "location",
+                          "id": "to_list_item_id"
+                        }
+                      },
+                      "delimiter": " "
+                    }
+                  }]
+                }
+              ]
+            },
             "answers": [{
               "id": "answer-1",
               "label": "Your age?",

--- a/tests/schemas/valid/test_relationship_collector.json
+++ b/tests/schemas/valid/test_relationship_collector.json
@@ -132,23 +132,245 @@
           "question": {
             "id": "relationship-question",
             "type": "General",
-            "title": "Thinking of {first_person_name}, {second_person_name} is their <em>...</em>",
+            "title": {
+              "text": "Thinking of {first_person_name}, {second_person_name} is their <em>...</em>",
+              "placeholders": [{
+                  "placeholder": "first_person_name",
+                  "transforms": [{
+                    "transform": "concatenate_list",
+                    "arguments": {
+                      "list_to_concatenate": {
+                        "source": "answers",
+                        "identifier": ["first-name", "last-name"],
+                        "list_item_selector": {
+                          "source": "location",
+                          "id": "list_item_id"
+                        }
+                      },
+                      "delimiter": " "
+                    }
+                  }]
+                },
+                {
+                  "placeholder": "second_person_name",
+                  "transforms": [{
+                    "transform": "concatenate_list",
+                    "arguments": {
+                      "list_to_concatenate": {
+                        "source": "answers",
+                        "identifier": ["first-name", "last-name"],
+                        "list_item_selector": {
+                          "source": "location",
+                          "id": "to_list_item_id"
+                        }
+                      },
+                      "delimiter": " "
+                    }
+                  }]
+                }
+              ]
+            },
             "answers": [{
               "id": "relationship-answer",
               "mandatory": true,
               "type": "Relationship",
-              "playback": "{second_person_name} is {first_person_name} <em>…</em>",
+              "playback": {
+                "text": "{second_person_name} is {first_person_name} <em>…</em>",
+                "placeholders": [{
+                    "placeholder": "second_person_name",
+                    "transforms": [{
+                      "transform": "concatenate_list",
+                      "arguments": {
+                        "list_to_concatenate": {
+                          "source": "answers",
+                          "identifier": ["first-name", "last-name"],
+                          "list_item_selector": {
+                            "source": "location",
+                            "id": "to_list_item_id"
+                          }
+                        },
+                        "delimiter": " "
+                      }
+                    }]
+                  },
+                  {
+                    "placeholder": "first_person_name",
+                    "transforms": [{
+                      "transform": "concatenate_list",
+                      "arguments": {
+                        "list_to_concatenate": {
+                          "source": "answers",
+                          "identifier": ["first-name", "last-name"],
+                          "list_item_selector": {
+                            "source": "location",
+                            "id": "list_item_id"
+                          }
+                        },
+                        "delimiter": " "
+                      }
+                    }]
+                  }
+                ]
+              },
               "options": [{
                   "value": "Husband or Wife",
                   "label": "Husband or Wife",
-                  "title": "Thinking of {first_person_name}, {second_person_name} is their <em>husband or wife</em>",
-                  "playback": "{second_person_name} is {first_person_name} <em>husband or wife</em>"
+                  "title": {
+                    "text": "Thinking of {first_person_name}, {second_person_name} is their <em>husband or wife</em>",
+                    "placeholders": [{
+                        "placeholder": "second_person_name",
+                        "transforms": [{
+                          "transform": "concatenate_list",
+                          "arguments": {
+                            "list_to_concatenate": {
+                              "source": "answers",
+                              "identifier": ["first-name", "last-name"],
+                              "list_item_selector": {
+                                "source": "location",
+                                "id": "to_list_item_id"
+                              }
+                            },
+                            "delimiter": " "
+                          }
+                        }]
+                      },
+                      {
+                        "placeholder": "first_person_name",
+                        "transforms": [{
+                          "transform": "concatenate_list",
+                          "arguments": {
+                            "list_to_concatenate": {
+                              "source": "answers",
+                              "identifier": ["first-name", "last-name"],
+                              "list_item_selector": {
+                                "source": "location",
+                                "id": "list_item_id"
+                              }
+                            },
+                            "delimiter": " "
+                          }
+                        }]
+                      }
+                    ]
+                  },
+                  "playback": {
+                    "text": "{second_person_name} is {first_person_name} <em>husband or wife</em>",
+                    "placeholders": [{
+                        "placeholder": "second_person_name",
+                        "transforms": [{
+                          "transform": "concatenate_list",
+                          "arguments": {
+                            "list_to_concatenate": {
+                              "source": "answers",
+                              "identifier": ["first-name", "last-name"],
+                              "list_item_selector": {
+                                "source": "location",
+                                "id": "to_list_item_id"
+                              }
+                            },
+                            "delimiter": " "
+                          }
+                        }]
+                      },
+                      {
+                        "placeholder": "first_person_name",
+                        "transforms": [{
+                          "transform": "concatenate_list",
+                          "arguments": {
+                            "list_to_concatenate": {
+                              "source": "answers",
+                              "identifier": ["first-name", "last-name"],
+                              "list_item_selector": {
+                                "source": "location",
+                                "id": "list_item_id"
+                              }
+                            },
+                            "delimiter": " "
+                          }
+                        }]
+                      }
+                    ]
+                  }
                 },
                 {
                   "value": "Legally Registered Civil Partner",
                   "label": "Legally Registered Civil Partner",
-                  "title": "Thinking of {first_person_name}, {second_person_name} is their <em>legally registered civil partner</em>",
-                  "playback": "{second_person_name} is {first_person_name} <em>legally registered civil partner</em>"
+                  "title": {
+                    "text": "Thinking of {first_person_name}, {second_person_name} is their <em>legally registered civil partner</em>",
+                    "placeholders": [{
+                        "placeholder": "second_person_name",
+                        "transforms": [{
+                          "transform": "concatenate_list",
+                          "arguments": {
+                            "list_to_concatenate": {
+                              "source": "answers",
+                              "identifier": ["first-name", "last-name"],
+                              "list_item_selector": {
+                                "source": "location",
+                                "id": "to_list_item_id"
+                              }
+                            },
+                            "delimiter": " "
+                          }
+                        }]
+                      },
+                      {
+                        "placeholder": "first_person_name",
+                        "transforms": [{
+                          "transform": "concatenate_list",
+                          "arguments": {
+                            "list_to_concatenate": {
+                              "source": "answers",
+                              "identifier": ["first-name", "last-name"],
+                              "list_item_selector": {
+                                "source": "location",
+                                "id": "list_item_id"
+                              }
+                            },
+                            "delimiter": " "
+                          }
+                        }]
+                      }
+                    ]
+                  },
+                  "playback": {
+                    "text": "{second_person_name} is {first_person_name} <em>legally registered civil partner</em>",
+                    "placeholders": [{
+                        "placeholder": "second_person_name",
+                        "transforms": [{
+                          "transform": "concatenate_list",
+                          "arguments": {
+                            "list_to_concatenate": {
+                              "source": "answers",
+                              "identifier": ["first-name", "last-name"],
+                              "list_item_selector": {
+                                "source": "location",
+                                "id": "to_list_item_id"
+                              }
+                            },
+                            "delimiter": " "
+                          }
+                        }]
+                      },
+                      {
+                        "placeholder": "first_person_name",
+                        "transforms": [{
+                          "transform": "concatenate_list",
+                          "arguments": {
+                            "list_to_concatenate": {
+                              "source": "answers",
+                              "identifier": ["first-name", "last-name"],
+                              "list_item_selector": {
+                                "source": "location",
+                                "id": "list_item_id"
+                              }
+                            },
+                            "delimiter": " "
+                          }
+                        }]
+                      }
+                    ]
+                  }
                 }
               ]
             }]

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -549,9 +549,14 @@ def test_invalid_list_name_in_when_rule():
 
 def test_invalid_relationship_no_list_specified():
     filename = 'schemas/invalid/test_invalid_relationship_list_doesnt_exist.json'
+    for_list_error = ["Schema Integrity Error. for_list 'not-a-list' is not populated by any ListCollector blocks"]
     expected_error_message = [
-        "Schema Integrity Error. for_list 'not-a-list' is not populated by any ListCollector blocks",
-    ]
+        'Schema Integrity Error. Invalid answer id reference `first-name` for placeholder `first_person_name`',
+        'Schema Integrity Error. Invalid answer id reference `last-name` for placeholder `first_person_name`',
+        'Schema Integrity Error. Invalid answer id reference `first-name` for placeholder `second_person_name`',
+        'Schema Integrity Error. Invalid answer id reference `last-name` for placeholder `second_person_name`',
+        ] * 6
+    expected_error_message = for_list_error + expected_error_message
 
     check_validation_errors(filename, expected_error_message)
 


### PR DESCRIPTION
### PR Context
Adds a new key to placeholder value_source objects - `list_item_selector`, which is a string object that can be either list_item_id or to_list_item_id.

Placeholder strings in relationship blocks must now be resolved via transforms, not in code.

This supports changes in runner for resolving possesive transformations via a schema.

### Checklist

* [ ] eq-translations updated to support any new schema keys which need translation
