### PR TITLE
Add show on section summary to driving question

### DIFF
--- a/schemas/blocks/list_collector_driving_question.json
+++ b/schemas/blocks/list_collector_driving_question.json
@@ -16,6 +16,9 @@
         "type": "string",
         "enum": ["ListCollectorDrivingQuestion"]
       },
+      "show_on_section_summary": {
+          "type": "boolean"
+      },
       "question": {
         "$ref": "../questions/definitions.json#/question"
       },


### PR DESCRIPTION
### PR Context

Due to https://github.com/ONSdigital/eq-schema-validator/pull/160 and https://github.com/ONSdigital/eq-schema-validator/pull/159 being in flight at the same time ListCollectorDrivingQuestion does not currently support the show_on_section_summary property.

It needs to be added to complete https://github.com/ONSdigital/eq-survey-runner/pull/2367

