### PR TITLE
Extend support for placeholders for contents

### DIFF
--- a/schemas/blocks/definitions.json
+++ b/schemas/blocks/definitions.json
@@ -5,7 +5,7 @@
     "type": "object",
     "properties": {
       "title": {
-        "type": "string",
+        "$ref": "../string_interpolation/definitions.json#/string_with_placeholders",
         "description": "The top-level heading on the page"
       },
       "contents": {

--- a/schemas/common_definitions.json
+++ b/schemas/common_definitions.json
@@ -63,7 +63,7 @@
         "list": {
           "type": "array",
           "items": {
-            "type": "string"
+            "$ref": "string_interpolation/definitions.json#/string_with_placeholders"
           }
         }
       },


### PR DESCRIPTION
### PR Context
Extends the support of placeholders for content blocks.
Already supported in runner.

Used by Census Household.

### How to review
- Check if placeholders are allowed for the new additions in the PR and ensure runner displays then correctly.