### PR TITLE
Add visible write-ins

### DIFF
--- a/schemas/answers/number.json
+++ b/schemas/answers/number.json
@@ -26,6 +26,9 @@
       "mandatory": {
         "type": "boolean"
       },
+      "visible": {
+        "type": "boolean"
+      },
       "max_length": {
         "type": "integer"
       },

--- a/schemas/answers/text_field.json
+++ b/schemas/answers/text_field.json
@@ -26,6 +26,9 @@
       "mandatory": {
         "type": "boolean"
       },
+      "open": {
+        "type": "boolean"
+      },
       "validation": {
         "type": "object",
         "properties": {

--- a/schemas/answers/text_field.json
+++ b/schemas/answers/text_field.json
@@ -26,7 +26,7 @@
       "mandatory": {
         "type": "boolean"
       },
-      "open": {
+      "visible": {
         "type": "boolean"
       },
       "validation": {

--- a/tests/schemas/valid/test_placeholder_source_ids.json
+++ b/tests/schemas/valid/test_placeholder_source_ids.json
@@ -68,7 +68,8 @@
                           "id": "ref-answer0-2-detail",
                           "label": "Answer detail",
                           "mandatory": true,
-                          "type": "TextField"
+                          "type": "TextField",
+                          "visible": true
                         },
                         "label": "Other",
                         "value": "Other"


### PR DESCRIPTION
### PR Context
This adds new boolean "open" property to be used in some voluntary radio and checkbox answers. It needs to be merged before changes described on [this Trello card](https://trello.com/c/g3esxHDn/3433-visible-write-ins-m) can be implemented. [PR of the runner change](hhttps://github.com/ONSdigital/eq-questionnaire-runner/pull/25).
