### PR TITLE
Add routing rules to the primary person schema

### DIFF
--- a/schemas/blocks/primary_person_list_collector.json
+++ b/schemas/blocks/primary_person_list_collector.json
@@ -37,7 +37,7 @@
       "question": {
         "$ref": "../questions/definitions.json#/question"
       },
-        "routing_rules": {
+      "routing_rules": {
         "$ref": "../common_definitions.json#/routing_rules"
       },
       "question_variants": {

--- a/schemas/blocks/primary_person_list_collector.json
+++ b/schemas/blocks/primary_person_list_collector.json
@@ -37,6 +37,9 @@
       "question": {
         "$ref": "../questions/definitions.json#/question"
       },
+        "routing_rules": {
+        "$ref": "../common_definitions.json#/routing_rules"
+      },
       "question_variants": {
         "$ref": "definitions.json#/question_variants"
       },

--- a/schemas/questions/types/general.json
+++ b/schemas/questions/types/general.json
@@ -35,7 +35,7 @@
         "type": "array",
         "minItems": 1,
         "items": {
-          "anyOf": [
+          "oneOf": [
             {
               "$ref": "../../answers/checkbox.json#/answer"
             },

--- a/schemas/questions/types/general.json
+++ b/schemas/questions/types/general.json
@@ -35,7 +35,7 @@
         "type": "array",
         "minItems": 1,
         "items": {
-          "oneOf": [
+          "anyOf": [
             {
               "$ref": "../../answers/checkbox.json#/answer"
             },


### PR DESCRIPTION
### PR Context
Census Coverage Survey was failing schema validation because there were routing rules attached to the Primary Person List Collector question.

I have added routing rules to the Primary Person list collector schema.