### PR TITLE
Allow duplicate answer_ids for list collector variants

### DIFF
--- a/app/validation/validator.py
+++ b/app/validation/validator.py
@@ -1350,15 +1350,17 @@ class Validator:  # pylint: disable=too-many-lines
             path = ''
 
         ignored_keys = ['routing_rules', 'skip_conditions', 'when']
-        ignored_sub_paths = ['edit_block/question/answers', 'add_block/question/answers', 'remove_block/question/answers']
+        ignored_sub_paths = ['edit_block/question', 'add_block/question', 'remove_block/question',
+                             'edit_block/question_variants', 'add_block/question_variants', 'remove_block/question_variants']
 
         for key, value in schema_json.items():
             new_path = f'{path}/{key}'
+
             if key == parsed_key:
                 yield (path, value)
             elif key in ignored_keys:
                 continue
-            elif any([ignored_path in new_path for ignored_path in ignored_sub_paths]):
+            elif any([ignored_path in new_path for ignored_path in ignored_sub_paths]) and key == 'answers':
                 continue
             elif isinstance(value, dict):
                 yield from self._parse_values(value, parsed_key, new_path)

--- a/tests/schemas/valid/test_duplicate_answer_id_for_list_collector_valid.json
+++ b/tests/schemas/valid/test_duplicate_answer_id_for_list_collector_valid.json
@@ -1,0 +1,253 @@
+{
+  "mime_type": "application/json/ons/eq",
+  "schema_version": "0.0.1",
+  "data_version": "0.0.3",
+  "survey_id": "0",
+  "session_timeout_in_seconds": 3,
+  "title": "Test Duplicate Ids",
+  "theme": "default",
+  "description": "A questionnaire to test duplication of id fields",
+  "metadata": [{
+      "name": "user_id",
+      "type": "string"
+    },
+    {
+      "name": "period_id",
+      "type": "string"
+    },
+    {
+      "name": "ru_name",
+      "type": "string"
+    }
+  ],
+  "sections": [{
+    "id": "block-2",
+    "groups": [{
+      "id": "group",
+      "title": "Variants",
+      "blocks": [{
+          "add_answer": {
+            "id": "anyone-else-answer",
+            "value": "Yes, I need to add someone"
+          },
+          "add_block": {
+            "id": "add-person",
+            "question": {
+              "answers": [{
+                  "id": "first-name",
+                  "label": "First name",
+                  "mandatory": true,
+                  "type": "TextField"
+                },
+                {
+                  "id": "middle-names",
+                  "label": "Middle names",
+                  "mandatory": false,
+                  "type": "TextField"
+                },
+                {
+                  "id": "last-name",
+                  "label": "Last name",
+                  "mandatory": true,
+                  "type": "TextField"
+                }
+              ],
+              "id": "add-question",
+              "title": "A title",
+              "type": "General"
+            },
+            "type": "ListAddQuestion"
+          },
+          "edit_block": {
+            "id": "edit-person",
+            "question_variants": [{
+                "question": {
+                  "answers": [{
+                      "id": "first-name",
+                      "label": "First name",
+                      "mandatory": true,
+                      "type": "TextField"
+                    },
+                    {
+                      "id": "middle-names",
+                      "label": "Middle names",
+                      "mandatory": false,
+                      "type": "TextField"
+                    },
+                    {
+                      "id": "last-name",
+                      "label": "Last name",
+                      "mandatory": true,
+                      "type": "TextField"
+                    }
+                  ],
+                  "id": "edit-question",
+                  "title": "A title",
+                  "type": "General"
+                },
+                "when": [{
+                  "comparison": {
+                    "id": "list_item_id",
+                    "source": "location"
+                  },
+                  "condition": "equals",
+                  "id_selector": "primary_person",
+                  "list": "household"
+                }]
+              },
+              {
+                "question": {
+                  "answers": [{
+                      "id": "first-name",
+                      "label": "First name",
+                      "mandatory": true,
+                      "type": "TextField"
+                    },
+                    {
+                      "id": "middle-names",
+                      "label": "Middle names",
+                      "mandatory": false,
+                      "type": "TextField"
+                    },
+                    {
+                      "id": "last-name",
+                      "label": "Last name",
+                      "mandatory": true,
+                      "type": "TextField"
+                    }
+                  ],
+                  "id": "edit-question",
+                  "title": {
+                    "placeholders": [{
+                      "placeholder": "person_name",
+                      "transforms": [{
+                        "arguments": {
+                          "delimiter": " ",
+                          "list_to_concatenate": {
+                            "identifier": [
+                              "first-name",
+                              "last-name"
+                            ],
+                            "source": "answers"
+                          }
+                        },
+                        "transform": "concatenate_list"
+                      }]
+                    }],
+                    "text": "Change details for {person_name}"
+                  },
+                  "type": "General"
+                },
+                "when": [{
+                  "comparison": {
+                    "id": "list_item_id",
+                    "source": "location"
+                  },
+                  "condition": "not equals",
+                  "id_selector": "primary_person",
+                  "list": "household"
+                }]
+              }
+            ],
+            "type": "ListEditQuestion"
+          },
+          "for_list": "household",
+          "id": "anyone-else-list-collector",
+          "question": {
+            "answers": [{
+              "id": "anyone-else-answer",
+              "mandatory": true,
+              "options": [{
+                  "label": "Yes, I need to add someone",
+                  "value": "Yes, I need to add someone"
+                },
+                {
+                  "label": "No, I do not need to add anyone",
+                  "value": "No, I do not need to add anyone"
+                }
+              ],
+              "type": "Radio"
+            }],
+            "id": "anyone-else-confirmation-question",
+            "title": "A title",
+            "type": "General"
+          },
+          "remove_answer": {
+            "id": "remove-confirmation",
+            "value": "Yes, I want to remove this person"
+          },
+          "remove_block": {
+            "id": "remove-person",
+            "question": {
+              "answers": [{
+                "id": "remove-confirmation",
+                "mandatory": true,
+                "options": [{
+                    "label": "Yes, I want to remove this person",
+                    "value": "Yes, I want to remove this person"
+                  },
+                  {
+                    "label": "No, I do not want to remove this person",
+                    "value": "No, I do not want to remove this person"
+                  }
+                ],
+                "type": "Radio"
+              }],
+              "id": "remove-question",
+              "title": {
+                "placeholders": [{
+                  "placeholder": "person_name",
+                  "transforms": [{
+                    "arguments": {
+                      "delimiter": " ",
+                      "list_to_concatenate": {
+                        "identifier": [
+                          "first-name",
+                          "last-name"
+                        ],
+                        "source": "answers"
+                      }
+                    },
+                    "transform": "concatenate_list"
+                  }]
+                }],
+                "text": "Are you sure you want to remove {person_name}?"
+              },
+              "type": "General"
+            },
+            "type": "ListRemoveQuestion"
+          },
+          "summary": {
+            "add_link_text": "Add someone to this household",
+            "empty_list_text": "There are no householders",
+            "item_title": {
+              "placeholders": [{
+                "placeholder": "person_name",
+                "transforms": [{
+                  "arguments": {
+                    "delimiter": " ",
+                    "list_to_concatenate": {
+                      "identifier": [
+                        "first-name",
+                        "last-name"
+                      ],
+                      "source": "answers"
+                    }
+                  },
+                  "transform": "concatenate_list"
+                }]
+              }],
+              "text": "{person_name}"
+            },
+            "title": "Household members"
+          },
+          "type": "ListCollector"
+        },
+        {
+          "type": "Summary",
+          "id": "summary"
+        }
+      ]
+    }]
+  }]
+}


### PR DESCRIPTION
### PR Context
Currently, variants are not considered when checking for duplicate ids for ListCollector child blocks.
This PR ensure they are also skipped.

This is needed for WLH https://github.com/ONSdigital/eq-survey-runner/pull/2308

### How to review
Ensure:
1. Duplicate answers ids are allowed for question variants of list collector child blocks.
