### PR TITLE
Add missing list collector summaries to test schemas

### DIFF
--- a/schemas/blocks/list_collector.json
+++ b/schemas/blocks/list_collector.json
@@ -92,7 +92,8 @@
       "remove_answer",
       "add_block",
       "edit_block",
-      "remove_block"
+      "remove_block",
+      "summary"
     ],
     "oneOf": [
       {

--- a/tests/schemas/invalid/test_invalid_list_collector_bad_answer_reference_ids.json
+++ b/tests/schemas/invalid/test_invalid_list_collector_bad_answer_reference_ids.json
@@ -225,30 +225,30 @@
             }]
           }
         },
-          "summary": {
-            "title": "Household members",
-            "add_link_text": "Add another person to this household",
-            "empty_list_text": "There are no people",
-            "item_title": {
-              "text": "{person_name}",
-              "placeholders": [{
-                "placeholder": "person_name",
-                "transforms": [{
-                  "arguments": {
-                    "delimiter": " ",
-                    "list_to_concatenate": {
-                      "identifier": [
-                        "first-name",
-                        "last-name"
-                      ],
-                      "source": "answers"
-                    }
-                  },
-                  "transform": "concatenate_list"
-                }]
+        "summary": {
+          "title": "Household members",
+          "add_link_text": "Add another person to this household",
+          "empty_list_text": "There are no people",
+          "item_title": {
+            "text": "{person_name}",
+            "placeholders": [{
+              "placeholder": "person_name",
+              "transforms": [{
+                "arguments": {
+                  "delimiter": " ",
+                  "list_to_concatenate": {
+                    "identifier": [
+                      "first-name",
+                      "last-name"
+                    ],
+                    "source": "answers"
+                  }
+                },
+                "transform": "concatenate_list"
               }]
-            }
+            }]
           }
+        }
       }, {
         "type": "Summary",
         "id": "summary"

--- a/tests/schemas/invalid/test_invalid_list_collector_bad_answer_reference_ids.json
+++ b/tests/schemas/invalid/test_invalid_list_collector_bad_answer_reference_ids.json
@@ -226,29 +226,29 @@
           }
         },
           "summary": {
-          "title": "Household members",
-          "add_link_text": "Add another person to this household",
-          "empty_list_text": "There are no people",
-          "item_title": {
-            "text": "{person_name}",
-            "placeholders": [{
-              "placeholder": "person_name",
-              "transforms": [{
-                "arguments": {
-                  "delimiter": " ",
-                  "list_to_concatenate": {
-                    "identifier": [
-                      "first-name",
-                      "last-name"
-                    ],
-                    "source": "answers"
-                  }
-                },
-                "transform": "concatenate_list"
+            "title": "Household members",
+            "add_link_text": "Add another person to this household",
+            "empty_list_text": "There are no people",
+            "item_title": {
+              "text": "{person_name}",
+              "placeholders": [{
+                "placeholder": "person_name",
+                "transforms": [{
+                  "arguments": {
+                    "delimiter": " ",
+                    "list_to_concatenate": {
+                      "identifier": [
+                        "first-name",
+                        "last-name"
+                      ],
+                      "source": "answers"
+                    }
+                  },
+                  "transform": "concatenate_list"
+                }]
               }]
-            }]
+            }
           }
-        }
       }, {
         "type": "Summary",
         "id": "summary"

--- a/tests/schemas/invalid/test_invalid_list_collector_bad_answer_reference_ids.json
+++ b/tests/schemas/invalid/test_invalid_list_collector_bad_answer_reference_ids.json
@@ -110,6 +110,30 @@
               }]
             }]
           }
+        },
+        "summary": {
+          "title": "Household members",
+          "add_link_text": "Add another person to this household",
+          "empty_list_text": "There are no people",
+          "item_title": {
+            "text": "{person_name}",
+            "placeholders": [{
+              "placeholder": "person_name",
+              "transforms": [{
+                "arguments": {
+                  "delimiter": " ",
+                  "list_to_concatenate": {
+                    "identifier": [
+                      "first-name",
+                      "last-name"
+                    ],
+                    "source": "answers"
+                  }
+                },
+                "transform": "concatenate_list"
+              }]
+            }]
+          }
         }
       }, {
         "id": "another-list-collector",
@@ -197,6 +221,30 @@
               }, {
                 "label": "No",
                 "value": "No"
+              }]
+            }]
+          }
+        },
+          "summary": {
+          "title": "Household members",
+          "add_link_text": "Add another person to this household",
+          "empty_list_text": "There are no people",
+          "item_title": {
+            "text": "{person_name}",
+            "placeholders": [{
+              "placeholder": "person_name",
+              "transforms": [{
+                "arguments": {
+                  "delimiter": " ",
+                  "list_to_concatenate": {
+                    "identifier": [
+                      "first-name",
+                      "last-name"
+                    ],
+                    "source": "answers"
+                  }
+                },
+                "transform": "concatenate_list"
               }]
             }]
           }

--- a/tests/schemas/invalid/test_invalid_list_collector_duplicate_ids_multiple_collectors.json
+++ b/tests/schemas/invalid/test_invalid_list_collector_duplicate_ids_multiple_collectors.json
@@ -110,6 +110,30 @@
               }]
             }]
           }
+        },
+        "summary": {
+          "title": "Household members",
+          "add_link_text": "Add another person to this household",
+          "empty_list_text": "There are no people",
+          "item_title": {
+            "text": "{person_name}",
+            "placeholders": [{
+              "placeholder": "person_name",
+              "transforms": [{
+                "arguments": {
+                  "delimiter": " ",
+                  "list_to_concatenate": {
+                    "identifier": [
+                      "first-name",
+                      "last-name"
+                    ],
+                    "source": "answers"
+                  }
+                },
+                "transform": "concatenate_list"
+              }]
+            }]
+          }
         }
       }, {
         "id": "another-list-collector",
@@ -197,6 +221,30 @@
               }, {
                 "label": "No",
                 "value": "No"
+              }]
+            }]
+          }
+        },
+        "summary": {
+          "title": "Household members",
+          "add_link_text": "Add another person to this household",
+          "empty_list_text": "There are no people",
+          "item_title": {
+            "text": "{person_name}",
+            "placeholders": [{
+              "placeholder": "person_name",
+              "transforms": [{
+                "arguments": {
+                  "delimiter": " ",
+                  "list_to_concatenate": {
+                    "identifier": [
+                      "first-name",
+                      "last-name"
+                    ],
+                    "source": "answers"
+                  }
+                },
+                "transform": "concatenate_list"
               }]
             }]
           }

--- a/tests/schemas/invalid/test_invalid_list_collector_non_radio.json
+++ b/tests/schemas/invalid/test_invalid_list_collector_non_radio.json
@@ -110,6 +110,30 @@
               }]
             }]
           }
+        },
+        "summary": {
+          "title": "Household members",
+          "add_link_text": "Add another person to this household",
+          "empty_list_text": "There are no people",
+          "item_title": {
+            "text": "{person_name}",
+            "placeholders": [{
+              "placeholder": "person_name",
+              "transforms": [{
+                "arguments": {
+                  "delimiter": " ",
+                  "list_to_concatenate": {
+                    "identifier": [
+                      "first-name",
+                      "last-name"
+                    ],
+                    "source": "answers"
+                  }
+                },
+                "transform": "concatenate_list"
+              }]
+            }]
+          }
         }
       }, {
         "type": "Summary",

--- a/tests/schemas/invalid/test_invalid_list_collector_with_different_add_block_answer_ids.json
+++ b/tests/schemas/invalid/test_invalid_list_collector_with_different_add_block_answer_ids.json
@@ -112,30 +112,30 @@
           }
         },
           "summary": {
-          "title": "Household members",
-          "add_link_text": "Add another person to this household",
-          "empty_list_text": "There are no people",
-          "item_title": {
-            "text": "{person_name}",
-            "placeholders": [{
-              "placeholder": "person_name",
-              "transforms": [{
-                "arguments": {
-                  "delimiter": " ",
-                  "list_to_concatenate": {
-                    "identifier": [
-                      "first-name",
-                      "last-name"
-                    ],
-                    "source": "answers"
-                  }
-                },
-                "transform": "concatenate_list"
+            "title": "Household members",
+            "add_link_text": "Add another person to this household",
+            "empty_list_text": "There are no people",
+            "item_title": {
+              "text": "{person_name}",
+              "placeholders": [{
+                "placeholder": "person_name",
+                "transforms": [{
+                  "arguments": {
+                    "delimiter": " ",
+                    "list_to_concatenate": {
+                      "identifier": [
+                        "first-name",
+                        "last-name"
+                      ],
+                      "source": "answers"
+                    }
+                  },
+                  "transform": "concatenate_list"
+                }]
               }]
-            }]
+            }
           }
-        }
-      }, {
+        }, {
         "id": "another-list-collector",
         "type": "ListCollector",
         "for_list": "people",

--- a/tests/schemas/invalid/test_invalid_list_collector_with_different_add_block_answer_ids.json
+++ b/tests/schemas/invalid/test_invalid_list_collector_with_different_add_block_answer_ids.json
@@ -111,31 +111,31 @@
             }]
           }
         },
-          "summary": {
-            "title": "Household members",
-            "add_link_text": "Add another person to this household",
-            "empty_list_text": "There are no people",
-            "item_title": {
-              "text": "{person_name}",
-              "placeholders": [{
-                "placeholder": "person_name",
-                "transforms": [{
-                  "arguments": {
-                    "delimiter": " ",
-                    "list_to_concatenate": {
-                      "identifier": [
-                        "first-name",
-                        "last-name"
-                      ],
-                      "source": "answers"
-                    }
-                  },
-                  "transform": "concatenate_list"
-                }]
+        "summary": {
+          "title": "Household members",
+          "add_link_text": "Add another person to this household",
+          "empty_list_text": "There are no people",
+          "item_title": {
+            "text": "{person_name}",
+            "placeholders": [{
+              "placeholder": "person_name",
+              "transforms": [{
+                "arguments": {
+                  "delimiter": " ",
+                  "list_to_concatenate": {
+                    "identifier": [
+                      "first-name",
+                      "last-name"
+                    ],
+                    "source": "answers"
+                  }
+                },
+                "transform": "concatenate_list"
               }]
-            }
+            }]
           }
-        }, {
+        }
+      }, {
         "id": "another-list-collector",
         "type": "ListCollector",
         "for_list": "people",

--- a/tests/schemas/invalid/test_invalid_list_collector_with_different_add_block_answer_ids.json
+++ b/tests/schemas/invalid/test_invalid_list_collector_with_different_add_block_answer_ids.json
@@ -110,6 +110,30 @@
               }]
             }]
           }
+        },
+          "summary": {
+          "title": "Household members",
+          "add_link_text": "Add another person to this household",
+          "empty_list_text": "There are no people",
+          "item_title": {
+            "text": "{person_name}",
+            "placeholders": [{
+              "placeholder": "person_name",
+              "transforms": [{
+                "arguments": {
+                  "delimiter": " ",
+                  "list_to_concatenate": {
+                    "identifier": [
+                      "first-name",
+                      "last-name"
+                    ],
+                    "source": "answers"
+                  }
+                },
+                "transform": "concatenate_list"
+              }]
+            }]
+          }
         }
       }, {
         "id": "another-list-collector",
@@ -197,6 +221,30 @@
               }, {
                 "label": "No",
                 "value": "No"
+              }]
+            }]
+          }
+        },
+        "summary": {
+          "title": "Household members",
+          "add_link_text": "Add another person to this household",
+          "empty_list_text": "There are no people",
+          "item_title": {
+            "text": "{person_name}",
+            "placeholders": [{
+              "placeholder": "person_name",
+              "transforms": [{
+                "arguments": {
+                  "delimiter": " ",
+                  "list_to_concatenate": {
+                    "identifier": [
+                      "first-name",
+                      "last-name"
+                    ],
+                    "source": "answers"
+                  }
+                },
+                "transform": "concatenate_list"
               }]
             }]
           }

--- a/tests/schemas/invalid/test_invalid_list_collector_with_different_answer_ids_in_add_and_edit.json
+++ b/tests/schemas/invalid/test_invalid_list_collector_with_different_answer_ids_in_add_and_edit.json
@@ -115,6 +115,30 @@
               }]
             }]
           }
+        },
+        "summary": {
+          "title": "Household members",
+          "add_link_text": "Add another person to this household",
+          "empty_list_text": "There are no people",
+          "item_title": {
+            "text": "{person_name}",
+            "placeholders": [{
+              "placeholder": "person_name",
+              "transforms": [{
+                "arguments": {
+                  "delimiter": " ",
+                  "list_to_concatenate": {
+                    "identifier": [
+                      "first-name",
+                      "last-name"
+                    ],
+                    "source": "answers"
+                  }
+                },
+                "transform": "concatenate_list"
+              }]
+            }]
+          }
         }
       }, {
         "type": "Summary",

--- a/tests/schemas/invalid/test_invalid_list_collector_with_no_add_option.json
+++ b/tests/schemas/invalid/test_invalid_list_collector_with_no_add_option.json
@@ -110,6 +110,30 @@
               }]
             }]
           }
+        },
+        "summary": {
+          "title": "Household members",
+          "add_link_text": "Add another person to this household",
+          "empty_list_text": "There are no people",
+          "item_title": {
+            "text": "{person_name}",
+            "placeholders": [{
+              "placeholder": "person_name",
+              "transforms": [{
+                "arguments": {
+                  "delimiter": " ",
+                  "list_to_concatenate": {
+                    "identifier": [
+                      "first-name",
+                      "last-name"
+                    ],
+                    "source": "answers"
+                  }
+                },
+                "transform": "concatenate_list"
+              }]
+            }]
+          }
         }
       }, {
         "type": "Summary",

--- a/tests/schemas/invalid/test_invalid_list_collector_with_routing_in_sub_block.json
+++ b/tests/schemas/invalid/test_invalid_list_collector_with_routing_in_sub_block.json
@@ -149,7 +149,7 @@
             }]
           }
         }
-      },{
+      }, {
         "type": "Summary",
         "id": "summary"
       }]

--- a/tests/schemas/invalid/test_invalid_list_collector_with_routing_in_sub_block.json
+++ b/tests/schemas/invalid/test_invalid_list_collector_with_routing_in_sub_block.json
@@ -124,8 +124,32 @@
               "block": "summary"
             }
           }]
+        },
+        "summary": {
+          "title": "Household members",
+          "add_link_text": "Add another person to this household",
+          "empty_list_text": "There are no people",
+          "item_title": {
+            "text": "{person_name}",
+            "placeholders": [{
+              "placeholder": "person_name",
+              "transforms": [{
+                "arguments": {
+                  "delimiter": " ",
+                  "list_to_concatenate": {
+                    "identifier": [
+                      "first-name",
+                      "last-name"
+                    ],
+                    "source": "answers"
+                  }
+                },
+                "transform": "concatenate_list"
+              }]
+            }]
+          }
         }
-      }, {
+      },{
         "type": "Summary",
         "id": "summary"
       }]

--- a/tests/schemas/invalid/test_invalid_relationship_multiple_answers.json
+++ b/tests/schemas/invalid/test_invalid_relationship_multiple_answers.json
@@ -124,30 +124,30 @@
             }
           },
           "summary": {
-          "title": "Household members",
-          "add_link_text": "Add another person to this household",
-          "empty_list_text": "There are no people",
-          "item_title": {
-            "text": "{person_name}",
-            "placeholders": [{
-              "placeholder": "person_name",
-              "transforms": [{
-                "arguments": {
-                  "delimiter": " ",
-                  "list_to_concatenate": {
-                    "identifier": [
-                      "first-name",
-                      "last-name"
-                    ],
-                    "source": "answers"
-                  }
-                },
-                "transform": "concatenate_list"
+            "title": "Household members",
+            "add_link_text": "Add another person to this household",
+            "empty_list_text": "There are no people",
+            "item_title": {
+              "text": "{person_name}",
+              "placeholders": [{
+                "placeholder": "person_name",
+                "transforms": [{
+                  "arguments": {
+                    "delimiter": " ",
+                    "list_to_concatenate": {
+                      "identifier": [
+                        "first-name",
+                        "last-name"
+                      ],
+                      "source": "answers"
+                    }
+                  },
+                  "transform": "concatenate_list"
+                }]
               }]
-            }]
+            }
           }
-        }
-      },
+        },
         {
           "type": "RelationshipCollector",
           "id": "relationships",

--- a/tests/schemas/invalid/test_invalid_relationship_multiple_answers.json
+++ b/tests/schemas/invalid/test_invalid_relationship_multiple_answers.json
@@ -122,8 +122,32 @@
                 ]
               }]
             }
+          },
+          "summary": {
+          "title": "Household members",
+          "add_link_text": "Add another person to this household",
+          "empty_list_text": "There are no people",
+          "item_title": {
+            "text": "{person_name}",
+            "placeholders": [{
+              "placeholder": "person_name",
+              "transforms": [{
+                "arguments": {
+                  "delimiter": " ",
+                  "list_to_concatenate": {
+                    "identifier": [
+                      "first-name",
+                      "last-name"
+                    ],
+                    "source": "answers"
+                  }
+                },
+                "transform": "concatenate_list"
+              }]
+            }]
           }
-        },
+        }
+      },
         {
           "type": "RelationshipCollector",
           "id": "relationships",

--- a/tests/schemas/invalid/test_invalid_relationship_wrong_answer_type.json
+++ b/tests/schemas/invalid/test_invalid_relationship_wrong_answer_type.json
@@ -124,30 +124,30 @@
             }
           },
           "summary": {
-          "title": "Household members",
-          "add_link_text": "Add another person to this household",
-          "empty_list_text": "There are no people",
-          "item_title": {
-            "text": "{person_name}",
-            "placeholders": [{
-              "placeholder": "person_name",
-              "transforms": [{
-                "arguments": {
-                  "delimiter": " ",
-                  "list_to_concatenate": {
-                    "identifier": [
-                      "first-name",
-                      "last-name"
-                    ],
-                    "source": "answers"
-                  }
-                },
-                "transform": "concatenate_list"
+            "title": "Household members",
+            "add_link_text": "Add another person to this household",
+            "empty_list_text": "There are no people",
+            "item_title": {
+              "text": "{person_name}",
+              "placeholders": [{
+                "placeholder": "person_name",
+                "transforms": [{
+                  "arguments": {
+                    "delimiter": " ",
+                    "list_to_concatenate": {
+                      "identifier": [
+                        "first-name",
+                        "last-name"
+                      ],
+                      "source": "answers"
+                    }
+                  },
+                  "transform": "concatenate_list"
+                }]
               }]
-            }]
+            }
           }
-        }
-      },
+        },
         {
           "type": "RelationshipCollector",
           "id": "relationships",

--- a/tests/schemas/invalid/test_invalid_relationship_wrong_answer_type.json
+++ b/tests/schemas/invalid/test_invalid_relationship_wrong_answer_type.json
@@ -122,8 +122,32 @@
                 ]
               }]
             }
+          },
+          "summary": {
+          "title": "Household members",
+          "add_link_text": "Add another person to this household",
+          "empty_list_text": "There are no people",
+          "item_title": {
+            "text": "{person_name}",
+            "placeholders": [{
+              "placeholder": "person_name",
+              "transforms": [{
+                "arguments": {
+                  "delimiter": " ",
+                  "list_to_concatenate": {
+                    "identifier": [
+                      "first-name",
+                      "last-name"
+                    ],
+                    "source": "answers"
+                  }
+                },
+                "transform": "concatenate_list"
+              }]
+            }]
           }
-        },
+        }
+      },
         {
           "type": "RelationshipCollector",
           "id": "relationships",

--- a/tests/schemas/invalid/test_invalid_repeating_section_list_name.json
+++ b/tests/schemas/invalid/test_invalid_repeating_section_list_name.json
@@ -321,23 +321,23 @@
                 "item_title": {
                 "text": "{person_name}",
                 "placeholders": [{
-                "placeholder": "person_name",
-                "transforms": [{
-                "arguments": {
-                  "delimiter": " ",
-                  "list_to_concatenate": {
-                    "identifier": [
-                      "first-name",
-                      "last-name"
-                    ],
-                    "source": "answers"
-                  }
-                },
-                "transform": "concatenate_list"
+                  "placeholder": "person_name",
+                  "transforms": [{
+                    "arguments": {
+                      "delimiter": " ",
+                      "list_to_concatenate": {
+                        "identifier": [
+                          "first-name",
+                          "last-name"
+                        ],
+                        "source": "answers"
+                      }
+                    },
+                  "transform": "concatenate_list"
+                }]
               }]
-            }]
+            }
           }
-        }
             }
           ]
         }

--- a/tests/schemas/invalid/test_invalid_repeating_section_list_name.json
+++ b/tests/schemas/invalid/test_invalid_repeating_section_list_name.json
@@ -177,30 +177,30 @@
                 }
               },
               "summary": {
-              "title": "Household members",
-              "add_link_text": "Add another person to this household",
-              "empty_list_text": "There are no people",
-              "item_title": {
-              "text": "{person_name}",
-              "placeholders": [{
-                "placeholder": "person_name",
-                "transforms": [{
-                  "arguments": {
-                    "delimiter": " ",
-                    "list_to_concatenate": {
-                      "identifier": [
-                        "first-name",
-                        "last-name"
-                    ],
-                    "source": "answers"
-                  }
-                },
-                "transform": "concatenate_list"
-              }]
-            }]
+                "title": "Household members",
+                "add_link_text": "Add another person to this household",
+                "empty_list_text": "There are no people",
+                "item_title": {
+                  "text": "{person_name}",
+                  "placeholders": [{
+                    "placeholder": "person_name",
+                    "transforms": [{
+                      "arguments": {
+                        "delimiter": " ",
+                        "list_to_concatenate": {
+                          "identifier": [
+                            "first-name",
+                            "last-name"
+                          ],
+                          "source": "answers"
+                        }
+                      },
+                      "transform": "concatenate_list"
+                    }]
+                  }]
+                }
+              }
             }
-          }
-          }
           ]
         },
         {
@@ -319,25 +319,25 @@
                 "add_link_text": "Add another person to this household",
                 "empty_list_text": "There are no people",
                 "item_title": {
-                "text": "{person_name}",
-                "placeholders": [{
-                  "placeholder": "person_name",
-                  "transforms": [{
-                    "arguments": {
-                      "delimiter": " ",
-                      "list_to_concatenate": {
-                        "identifier": [
-                          "first-name",
-                          "last-name"
-                        ],
-                        "source": "answers"
-                      }
-                    },
-                  "transform": "concatenate_list"
-                }]
-              }]
-            }
-          }
+                  "text": "{person_name}",
+                  "placeholders": [{
+                    "placeholder": "person_name",
+                    "transforms": [{
+                      "arguments": {
+                        "delimiter": " ",
+                        "list_to_concatenate": {
+                          "identifier": [
+                            "first-name",
+                            "last-name"
+                          ],
+                          "source": "answers"
+                        }
+                      },
+                      "transform": "concatenate_list"
+                    }]
+                  }]
+                }
+              }
             }
           ]
         }

--- a/tests/schemas/invalid/test_invalid_repeating_section_list_name.json
+++ b/tests/schemas/invalid/test_invalid_repeating_section_list_name.json
@@ -175,8 +175,32 @@
                     ]
                   }]
                 }
-              }
+              },
+              "summary": {
+              "title": "Household members",
+              "add_link_text": "Add another person to this household",
+              "empty_list_text": "There are no people",
+              "item_title": {
+              "text": "{person_name}",
+              "placeholders": [{
+                "placeholder": "person_name",
+                "transforms": [{
+                  "arguments": {
+                    "delimiter": " ",
+                    "list_to_concatenate": {
+                      "identifier": [
+                        "first-name",
+                        "last-name"
+                    ],
+                    "source": "answers"
+                  }
+                },
+                "transform": "concatenate_list"
+              }]
+            }]
             }
+          }
+          }
           ]
         },
         {
@@ -289,7 +313,31 @@
                     ]
                   }]
                 }
-              }
+              },
+              "summary": {
+                "title": "Household members",
+                "add_link_text": "Add another person to this household",
+                "empty_list_text": "There are no people",
+                "item_title": {
+                "text": "{person_name}",
+                "placeholders": [{
+                "placeholder": "person_name",
+                "transforms": [{
+                "arguments": {
+                  "delimiter": " ",
+                  "list_to_concatenate": {
+                    "identifier": [
+                      "first-name",
+                      "last-name"
+                    ],
+                    "source": "answers"
+                  }
+                },
+                "transform": "concatenate_list"
+              }]
+            }]
+          }
+        }
             }
           ]
         }

--- a/tests/schemas/invalid/test_invalid_repeating_section_title_placeholders.json
+++ b/tests/schemas/invalid/test_invalid_repeating_section_title_placeholders.json
@@ -176,30 +176,30 @@
                   }]
                 }
               },
-                "summary": {
+              "summary": {
                 "title": "Household members",
                 "add_link_text": "Add another person to this household",
                 "empty_list_text": "There are no people",
                 "item_title": {
                 "text": "{person_name}",
                 "placeholders": [{
-                "placeholder": "person_name",
-                "transforms": [{
-                "arguments": {
-                  "delimiter": " ",
-                  "list_to_concatenate": {
-                    "identifier": [
-                      "first-name",
-                      "last-name"
-                    ],
-                    "source": "answers"
-                  }
-                },
-                "transform": "concatenate_list"
+                  "placeholder": "person_name",
+                  "transforms": [{
+                    "arguments": {
+                    "delimiter": " ",
+                    "list_to_concatenate": {
+                      "identifier": [
+                        "first-name",
+                        "last-name"
+                      ],
+                      "source": "answers"
+                    }
+                  },
+                  "transform": "concatenate_list"
+                }]
               }]
-            }]
+            }
           }
-        }
             }
           ]
         },

--- a/tests/schemas/invalid/test_invalid_repeating_section_title_placeholders.json
+++ b/tests/schemas/invalid/test_invalid_repeating_section_title_placeholders.json
@@ -175,7 +175,31 @@
                     ]
                   }]
                 }
-              }
+              },
+                "summary": {
+                "title": "Household members",
+                "add_link_text": "Add another person to this household",
+                "empty_list_text": "There are no people",
+                "item_title": {
+                "text": "{person_name}",
+                "placeholders": [{
+                "placeholder": "person_name",
+                "transforms": [{
+                "arguments": {
+                  "delimiter": " ",
+                  "list_to_concatenate": {
+                    "identifier": [
+                      "first-name",
+                      "last-name"
+                    ],
+                    "source": "answers"
+                  }
+                },
+                "transform": "concatenate_list"
+              }]
+            }]
+          }
+        }
             }
           ]
         },
@@ -289,7 +313,31 @@
                     ]
                   }]
                 }
-              }
+              },
+              "summary": {
+                "title": "Household members",
+                "add_link_text": "Add another person to this household",
+                "empty_list_text": "There are no people",
+                "item_title": {
+                  "text": "{person_name}",
+                  "placeholders": [{
+                    "placeholder": "person_name",
+                    "transforms": [{
+                    "arguments": {
+                      "delimiter": " ",
+                      "list_to_concatenate": {
+                        "identifier": [
+                        "first-name",
+                        "last-name"
+                    ],
+                    "source": "answers"
+                    }
+                  },
+                    "transform": "concatenate_list"
+                }]
+              }]
+            }
+          }
             }
           ]
         }

--- a/tests/schemas/invalid/test_invalid_repeating_section_title_placeholders.json
+++ b/tests/schemas/invalid/test_invalid_repeating_section_title_placeholders.json
@@ -181,25 +181,25 @@
                 "add_link_text": "Add another person to this household",
                 "empty_list_text": "There are no people",
                 "item_title": {
-                "text": "{person_name}",
-                "placeholders": [{
-                  "placeholder": "person_name",
-                  "transforms": [{
-                    "arguments": {
-                    "delimiter": " ",
-                    "list_to_concatenate": {
-                      "identifier": [
-                        "first-name",
-                        "last-name"
-                      ],
-                      "source": "answers"
-                    }
-                  },
-                  "transform": "concatenate_list"
-                }]
-              }]
-            }
-          }
+                  "text": "{person_name}",
+                  "placeholders": [{
+                    "placeholder": "person_name",
+                    "transforms": [{
+                      "arguments": {
+                        "delimiter": " ",
+                        "list_to_concatenate": {
+                          "identifier": [
+                            "first-name",
+                            "last-name"
+                          ],
+                          "source": "answers"
+                        }
+                      },
+                      "transform": "concatenate_list"
+                    }]
+                  }]
+                }
+              }
             }
           ]
         },
@@ -323,21 +323,21 @@
                   "placeholders": [{
                     "placeholder": "person_name",
                     "transforms": [{
-                    "arguments": {
-                      "delimiter": " ",
-                      "list_to_concatenate": {
-                        "identifier": [
-                        "first-name",
-                        "last-name"
-                    ],
-                    "source": "answers"
-                    }
-                  },
-                    "transform": "concatenate_list"
-                }]
-              }]
-            }
-          }
+                      "arguments": {
+                        "delimiter": " ",
+                        "list_to_concatenate": {
+                          "identifier": [
+                            "first-name",
+                            "last-name"
+                          ],
+                          "source": "answers"
+                        }
+                      },
+                      "transform": "concatenate_list"
+                    }]
+                  }]
+                }
+              }
             }
           ]
         }

--- a/tests/schemas/valid/test_list_collector.json
+++ b/tests/schemas/valid/test_list_collector.json
@@ -110,6 +110,30 @@
               }]
             }]
           }
+        },
+        "summary": {
+          "title": "Household members",
+          "add_link_text": "Add another person to this household",
+          "empty_list_text": "There are no people",
+          "item_title": {
+            "text": "{person_name}",
+            "placeholders": [{
+              "placeholder": "person_name",
+              "transforms": [{
+                "arguments": {
+                  "delimiter": " ",
+                  "list_to_concatenate": {
+                    "identifier": [
+                      "first-name",
+                      "last-name"
+                    ],
+                    "source": "answers"
+                  }
+                },
+                "transform": "concatenate_list"
+              }]
+            }]
+          }
         }
       }, {
         "id": "another-list-collector",

--- a/tests/schemas/valid/test_list_collector_with_routing_rule.json
+++ b/tests/schemas/valid/test_list_collector_with_routing_rule.json
@@ -124,6 +124,30 @@
               }]
             }]
           }
+        },
+        "summary": {
+          "title": "Household members",
+          "add_link_text": "Add another person to this household",
+          "empty_list_text": "There are no people",
+          "item_title": {
+            "text": "{person_name}",
+            "placeholders": [{
+              "placeholder": "person_name",
+              "transforms": [{
+                "arguments": {
+                  "delimiter": " ",
+                  "list_to_concatenate": {
+                    "identifier": [
+                      "first-name",
+                      "last-name"
+                    ],
+                    "source": "answers"
+                  }
+                },
+                "transform": "concatenate_list"
+              }]
+            }]
+          }
         }
       }, {
         "type": "Summary",

--- a/tests/schemas/valid/test_relationship_collector.json
+++ b/tests/schemas/valid/test_relationship_collector.json
@@ -122,8 +122,33 @@
                 ]
               }]
             }
-          }
-        },
+          },
+          "summary": {
+            "title": "Household members",
+            "add_link_text": "Add another person to this household",
+            "empty_list_text": "There are no people",
+            "item_title": {
+              "text": "{person_name}",
+              "placeholders": [{
+                "placeholder": "person_name",
+                "transforms": [{
+                  "arguments": {
+                    "delimiter": " ",
+                    "list_to_concatenate": {
+                      "identifier": [
+                        "first-name",
+                        "last-name"
+                      ],
+                      "source": "answers"
+                    }
+                  },
+                  "transform": "concatenate_list"
+                  }]
+                }]
+              }
+            }
+          },
+
         {
           "type": "RelationshipCollector",
           "id": "relationships",

--- a/tests/schemas/valid/test_relationship_collector.json
+++ b/tests/schemas/valid/test_relationship_collector.json
@@ -147,7 +147,7 @@
               }]
             }
           }
-          },
+        },
 
         {
           "type": "RelationshipCollector",

--- a/tests/schemas/valid/test_relationship_collector.json
+++ b/tests/schemas/valid/test_relationship_collector.json
@@ -143,10 +143,10 @@
                     }
                   },
                   "transform": "concatenate_list"
-                  }]
                 }]
-              }
+              }]
             }
+          }
           },
 
         {

--- a/tests/schemas/valid/test_repeating_section.json
+++ b/tests/schemas/valid/test_repeating_section.json
@@ -175,6 +175,30 @@
                     ]
                   }]
                 }
+              },
+              "summary": {
+                "title": "Household members",
+                "add_link_text": "Add another person to this household",
+                "empty_list_text": "There are no people",
+                "item_title": {
+                  "text": "{person_name}",
+                  "placeholders": [{
+                    "placeholder": "person_name",
+                    "transforms": [{
+                      "arguments": {
+                        "delimiter": " ",
+                        "list_to_concatenate": {
+                          "identifier": [
+                            "first-name",
+                            "last-name"
+                           ],
+                          "source": "answers"
+                        }
+                      },
+                    "transform": "concatenate_list"
+                    }]
+                  }]
+                }
               }
             }
           ]
@@ -289,7 +313,31 @@
                     ]
                   }]
                 }
-              }
+              },
+              "summary": {
+                "title": "Household members",
+                "add_link_text": "Add another person to this household",
+                "empty_list_text": "There are no people",
+                "item_title": {
+                  "text": "{person_name}",
+                  "placeholders": [{
+                    "placeholder": "person_name",
+                    "transforms": [{
+                      "arguments": {
+                        "delimiter": " ",
+                        "list_to_concatenate": {
+                        "identifier": [
+                          "first-name",
+                          "last-name"
+                        ],
+                        "source": "answers"
+                      }
+                    },
+                    "transform": "concatenate_list"
+                    }]
+                  }]
+                  }
+               }
             }
           ]
         }

--- a/tests/schemas/valid/test_repeating_section.json
+++ b/tests/schemas/valid/test_repeating_section.json
@@ -191,11 +191,11 @@
                           "identifier": [
                             "first-name",
                             "last-name"
-                           ],
+                          ],
                           "source": "answers"
                         }
                       },
-                    "transform": "concatenate_list"
+                      "transform": "concatenate_list"
                     }]
                   }]
                 }
@@ -326,18 +326,18 @@
                       "arguments": {
                         "delimiter": " ",
                         "list_to_concatenate": {
-                        "identifier": [
-                          "first-name",
-                          "last-name"
-                        ],
-                        "source": "answers"
-                      }
-                    },
-                    "transform": "concatenate_list"
+                          "identifier": [
+                            "first-name",
+                            "last-name"
+                          ],
+                          "source": "answers"
+                        }
+                      },
+                      "transform": "concatenate_list"
                     }]
                   }]
-                  }
-               }
+                }
+              }
             }
           ]
         }

--- a/tests/schemas/valid/test_when_location_comparison.json
+++ b/tests/schemas/valid/test_when_location_comparison.json
@@ -114,7 +114,31 @@
                 }]
               }]
             }
+          },
+          "summary": {
+                "title": "Household members",
+                "add_link_text": "Add another person to this household",
+                "empty_list_text": "There are no people",
+                "item_title": {
+                "text": "{person_name}",
+                "placeholders": [{
+                "placeholder": "person_name",
+                "transforms": [{
+                "arguments": {
+                  "delimiter": " ",
+                  "list_to_concatenate": {
+                    "identifier": [
+                      "first-name",
+                      "last-name"
+                    ],
+                    "source": "answers"
+                  }
+                },
+                "transform": "concatenate_list"
+              }]
+            }]
           }
+        }
         }]
       }]
     },

--- a/tests/schemas/valid/test_when_location_comparison.json
+++ b/tests/schemas/valid/test_when_location_comparison.json
@@ -120,21 +120,21 @@
             "add_link_text": "Add another person to this household",
             "empty_list_text": "There are no people",
             "item_title": {
-            "text": "{person_name}",
-            "placeholders": [{
-              "placeholder": "person_name",
-              "transforms": [{
-                "arguments": {
-                  "delimiter": " ",
-                  "list_to_concatenate": {
-                    "identifier": [
-                      "first-name",
-                      "last-name"
-                    ],
-                  "source": "answers"
-                  }
-                },
-                "transform": "concatenate_list"
+              "text": "{person_name}",
+              "placeholders": [{
+                "placeholder": "person_name",
+                "transforms": [{
+                  "arguments": {
+                    "delimiter": " ",
+                    "list_to_concatenate": {
+                      "identifier": [
+                        "first-name",
+                        "last-name"
+                      ],
+                      "source": "answers"
+                    }
+                  },
+                  "transform": "concatenate_list"
                 }]
               }]
             }

--- a/tests/schemas/valid/test_when_location_comparison.json
+++ b/tests/schemas/valid/test_when_location_comparison.json
@@ -116,14 +116,14 @@
             }
           },
           "summary": {
-                "title": "Household members",
-                "add_link_text": "Add another person to this household",
-                "empty_list_text": "There are no people",
-                "item_title": {
-                "text": "{person_name}",
-                "placeholders": [{
-                "placeholder": "person_name",
-                "transforms": [{
+            "title": "Household members",
+            "add_link_text": "Add another person to this household",
+            "empty_list_text": "There are no people",
+            "item_title": {
+            "text": "{person_name}",
+            "placeholders": [{
+              "placeholder": "person_name",
+              "transforms": [{
                 "arguments": {
                   "delimiter": " ",
                   "list_to_concatenate": {
@@ -131,14 +131,14 @@
                       "first-name",
                       "last-name"
                     ],
-                    "source": "answers"
+                  "source": "answers"
                   }
                 },
                 "transform": "concatenate_list"
+                }]
               }]
-            }]
+            }
           }
-        }
         }]
       }]
     },


### PR DESCRIPTION
### What is the context of this PR?
A lot of test schemas were missing list collector summaries but it was not breaking any tests. Summaries were added back in to test schemas and changed to mandatory blocks of ListCollector type in schema validator. It does detect missing summaries in list collectors now. [Trello card](https://trello.com/c/WVveCTV4/3223-adding-missing-list-collector-summaries-to-test-schemas-xs).

### How to review 
All schemas in the tests/schemas/ directory will be evaluated as part of the unit tests. Any errors in these schemas will cause a failure.
Use schema validator's unit test:
`pipenv run ./scripts/run_tests_unit.sh`


### Checklist

* [x] Missing summaries added to all list collectors in test schemas
* [x] Schema validator updated to make `summary` mandatory in list collectors
