### PR TITLE
Add voluntary property to radio answer

### DIFF
--- a/schemas/answers/radio.json
+++ b/schemas/answers/radio.json
@@ -58,10 +58,10 @@
     "additionalProperties": false,
     "required": ["id", "type", "mandatory", "options"],
     "if": {
-      "properties": { "mandatory": {"const": true}}
+      "properties": { "mandatory": { "const": true } }
     },
     "then": {
-      "properties": { "voluntary": { "not": {"const": true }}}
+      "properties": { "voluntary": { "not": { "const": true } } }
     }
   }
 }

--- a/schemas/answers/radio.json
+++ b/schemas/answers/radio.json
@@ -10,6 +10,10 @@
       "q_code": {
         "$ref": "https://eq.ons.gov.uk/common_definitions.json#/q_code"
       },
+      "voluntary": {
+        "description": "If set to true, and an option is selected then there will be an option to unselect",
+        "type": "boolean"
+      },
       "label": {
         "type": "string"
       },

--- a/schemas/answers/radio.json
+++ b/schemas/answers/radio.json
@@ -56,6 +56,12 @@
       }
     },
     "additionalProperties": false,
-    "required": ["id", "type", "mandatory", "options"]
+    "required": ["id", "type", "mandatory", "options"],
+    "if": {
+      "properties": { "mandatory": {"const": true}}
+    },
+    "then": {
+      "properties": { "voluntary": { "not": {"const": true }}}
+    }
   }
 }


### PR DESCRIPTION
### PR Context
This adds new boolean "voluntary" property to radio answer. It needs to be merged before changes described on [this Trello card](https://trello.com/c/Wu3oraFw/3424-voluntary-questions-m) can be implemented. It makes validator up to date with [this design systems](https://github.com/ONSdigital/design-system/pull/660) change.

