### PR TITLE
Add the list collector summary type

### DIFF
--- a/schemas/blocks/summary.json
+++ b/schemas/blocks/summary.json
@@ -9,7 +9,10 @@
       },
       "type": {
         "type": "string",
-        "enum": ["Summary", "SectionSummary"]
+        "enum": ["Summary", "SectionSummary", "ListCollectorSummary"]
+      },
+      "title": {
+        "type": "string"
       },
       "collapsible": {
         "description": "When True, the summary page will contain a list of collapsible section summaries",


### PR DESCRIPTION
### PR Context
I have added the `ListCollectorSummary` type and `title` field to the Summary schema.

This change is required for the refactor of Summary page types in eq-questionnaire-runner.

