### PR TITLE
Extend support for placeholders to option descriptions

### DIFF
--- a/schemas/answers/definitions.json
+++ b/schemas/answers/definitions.json
@@ -23,7 +23,7 @@
                     "$ref": "./text_field.json#/answer"
                 },
                 "description": {
-                    "type": "string",
+                    "$ref": "../string_interpolation/definitions.json#/string_with_placeholders",
                     "description": "Descriptive text that appears below the option label"
                 },
                 "action": {


### PR DESCRIPTION
### PR Context
One of many PR to come to add support for Who Lives Here.

This PR allows the use of placeholders in answer option descriptions.