### PR TITLE
Propose plural forms in schema text

### DIFF
--- a/app/validation/validator.py
+++ b/app/validation/validator.py
@@ -1722,6 +1722,8 @@ class Validator:  # pylint: disable=too-many-lines
         elif isinstance(input_data, list):
             for item in input_data:
                 yield from self._get_dicts_with_key(item, key_name)
+        else:
+            yield from ()
 
     def _validate_placeholder_object(self, placeholder_object, current_block_id):
         """ Current block id may be None if called outside of a block
@@ -1766,7 +1768,7 @@ class Validator:  # pylint: disable=too-many-lines
     def _validate_placeholders(self, block_json):
         errors = []
         strings_with_placeholders = self._get_dicts_with_key(block_json, "placeholders")
-        for placeholder_object in strings_with_placeholders or []:
+        for placeholder_object in strings_with_placeholders:
             errors.extend(
                 self._validate_placeholder_object(placeholder_object, block_json["id"])
             )
@@ -1778,7 +1780,7 @@ class Validator:  # pylint: disable=too-many-lines
     ):
         errors = []
         source_references = self._get_dicts_with_key(block_json, "identifier")
-        for source_reference in source_references or []:
+        for source_reference in source_references:
             source = source_reference["source"]
             if isinstance(source_reference["identifier"], str):
                 identifiers = [source_reference["identifier"]]

--- a/app/validation/validator.py
+++ b/app/validation/validator.py
@@ -1817,15 +1817,14 @@ class Validator:  # pylint: disable=too-many-lines
                         f"Invalid answer reference '{identifier}' in block '{current_block_id}'"
                     )
                 )
-            else:
-                if answers_with_parent_ids[identifier]["block"] == current_block_id:
-                    errors.append(
-                        self._error_message(
-                            "Invalid answer reference '{}' in block '{}' (self-reference)".format(
-                                identifier, current_block_id
-                            )
+            elif answers_with_parent_ids[identifier]["block"] == current_block_id:
+                errors.append(
+                    self._error_message(
+                        "Invalid answer reference '{}' in block '{}' (self-reference)".format(
+                            identifier, current_block_id
                         )
                     )
+                )
         return errors
 
     def _validate_metadata_source_reference(

--- a/app/validation/validator.py
+++ b/app/validation/validator.py
@@ -1733,7 +1733,7 @@ class Validator:  # pylint: disable=too-many-lines
             placeholders_in_string.update(
                 placeholder_regex.findall(placeholder_object.get("text"))
             )
-        if "text_plural" in placeholder_object:
+        elif "text_plural" in placeholder_object:
             for text in placeholder_object["text_plural"]["forms"].values():
                 placeholders_in_string.update(placeholder_regex.findall(text))
 
@@ -1791,13 +1791,13 @@ class Validator:  # pylint: disable=too-many-lines
                         identifiers, answers_with_parent_ids, block_json["id"]
                     )
                 )
-            if source == "metadata":
+            elif source == "metadata":
                 errors.extend(
                     self._validate_metadata_source_reference(
                         identifiers, valid_metadata_ids, block_json["id"]
                     )
                 )
-            if source == "list":
+            elif source == "list":
                 errors.extend(
                     self._validate_list_source_reference(identifiers, block_json["id"])
                 )

--- a/app/validation/validator.py
+++ b/app/validation/validator.py
@@ -88,11 +88,7 @@ class Validator:  # pylint: disable=too-many-lines
             self._block_ids = self._get_block_ids(json_to_validate)
 
             for section in json_to_validate["sections"]:
-                validation_errors.extend(
-                    self._validate_section(
-                        json_to_validate, section, answers_with_parent_ids
-                    )
-                )
+                validation_errors.extend(self._validate_section(section))
                 section_ids.append(section["id"])
                 for group in section["groups"]:
                     validation_errors.extend(
@@ -129,23 +125,14 @@ class Validator:  # pylint: disable=too-many-lines
 
         return validation_errors
 
-    def _validate_section(self, json_to_validate, section, answers_with_parent_ids):
+    def _validate_section(self, section):
         errors = []
-        valid_metadata_ids = []
-        if "metadata" in json_to_validate:
-            valid_metadata_ids = [m["name"] for m in json_to_validate["metadata"]]
-
         section_repeat = section.get("repeat", {})
 
         if section_repeat:
             errors.extend(self._validate_list_exists(section_repeat["for_list"]))
             errors.extend(
-                self._validate_placeholder_object(
-                    answers_with_parent_ids,
-                    valid_metadata_ids,
-                    section_repeat["title"],
-                    None,
-                )
+                self._validate_placeholder_object(section_repeat["title"], None)
             )
         return errors
 
@@ -326,10 +313,12 @@ class Validator:  # pylint: disable=too-many-lines
                 valid_metadata_ids = [m["name"] for m in json_to_validate["metadata"]]
 
             errors.extend(
-                self._validate_placeholders(
-                    block, answers_with_parent_ids, valid_metadata_ids, block["id"]
+                self._validate_source_references(
+                    block, answers_with_parent_ids, valid_metadata_ids
                 )
             )
+
+            errors.extend(self._validate_placeholders(block))
 
             errors.extend(
                 self._validate_variants(
@@ -1734,79 +1723,131 @@ class Validator:  # pylint: disable=too-many-lines
             for item in input_data:
                 yield from self._get_dicts_with_key(item, key_name)
 
-    def _validate_placeholder_object(
-        self,
-        answers_with_parent_ids,
-        valid_metadata_ids,
-        placeholder_object,
-        current_block_id,
-    ):
+    def _validate_placeholder_object(self, placeholder_object, current_block_id):
         """ Current block id may be None if called outside of a block
         """
         errors = []
-        placeholders_in_string = re.compile("{(.*?)}").findall(
-            placeholder_object.get("text")
-        )
-        placeholder_definition_names = []
+        placeholders_in_string = set()
+        placeholder_regex = re.compile("{(.*?)}")
+        if "text" in placeholder_object:
+            placeholders_in_string.update(
+                placeholder_regex.findall(placeholder_object.get("text"))
+            )
+        if "text_plural" in placeholder_object:
+            for text in placeholder_object["text_plural"]["forms"].values():
+                placeholders_in_string.update(placeholder_regex.findall(text))
+
+        placeholder_definition_names = set()
         for placeholder_definition in placeholder_object.get("placeholders"):
-            placeholder_definition_names.append(placeholder_definition["placeholder"])
+            placeholder_definition_names.add(placeholder_definition["placeholder"])
 
             transforms = placeholder_definition.get("transforms")
-            (
-                answer_ids_to_validate,
-                metadata_ids_to_validate,
-            ) = self._get_placeholder_source_ids(placeholder_definition, transforms)
-
-            errors.extend(
-                self._validate_placeholder_answer_ids(
-                    current_block_id,
-                    placeholder_definition,
-                    answers_with_parent_ids,
-                    answer_ids_to_validate,
-                )
-            )
-            errors.extend(
-                self._validate_placeholder_metadata_ids(
-                    valid_metadata_ids,
-                    metadata_ids_to_validate,
-                    placeholder_definition["placeholder"],
-                )
-            )
-
             if transforms:
                 errors.extend(
                     self._validate_placeholder_transforms(transforms, current_block_id)
                 )
 
-        placeholder_differences = set(placeholders_in_string) - set(
-            placeholder_definition_names
-        )
+        placeholder_differences = placeholders_in_string - placeholder_definition_names
         if placeholder_differences:
+            try:
+                text = placeholder_object["text"]
+            except KeyError:
+                text = placeholder_object["text_plural"]["forms"]["other"]
             errors.append(
                 self._error_message(
                     "Placeholders in '{}' don't match definitions. Missing '{}'".format(
-                        placeholder_object["text"], placeholder_differences
+                        text, placeholder_differences
                     )
                 )
             )
 
         return errors
 
-    def _validate_placeholders(
-        self, block_json, answers_with_parent_ids, valid_metadata_ids, current_block_id
-    ):
+    def _validate_placeholders(self, block_json):
         errors = []
         strings_with_placeholders = self._get_dicts_with_key(block_json, "placeholders")
         for placeholder_object in strings_with_placeholders or []:
             errors.extend(
-                self._validate_placeholder_object(
-                    answers_with_parent_ids,
-                    valid_metadata_ids,
-                    placeholder_object,
-                    current_block_id,
-                )
+                self._validate_placeholder_object(placeholder_object, block_json["id"])
             )
 
+        return errors
+
+    def _validate_source_references(
+        self, block_json, answers_with_parent_ids, valid_metadata_ids
+    ):
+        errors = []
+        source_references = self._get_dicts_with_key(block_json, "identifier")
+        for source_reference in source_references or []:
+            source = source_reference["source"]
+            if isinstance(source_reference["identifier"], str):
+                identifiers = [source_reference["identifier"]]
+            else:
+                identifiers = source_reference["identifier"]
+
+            if source == "answers":
+                errors.extend(
+                    self._validate_answer_source_reference(
+                        identifiers, answers_with_parent_ids, block_json["id"]
+                    )
+                )
+            if source == "metadata":
+                errors.extend(
+                    self._validate_metadata_source_reference(
+                        identifiers, valid_metadata_ids, block_json["id"]
+                    )
+                )
+            if source == "list":
+                errors.extend(
+                    self._validate_list_source_reference(identifiers, block_json["id"])
+                )
+
+        return errors
+
+    def _validate_answer_source_reference(
+        self, identifiers, answers_with_parent_ids, current_block_id
+    ):
+        errors = []
+        for identifier in identifiers:
+            if identifier not in answers_with_parent_ids:
+                errors.append(
+                    self._error_message(
+                        f"Invalid answer reference '{identifier}' in block '{current_block_id}'"
+                    )
+                )
+            else:
+                if answers_with_parent_ids[identifier]["block"] == current_block_id:
+                    errors.append(
+                        self._error_message(
+                            "Invalid answer reference '{}' in block '{}' (self-reference)".format(
+                                identifier, current_block_id
+                            )
+                        )
+                    )
+        return errors
+
+    def _validate_metadata_source_reference(
+        self, identifiers, valid_metadata_ids, current_block_id
+    ):
+        errors = []
+        for identifier in identifiers:
+            if identifier not in valid_metadata_ids:
+                errors.append(
+                    self._error_message(
+                        f"Invalid metadata reference '{identifier}' in block '{current_block_id}'"
+                    )
+                )
+        return errors
+
+    def _validate_list_source_reference(self, identifiers, current_block_id):
+        errors = []
+        for identifier in identifiers:
+            if identifier not in self._list_names:
+                errors.append(
+                    self._error_message(
+                        f"Invalid list reference '{identifier}' in block '{current_block_id}'"
+                    )
+                )
         return errors
 
     def _validate_list_exists(self, list_name):
@@ -1825,94 +1866,6 @@ class Validator:  # pylint: disable=too-many-lines
             errors.append(self._error_message(one_answer_msg))
         if answers[0]["type"] != "Relationship":
             errors.append(self._error_message(answer_type_msg))
-
-        return errors
-
-    @staticmethod
-    def _get_placeholder_source_ids(placeholder_definition, transforms):
-
-        answer_ids_to_validate = []
-        metadata_ids_to_validate = []
-
-        if transforms:
-            for transform in transforms:
-                for argument in transform["arguments"].values():
-                    if "source" in argument and argument["source"] == "answers":
-                        if isinstance(argument["identifier"], list):
-                            answer_ids_to_validate.extend(argument["identifier"])
-                        else:
-                            answer_ids_to_validate.append(argument["identifier"])
-
-                    if "source" in argument and argument["source"] == "metadata":
-                        if isinstance(argument["identifier"], list):
-                            metadata_ids_to_validate.extend(argument["identifier"])
-                        else:
-                            metadata_ids_to_validate.append(argument["identifier"])
-
-        if (
-            "value" in placeholder_definition
-            and "source" in placeholder_definition["value"]
-            and placeholder_definition["value"]["source"] == "answers"
-        ):
-            answer_ids_to_validate.append(placeholder_definition["value"]["identifier"])
-
-        if (
-            "value" in placeholder_definition
-            and "source" in placeholder_definition["value"]
-            and placeholder_definition["value"]["source"] == "metadata"
-        ):
-            metadata_ids_to_validate.append(
-                placeholder_definition["value"]["identifier"]
-            )
-
-        return answer_ids_to_validate, metadata_ids_to_validate
-
-    def _validate_placeholder_answer_ids(
-        self,
-        block_id,
-        placeholder_definition,
-        answers_with_parent_ids,
-        answer_ids_to_validate,
-    ):
-        errors = []
-
-        for answer_id_to_validate in answer_ids_to_validate:
-            if answer_id_to_validate not in answers_with_parent_ids:
-                errors.append(
-                    self._error_message(
-                        "Invalid answer id reference `{}` for placeholder `{}`".format(
-                            answer_id_to_validate, placeholder_definition["placeholder"]
-                        )
-                    )
-                )
-                continue
-
-            answer_block_id = answers_with_parent_ids[answer_id_to_validate]["block"]
-
-            if answer_block_id == block_id:
-                errors.append(
-                    self._error_message(
-                        "Invalid answer id reference `{}` for placeholder `{}` (self-reference)".format(
-                            answer_id_to_validate, placeholder_definition["placeholder"]
-                        )
-                    )
-                )
-
-        return errors
-
-    def _validate_placeholder_metadata_ids(
-        self, valid_metadata_ids, metadata_ids_to_validate, placeholder_name
-    ):
-        errors = []
-        for metadata_id_to_validate in metadata_ids_to_validate:
-            if metadata_id_to_validate not in valid_metadata_ids:
-                errors.append(
-                    self._error_message(
-                        "Invalid metadata reference `{}` for placeholder `{}`".format(
-                            metadata_id_to_validate, placeholder_name
-                        )
-                    )
-                )
 
         return errors
 

--- a/doc/decisions/0003-plural-forms-in-schema-text.md
+++ b/doc/decisions/0003-plural-forms-in-schema-text.md
@@ -103,12 +103,12 @@ Additional placeholders can also be defined:
                     }
                 ]
             },
-			{
-				"placeholder": "address",
+            {
+                "placeholder": "address",
                 "value": {
-					"source": "metadata",
-					"identifier": "display_address"
-				}
+                    "source": "metadata",
+                    "identifier": "display_address"
+                }
             }
         ],
         "text_plural": {

--- a/doc/decisions/0003-plural-forms-in-schema-text.md
+++ b/doc/decisions/0003-plural-forms-in-schema-text.md
@@ -63,6 +63,7 @@ Example schema:
             }
         }
     }
+}
 ```
 
 Translated schemas can contain more forms than an English source schema, for example:
@@ -121,6 +122,7 @@ Additional placeholders can also be defined:
             }
         }
     }
+}
 ```
 
 ### Mapping the count to the CLDR plural forms

--- a/doc/decisions/0003-plural-forms-in-schema-text.md
+++ b/doc/decisions/0003-plural-forms-in-schema-text.md
@@ -40,15 +40,15 @@ Example schema:
             {
                 "placeholder": "number_of_people",
                 "transforms": [
-                {
-                    "arguments": {
-                        "number": {
-                            "source": "list",
-                            "identifier": "household"
-                        }
-                    },
-                    "transform": "number_to_words"
-                }
+                    {
+                        "arguments": {
+                            "number": {
+                                "source": "list",
+                                "identifier": "household"
+                            }
+                        },
+                        "transform": "number_to_words"
+                    }
                 ]
             }
         ],
@@ -80,6 +80,47 @@ Translated schemas can contain more forms than an English source schema, for exa
         }
     }
 }
+```
+
+Additional placeholders can also be defined:
+
+```json
+{
+    "summary_text": {
+        "placeholders": [
+            {
+                "placeholder": "number_of_people",
+                "transforms": [
+                    {
+                        "arguments": {
+                            "number": {
+                                "source": "list",
+                                "identifier": "household"
+                            }
+                        },
+                        "transform": "number_to_words"
+                    }
+                ]
+            },
+			{
+				"placeholder": "address",
+                "value": {
+					"source": "metadata",
+					"identifier": "display_address"
+				}
+            }
+        ],
+        "text_plural": {
+            "forms": {
+                "one": "Yes, {number_of_people} person live at {address}",
+                "other": "Yes, {number_of_people} people live at {address}"
+            },
+            "count": {
+                "source": "list",
+                "identifier": "household"
+            }
+        }
+    }
 ```
 
 ### Mapping the count to the CLDR plural forms

--- a/doc/decisions/0003-plural-forms-in-schema-text.md
+++ b/doc/decisions/0003-plural-forms-in-schema-text.md
@@ -1,0 +1,115 @@
+# 3. Plural forms in schema text
+
+## Context
+
+We need to be able to support:
+- variations of text based on the number of items in a list
+- word forms of numbers 1 to 9
+
+For example:
+
+```
+Yes, one person lives here
+Yes, two people live here
+Yes, three people live here
+Yes, ... people live here
+Yes, 10 people live here
+Yes, 11 people live here
+Yes, .. people live here
+```
+
+## Proposal
+
+- Use a placeholder transform to transform a number into words.
+- New `text_plural` element to support the plural forms of the text.
+- Use the CLDR plural categories to define the plural forms (http://www.unicode.org/reports/tr35/tr35-33/tr35-numbers.html#Language_Plural_Rules):
+  - zero
+  - one
+  - two
+  - few
+  - many
+  - other
+- Choose the plural form based on a numeric answer, metadata or number of items in a list.
+
+Example schema:
+
+```json
+{
+    "summary_text": {
+        "placeholders": [
+            {
+                "placeholder": "number_of_people",
+                "transforms": [
+                {
+                    "arguments": {
+                        "number": {
+                            "source": "list",
+                            "identifier": "household"
+                        }
+                    },
+                    "transform": "number_to_words"
+                }
+                ]
+            }
+        ],
+        "text_plural": {
+            "forms": {
+                "one": "Yes, {number_of_people} person lives here",
+                "other": "Yes, {number_of_people} people live here"
+            },
+            "count": {
+                "source": "list",
+                "identifier": "household"
+            }
+        }
+    }
+```
+
+Translated schemas can contain more forms than an English source schema, for example:
+
+```json
+{
+    "text_plural": {
+        "forms": {
+            "zero": "Ydy, nid oes unrhyw bobl yn byw yma",
+            "one": "Ydy, mae {number_of_people} person yn byw yma",
+            "two": "Ydy, mae {number_of_people} berson yn byw yma",
+            "few": "Ydy, mae {number_of_people} o bobl yn byw yma",
+            "many": "Ydy, mae {number_of_people} o bobl yn byw yma",
+            "other": "Ydy, mae {number_of_people} o bobl yn byw yma"
+        }
+    }
+}
+```
+
+### Mapping the count to the CLDR plural forms
+
+We will use the gettext plural forms mapping. For example, the Welsh gettext plural forms are:
+
+```
+"Plural-Forms: nplurals=6; plural=(n == 0) ? 0 : ((n == 1) ? 1 : ((n == 2) ? 2 : ((n == 3) ? 3 : ((n == 6) ? 4 : 5))));\n"
+```
+
+Which would map to:
+
+```
+zero - msgstr[0]
+one - msgstr[1]
+two - msgstr[2]
+few - msgstr[3]
+many - msgstr[4]
+other - msgstr[5]
+```
+
+## Consequences
+
+- Plural forms can be used in schema text.
+- Translators need to be aware of how to populate the plural forms in the translation tool.
+- Need to review the rule that enforces answer labels and values are the same.
+
+## Useful references
+
+- http://babel.pocoo.org/en/latest/api/plural.html
+- http://cldr.unicode.org/index/cldr-spec/plural-rules#TOC-Determining-Plural-Categories
+- http://www.unicode.org/cldr/charts/latest/supplemental/language_plural_rules.html#cy
+- https://www.omniglot.com/language/numbers/welsh.htm

--- a/schemas/questionnaire_v1.json
+++ b/schemas/questionnaire_v1.json
@@ -143,6 +143,7 @@
     },
     "sections": {
       "type": "array",
+      "minItems": 1,
       "items": {
         "additionalProperties": false,
         "type": "object",

--- a/schemas/string_interpolation/definitions.json
+++ b/schemas/string_interpolation/definitions.json
@@ -192,10 +192,10 @@
           },
           "other": {
             "type": "string"
-          },
-          "additionalProperties": false,
-          "required": ["other"]
-        }
+          }
+        },
+        "additionalProperties": false,
+        "required": ["other"]
       },
       "count": {
         "description": "The source to use for the count. Must resolve to a number.",

--- a/schemas/string_interpolation/definitions.json
+++ b/schemas/string_interpolation/definitions.json
@@ -17,12 +17,23 @@
           "text": {
             "type": "string"
           },
+          "text_plural": {
+            "$ref": "#/text_plural"
+          },
           "placeholders": {
             "$ref": "#/placeholders"
           }
         },
         "additionalProperties": false,
-        "required": ["text", "placeholders"]
+        "required": ["placeholders"],
+        "oneOf": [
+          {
+            "required": ["text"]
+          },
+          {
+            "required": ["text_plural"]
+          }
+        ]
       }
     ]
   },
@@ -82,6 +93,9 @@
             },
             {
               "$ref": "https://eq.ons.gov.uk/string_interpolation/transforms/remove_empty.json#/remove_empty"
+            },
+            {
+              "$ref": "https://eq.ons.gov.uk/string_interpolation/transforms/number_to_words.json#/number_to_words"
             }
           ]
         }
@@ -127,10 +141,10 @@
       "source": {
         "description": "The data source.",
         "type": "string",
-        "enum": ["answers", "metadata", "collection_metadata"]
+        "enum": ["answers", "metadata", "collection_metadata", "list"]
       },
       "identifier": {
-        "description": "The identifier of the item in the data source. This would be an answer id for answers, and a metadata property name for metadata. The array option allows multiple values to be passed as a list to a transform.",
+        "description": "The identifier of the item in the data source. This would be an answer id for answers, a metadata property name for metadata, or a list name for lists. The array option allows multiple values to be passed as a list to a transform.",
         "type": ["string", "array"]
       },
       "list_item_selector": {
@@ -152,5 +166,42 @@
     },
     "additionalProperties": false,
     "required": ["source", "identifier"]
+  },
+  "text_plural": {
+    "description": "A mapping of a count to plural strings",
+    "type": "object",
+    "properties": {
+      "forms": {
+        "description": "Plural forms of the text. Uses the CLDR plural categories. One or more of these properties will be present dependent on the language.",
+        "type": "object",
+        "properties": {
+          "zero": {
+            "type": "string"
+          },
+          "one": {
+            "type": "string"
+          },
+          "two": {
+            "type": "string"
+          },
+          "few": {
+            "type": "string"
+          },
+          "many": {
+            "type": "string"
+          },
+          "other": {
+            "type": "string"
+          },
+          "additionalProperties": false,
+          "required": ["other"]
+        }
+      },
+      "count": {
+        "description": "The source to use for the count. Must resolve to a number.",
+        "$ref": "#/lookup_source"
+      },
+      "additionalProperties": false
+    }
   }
 }

--- a/schemas/string_interpolation/definitions.json
+++ b/schemas/string_interpolation/definitions.json
@@ -200,8 +200,9 @@
       "count": {
         "description": "The source to use for the count. Must resolve to a number.",
         "$ref": "#/lookup_source"
-      },
-      "additionalProperties": false
-    }
+      }
+    },
+    "additionalProperties": false,
+    "required": ["forms", "count"]
   }
 }

--- a/schemas/string_interpolation/transforms/number_to_words.json
+++ b/schemas/string_interpolation/transforms/number_to_words.json
@@ -1,0 +1,25 @@
+{
+  "$id": "https://eq.ons.gov.uk/string_interpolation/transforms/number_to_words.json",
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "number_to_words": {
+    "type": "object",
+    "properties": {
+      "transform": {
+        "type": "string",
+        "enum": ["number_to_words"]
+      },
+      "arguments": {
+        "type": "object",
+        "properties": {
+          "number": {
+            "$ref": "https://eq.ons.gov.uk/string_interpolation/definitions.json#/value_sources"
+          }
+        },
+        "additionalProperties": false,
+        "required": ["number"]
+      }
+    },
+    "additionalProperties": false,
+    "required": ["transform", "arguments"]
+  }
+}

--- a/tests/schemas/invalid/test_invalid_placeholder_plurals.json
+++ b/tests/schemas/invalid/test_invalid_placeholder_plurals.json
@@ -1,0 +1,105 @@
+{
+  "eq_id": "3",
+  "form_type": "3",
+  "mime_type": "application/json/ons/eq",
+  "schema_version": "0.0.1",
+  "data_version": "0.0.3",
+  "survey_id": "3",
+  "title": "String Transforms",
+  "theme": "default",
+  "legal_basis": "StatisticsOfTradeAct",
+  "navigation": {
+    "visible": false
+  },
+  "metadata": [
+    {
+      "name": "user_id",
+      "type": "string"
+    },
+    {
+      "name": "period_id",
+      "type": "string"
+    },
+    {
+      "name": "ru_name",
+      "type": "string"
+    },
+    {
+      "name": "test_metadata",
+      "type": "string"
+    }
+  ],
+  "sections": [
+    {
+      "id": "section1",
+      "groups": [
+        {
+          "id": "group1",
+          "title": "",
+          "blocks": [
+            {
+              "id": "block1",
+              "type": "Question",
+              "question": {
+                "id": "question1",
+                "title": {
+                  "text_plural": {
+                    "forms": {
+                      "one": "You've said one person lives here. Is that correct?",
+                      "other": "You've said {number_of_people} people live here. Is that correct?"
+                    },
+                    "count": {
+                      "source": "list",
+                      "identifier": "people"
+                    }
+                  },
+                  "placeholders": [
+                    {
+                      "placeholder": "number_of_people",
+                      "transforms": [
+                        {
+                          "transform": "number_to_words",
+                          "arguments": {
+                            "number": {
+                              "source": "list",
+                              "identifier": "people"
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                },
+                "type": "General",
+                "answers": [
+                  {
+                    "id": "answer2",
+                    "mandatory": false,
+                    "type": "Radio",
+                    "options": [
+                      {
+                        "label": "Yes",
+                        "value": "Yes"
+                      },
+                      {
+                        "label": "No",
+                        "value": "No"
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "id": "confirmation",
+              "type": "Confirmation",
+              "content": {
+                "title": "Confirm"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/schemas/valid/test_placeholder_plurals.json
+++ b/tests/schemas/valid/test_placeholder_plurals.json
@@ -92,7 +92,6 @@
                   {
                     "id": "answer2",
                     "mandatory": false,
-                    "type": "Number",
                     "type": "Radio",
                     "options": [
                       {

--- a/tests/schemas/valid/test_placeholder_plurals.json
+++ b/tests/schemas/valid/test_placeholder_plurals.json
@@ -1,0 +1,123 @@
+{
+  "eq_id": "3",
+  "form_type": "3",
+  "mime_type": "application/json/ons/eq",
+  "schema_version": "0.0.1",
+  "data_version": "0.0.3",
+  "survey_id": "3",
+  "title": "String Transforms",
+  "theme": "default",
+  "legal_basis": "StatisticsOfTradeAct",
+  "navigation": {
+    "visible": false
+  },
+  "metadata": [
+    {
+      "name": "user_id",
+      "type": "string"
+    },
+    {
+      "name": "period_id",
+      "type": "string"
+    },
+    {
+      "name": "ru_name",
+      "type": "string"
+    },
+    {
+      "name": "test_metadata",
+      "type": "string"
+    }
+  ],
+  "sections": [
+    {
+      "id": "section1",
+      "groups": [
+        {
+          "id": "group1",
+          "title": "",
+          "blocks": [
+            {
+              "id": "block1",
+              "type": "Question",
+              "question": {
+                "id": "question1",
+                "title": "How many people live in the house?",
+                "type": "General",
+                "answers": [
+                  {
+                    "id": "answer1",
+                    "mandatory": true,
+                    "type": "Number",
+                    "label": "Number of people"
+                  }
+                ]
+              }
+            },
+            {
+              "id": "block2",
+              "type": "Question",
+              "question": {
+                "id": "question2",
+                "title": {
+                  "text_plural": {
+                    "forms": {
+                      "one": "You've said one person lives here. Is that correct?",
+                      "other": "You've said {number_of_people} people live here. Is that correct?"
+                    },
+                    "count": {
+                      "source": "answers",
+                      "identifier": "answer1"
+                    }
+                  },
+                  "placeholders": [
+                    {
+                      "placeholder": "number_of_people",
+                      "transforms": [
+                        {
+                          "transform": "number_to_words",
+                          "arguments": {
+                            "number": {
+                              "source": "answers",
+                              "identifier": "answer1"
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                },
+                "type": "General",
+                "answers": [
+                  {
+                    "id": "answer2",
+                    "mandatory": false,
+                    "type": "Number",
+                    "type": "Radio",
+                    "options": [
+                      {
+                        "label": "Yes",
+                        "value": "Yes"
+                      },
+                      {
+                        "label": "No",
+                        "value": "No"
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "id": "confirmation",
+              "type": "Confirmation",
+              "content": {
+                "title": "Confirm"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/test_questionnaire_validation.py
+++ b/tests/test_questionnaire_validation.py
@@ -299,10 +299,21 @@ def test_invalid_placeholder_answer_ids():
     filename = "schemas/invalid/test_invalid_placeholder_source_ids.json"
 
     expected_error_messages = [
-        "Invalid answer id reference `answer4` for placeholder `simple_answer` (self-reference)",
-        "Invalid answer id reference `invalid-answer0` for placeholder `simple_answer`",
-        "Invalid answer id reference `invalid-answer1` for placeholder `answer1`",
-        "Invalid metadata reference `invalid-metadata-ref` for placeholder `simple_metadata`",
+        "Invalid answer reference 'answer4' in block 'block3' (self-reference)",
+        "Invalid answer reference 'invalid-answer0' in block 'block1'",
+        "Invalid answer reference 'invalid-answer1' in block 'block2'",
+        "Invalid metadata reference 'invalid-metadata-ref' in block 'block4'",
+    ]
+
+    check_validation_errors(filename, expected_error_messages)
+
+
+def test_invalid_placeholder_list_reference():
+    filename = "schemas/invalid/test_invalid_placeholder_plurals.json"
+
+    expected_error_messages = [
+        "Invalid list reference 'people' in block 'block1'",
+        "Invalid list reference 'people' in block 'block1'",
     ]
 
     check_validation_errors(filename, expected_error_messages)
@@ -572,10 +583,10 @@ def test_invalid_relationship_no_list_specified():
         "for_list 'not-a-list' is not populated by any ListCollector blocks"
     ]
     expected_error_message = [
-        "Invalid answer id reference `first-name` for placeholder `first_person_name`",
-        "Invalid answer id reference `last-name` for placeholder `first_person_name`",
-        "Invalid answer id reference `first-name` for placeholder `second_person_name`",
-        "Invalid answer id reference `last-name` for placeholder `second_person_name`",
+        "Invalid answer reference 'first-name' in block 'relationships'",
+        "Invalid answer reference 'last-name' in block 'relationships'",
+        "Invalid answer reference 'first-name' in block 'relationships'",
+        "Invalid answer reference 'last-name' in block 'relationships'",
     ] * 6
     expected_error_message = for_list_error + expected_error_message
 


### PR DESCRIPTION
### PR Context

See https://github.com/ONSdigital/eq-schema-validator/blob/propose-plural-forms-in-schema-text/doc/decisions/0003-plural-forms-in-schema-text.md for the proposal to add plural forms to the schema. 

This pull request also adds the required schema. 

The code to check for valid value sources has been factored out of the placeholders validation. It now searches the schema for all references to value sources and checks their validity against answer ids, metadata and lists.
