### PR TITLE
Add show_on_section_summary to question blocks

### DIFF
--- a/schemas/blocks/list_collector.json
+++ b/schemas/blocks/list_collector.json
@@ -76,7 +76,7 @@
       "summary": {
         "$ref": "list_collector.json#/summary"
       },
-      "hide_on_section_summary": {
+      "show_on_section_summary": {
         "type": "boolean"
       }
     },

--- a/schemas/blocks/question.json
+++ b/schemas/blocks/question.json
@@ -13,6 +13,9 @@
         "type": "string",
         "enum": ["Question", "ListAddQuestion", "ListEditQuestion", "ListRemoveQuestion", "PrimaryPersonListAddOrEditQuestion"]
       },
+      "show_on_section_summary": {
+          "type": "boolean"
+      },
       "question": {
         "$ref": "../questions/definitions.json#/question"
       },

--- a/schemas/questions/types/calculated.json
+++ b/schemas/questions/types/calculated.json
@@ -30,6 +30,9 @@
           "Calculated"
         ]
       },
+      "show_on_section_summary": {
+          "type": "boolean"
+      },
       "calculations": {
         "type": "array",
         "items": {

--- a/schemas/questions/types/date_range.json
+++ b/schemas/questions/types/date_range.json
@@ -28,6 +28,9 @@
         "type": "string",
         "enum": ["DateRange"]
       },
+      "show_on_section_summary": {
+          "type": "boolean"
+      },
       "period_limits": {
         "type": "object",
         "description": "minimum and/or maximum time limit for the period to be in days/months/years.",

--- a/schemas/questions/types/general.json
+++ b/schemas/questions/types/general.json
@@ -28,6 +28,9 @@
         "type": "string",
         "enum": ["General"]
       },
+      "show_on_section_summary": {
+          "type": "boolean"
+      },
       "answers": {
         "type": "array",
         "minItems": 1,

--- a/schemas/questions/types/mutually_exclusive.json
+++ b/schemas/questions/types/mutually_exclusive.json
@@ -31,6 +31,9 @@
       "mandatory": {
         "type": "boolean"
       },
+      "show_on_section_summary": {
+          "type": "boolean"
+      },
       "answers": {
         "type": "array",
         "minItems": 2,

--- a/tests/schemas/invalid/test_invalid_answer_action_redirect_to_list_add_question.json
+++ b/tests/schemas/invalid/test_invalid_answer_action_redirect_to_list_add_question.json
@@ -176,7 +176,7 @@
                 }]
               }
             },
-            "hide_on_section_summary": false
+            "show_on_section_summary": true
           }
         ]
       }]

--- a/tests/schemas/valid/test_answer_action_redirect_to_list_add_question.json
+++ b/tests/schemas/valid/test_answer_action_redirect_to_list_add_question.json
@@ -176,7 +176,7 @@
                 }]
               }
             },
-            "show_on_section_summary": false
+            "show_on_section_summary": true
           }
         ]
       }]

--- a/tests/schemas/valid/test_answer_action_redirect_to_list_add_question.json
+++ b/tests/schemas/valid/test_answer_action_redirect_to_list_add_question.json
@@ -176,7 +176,7 @@
                 }]
               }
             },
-            "hide_on_section_summary": false
+            "show_on_section_summary": false
           }
         ]
       }]

--- a/tests/schemas/valid/test_list_collector.json
+++ b/tests/schemas/valid/test_list_collector.json
@@ -225,7 +225,7 @@
             }]
           }
         },
-        "hide_on_section_summary": false
+        "show_on_section_summary": true
       }, {
         "type": "Summary",
         "id": "summary"

--- a/tests/schemas/valid/test_question_variants.json
+++ b/tests/schemas/valid/test_question_variants.json
@@ -39,6 +39,7 @@
       }, {
         "type": "Question",
         "id": "block-2",
+        "show_on_section_summary": true,
         "question_variants": [{
           "question": {
             "id": "question-2",


### PR DESCRIPTION
### PR Context
Adds an optional `hide_on_section_summary` to question blocks.
 
### Checklist

* [:+1: ] eq-translations updated to support any new schema keys which need translation (no new keys)
