### PR TITLE
Add voluntary property to radio detail answer

### DIFF
--- a/schemas/answers/number.json
+++ b/schemas/answers/number.json
@@ -29,6 +29,10 @@
       "visible": {
         "type": "boolean"
       },
+      "voluntary": {
+        "description": "If set to true, and an option is selected then there will be an option to unselect",
+        "type": "boolean"
+      },
       "max_length": {
         "type": "integer"
       },
@@ -82,6 +86,12 @@
       }
     },
     "additionalProperties": false,
-    "required": ["id", "type", "mandatory", "label"]
+    "required": ["id", "type", "mandatory", "label"],
+    "if": {
+      "properties": { "mandatory": { "const": true } }
+    },
+    "then": {
+      "properties": { "voluntary": { "not": { "const": true } } }
+    }
   }
 }

--- a/schemas/answers/text_field.json
+++ b/schemas/answers/text_field.json
@@ -29,6 +29,10 @@
       "visible": {
         "type": "boolean"
       },
+      "voluntary": {
+        "description": "If set to true, and an option is selected then there will be an option to unselect",
+        "type": "boolean"
+      },
       "validation": {
         "type": "object",
         "properties": {
@@ -44,6 +48,12 @@
       }
     },
     "additionalProperties": false,
-    "required": ["id", "type", "label", "mandatory"]
+    "required": ["id", "type", "label", "mandatory"],
+    "if": {
+      "properties": { "mandatory": { "const": true } }
+    },
+    "then": {
+      "properties": { "voluntary": { "not": { "const": true } } }
+    }
   }
 }


### PR DESCRIPTION
### PR Context
This adds new boolean "voluntary" property to radio detail answer (text field and number). It needs to be merged before [this schemas PR](https://github.com/ONSdigital/eq-questionnaire-schemas/pull/3). It makes validator up to date with [this design systems](https://github.com/ONSdigital/design-system/pull/660) change.
