### PR TITLE
Add descriptions to relationship options

### DIFF
--- a/schemas/answers/relationship.json
+++ b/schemas/answers/relationship.json
@@ -38,6 +38,10 @@
                         },
                         "playback": {
                             "$ref": "../string_interpolation/definitions.json#/string_with_placeholders"
+                        },
+                        "description": {
+                            "$ref": "../string_interpolation/definitions.json#/string_with_placeholders",
+                            "description": "Descriptive text that appears below the option label"
                         }
                     },
                     "additionalProperties": false,

--- a/tests/schemas/valid/test_relationship_collector.json
+++ b/tests/schemas/valid/test_relationship_collector.json
@@ -149,7 +149,14 @@
                   "label": "Legally Registered Civil Partner",
                   "title": "Thinking of {first_person_name}, {second_person_name} is their <em>legally registered civil partner</em>",
                   "playback": "{second_person_name} is {first_person_name} <em>legally registered civil partner</em>"
-                }
+                },
+                {
+                  "label": "Brother or sister",
+                  "value": "Brother or sister",
+                  "title": "Thinking of {first_person_name}, {second_person_name} is their <em>brother or sister</em>",
+                  "playback": "{second_person_name} is {first_person_name_possessive} <em>brother or sister</em>",
+                  "description": "Including half brother or half sister"
+              }
               ]
             }]
           }


### PR DESCRIPTION
### PR Context

Adds a description property to relationship options.

### Checklist

* [👍] eq-translations updated to support any new schema keys which need translation - `description` is an existing no-context key.
